### PR TITLE
ci: add Cloudflare Workers deploy + grants migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run typecheck
+
+      - run: npm test -- --ci
+
+      - run: npm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}

--- a/supabase/migrations/0007_grants.sql
+++ b/supabase/migrations/0007_grants.sql
@@ -1,0 +1,20 @@
+-- Cloud Supabase projects do not always extend default schema privileges to
+-- tables created via migrations, so PostgREST returns 401 (permission denied)
+-- before RLS is ever consulted. Grant SELECT explicitly; RLS continues to
+-- enforce row-level scope on user-owned tables.
+
+grant select on
+    public.groups,
+    public.teams,
+    public.knockout_matches,
+    public.tournaments,
+    public.group_standings,
+    public.knockout_results,
+    public.profiles
+  to anon, authenticated;
+
+grant select on
+    public.predictions,
+    public.group_predictions,
+    public.knockout_predictions
+  to authenticated;


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to deploy the Next.js app to Cloudflare Workers via OpenNext
- Adds `0007_grants.sql` migration granting `SELECT` on public tables to `anon`/`authenticated` so PostgREST stops returning 401 before RLS is consulted in cloud Supabase projects

## Test plan
- [ ] CI workflow runs successfully on push to main
- [ ] After applying `0007_grants.sql` to the cloud project, public reads (`/api/groups`, `/api/teams`, `/api/tournament`, `/api/leaderboard`) return 200
- [ ] Authenticated reads of `predictions` still respect RLS (users only see their own row)