### PR TITLE
ci: add Cloudflare Workers deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run typecheck
+
+      - run: npm test -- --ci
+
+      - run: npm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` triggering on push to `main` (and manual `workflow_dispatch`)
- Gates the deploy behind `npm run lint && npm run typecheck && npm test -- --ci`
- Uses `npm run deploy` (`opennextjs-cloudflare build && deploy`) under the hood
- Concurrency group prevents overlapping deploys; in-flight deploys are not cancelled (interrupting a partial Worker upload can leave it in a bad state)

## Required setup before merging

**GitHub repo secrets** (Settings → Secrets and variables → Actions):
- `CLOUDFLARE_API_TOKEN` — from "Edit Cloudflare Workers" template
- `CLOUDFLARE_ACCOUNT_ID` — from Cloudflare dashboard sidebar
- `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `NEXT_PUBLIC_APP_URL` — same values as your Supabase project / production URL

**Cloudflare side:**
- Disconnect the existing Cloudflare Pages GitHub integration so it stops racing this workflow
- After the first successful deploy creates the `wc2026` Worker, add `SUPABASE_SERVICE_ROLE_KEY` as a Worker secret in the dashboard, then re-run the workflow

## Test plan
- [ ] All five GitHub repo secrets configured
- [ ] Cloudflare Pages integration disconnected
- [ ] Merge → workflow runs and completes deploy
- [ ] Add `SUPABASE_SERVICE_ROLE_KEY` Worker secret in Cloudflare dashboard
- [ ] Re-run workflow (Actions tab → "Run workflow")
- [ ] Smoke test deployed Worker URL: `/`, `/predictions` redirects to `/login`, `/api/tournament` returns JSON, sign-in persists session

🤖 Generated with [Claude Code](https://claude.com/claude-code)