### PR TITLE
feat: forgot-password / reset-password flow

### DIFF
--- a/frontend/src/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/frontend/src/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const serverSupabase = {
+  auth: { resetPasswordForEmail: jest.fn() },
+};
+
+const adminSupabase = {
+  from: jest.fn(),
+  auth: { admin: { getUserById: jest.fn() } },
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => serverSupabase,
+}));
+
+jest.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => adminSupabase,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function postRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/auth/forgot-password', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockProfileLookup(profile: { id: string } | null) {
+  adminSupabase.from.mockImplementation((table: string) => {
+    if (table !== 'profiles') throw new Error(`unexpected table ${table}`);
+    return {
+      select: () => ({
+        eq: () => ({ maybeSingle: async () => ({ data: profile }) }),
+      }),
+    };
+  });
+}
+
+describe('POST /api/auth/forgot-password', () => {
+  beforeEach(() => {
+    serverSupabase.auth.resetPasswordForEmail.mockReset();
+    adminSupabase.from.mockReset();
+    adminSupabase.auth.admin.getUserById.mockReset();
+    serverSupabase.auth.resetPasswordForEmail.mockResolvedValue({ data: {}, error: null });
+  });
+
+  it('always returns 200 ok:true', async () => {
+    const res = await POST(postRequest({ identifier: '' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('calls resetPasswordForEmail directly when identifier is an email', async () => {
+    const res = await POST(postRequest({ identifier: 'Alice@Example.com' }));
+    expect(res.status).toBe(200);
+    expect(serverSupabase.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+      'alice@example.com',
+      expect.objectContaining({
+        redirectTo: 'http://localhost:3000/auth/callback?next=/reset-password',
+      })
+    );
+    expect(adminSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('looks up email by username and resets when found', async () => {
+    mockProfileLookup({ id: 'user-1' });
+    adminSupabase.auth.admin.getUserById.mockResolvedValue({
+      data: { user: { email: 'alice@example.com' } },
+    });
+
+    const res = await POST(postRequest({ identifier: 'alice' }));
+    expect(res.status).toBe(200);
+    expect(adminSupabase.auth.admin.getUserById).toHaveBeenCalledWith('user-1');
+    expect(serverSupabase.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+      'alice@example.com',
+      expect.any(Object)
+    );
+  });
+
+  it('returns 200 silently when username does not exist', async () => {
+    mockProfileLookup(null);
+    const res = await POST(postRequest({ identifier: 'ghost' }));
+    expect(res.status).toBe(200);
+    expect(adminSupabase.auth.admin.getUserById).not.toHaveBeenCalled();
+    expect(serverSupabase.auth.resetPasswordForEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 silently when username fails regex', async () => {
+    const res = await POST(postRequest({ identifier: 'no' })); // too short
+    expect(res.status).toBe(200);
+    expect(adminSupabase.from).not.toHaveBeenCalled();
+    expect(serverSupabase.auth.resetPasswordForEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 silently for non-string identifier', async () => {
+    const res = await POST(postRequest({ identifier: 123 }));
+    expect(res.status).toBe(200);
+    expect(serverSupabase.auth.resetPasswordForEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 silently for over-long identifier', async () => {
+    const res = await POST(postRequest({ identifier: 'a'.repeat(300) }));
+    expect(res.status).toBe(200);
+    expect(serverSupabase.auth.resetPasswordForEmail).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/api/auth/forgot-password/route.ts
+++ b/frontend/src/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+import { createAdminSupabaseClient } from '@/lib/supabase/admin';
+import { USERNAME_REGEX } from '@/lib/constants';
+
+interface ForgotPasswordPayload {
+  identifier?: unknown;
+}
+
+const ok = () => NextResponse.json({ ok: true }, { status: 200 });
+
+export async function POST(request: NextRequest) {
+  let body: ForgotPasswordPayload;
+  try {
+    body = (await request.json()) as ForgotPasswordPayload;
+  } catch {
+    return ok();
+  }
+
+  const identifier = typeof body.identifier === 'string' ? body.identifier.trim() : '';
+  if (!identifier || identifier.length > 254) return ok();
+
+  const isEmail = identifier.includes('@');
+  let email: string | null = null;
+
+  if (isEmail) {
+    email = identifier.toLowerCase();
+  } else {
+    if (!USERNAME_REGEX.test(identifier)) return ok();
+
+    const admin = createAdminSupabaseClient();
+    const { data: profile } = await admin
+      .from('profiles')
+      .select('id')
+      .eq('username', identifier)
+      .maybeSingle();
+
+    if (!profile) return ok();
+
+    const { data } = await admin.auth.admin.getUserById(profile.id);
+    email = data?.user?.email ?? null;
+  }
+
+  if (email) {
+    const origin = new URL(request.url).origin;
+    const supabase = await getServerSupabase();
+    await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${origin}/auth/callback?next=/reset-password`,
+    });
+  }
+
+  return ok();
+}

--- a/frontend/src/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/frontend/src/app/api/auth/reset-password/__tests__/route.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: {
+    getUser: jest.fn(),
+    updateUser: jest.fn(),
+  },
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function postRequest(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/auth/reset-password', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/auth/reset-password', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.auth.updateUser.mockReset();
+  });
+
+  it('returns 400 when password is too short', async () => {
+    const res = await POST(postRequest({ password: 'short' }));
+    expect(res.status).toBe(400);
+    expect(supabaseMock.auth.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when password missing or non-string', async () => {
+    const res = await POST(postRequest({ password: 123 }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when no recovery session', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(postRequest({ password: 'longenough1' }));
+    expect(res.status).toBe(401);
+    expect(supabaseMock.auth.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when supabase rejects the password', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.auth.updateUser.mockResolvedValue({
+      error: { message: 'New password should be different' },
+    });
+    const res = await POST(postRequest({ password: 'longenough1' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/should be different/i);
+  });
+
+  it('returns 200 ok on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.auth.updateUser.mockResolvedValue({ error: null });
+    const res = await POST(postRequest({ password: 'longenough1' }));
+    expect(res.status).toBe(200);
+    expect(supabaseMock.auth.updateUser).toHaveBeenCalledWith({ password: 'longenough1' });
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/frontend/src/app/api/auth/reset-password/route.ts
+++ b/frontend/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+
+interface ResetPasswordPayload {
+  password?: unknown;
+}
+
+export async function POST(request: NextRequest) {
+  let body: ResetPasswordPayload;
+  try {
+    body = (await request.json()) as ResetPasswordPayload;
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const password = typeof body.password === 'string' ? body.password : '';
+  if (password.length < 8) {
+    return NextResponse.json({ error: 'Password must be at least 8 characters.' }, { status: 400 });
+  }
+
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { error } = await supabase.auth.updateUser({ password });
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/forgot-password/ForgotPasswordForm.tsx
+++ b/frontend/src/app/forgot-password/ForgotPasswordForm.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { ROUTES } from '@/lib/constants';
+
+export function ForgotPasswordForm() {
+  const [identifier, setIdentifier] = React.useState('');
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [submitted, setSubmitted] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const res = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ identifier }),
+      });
+      if (!res.ok) {
+        setError('Something went wrong. Please try again.');
+        setIsSubmitting(false);
+        return;
+      }
+      setSubmitted(true);
+    } catch {
+      setError('Network error. Please try again.');
+      setIsSubmitting(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm" role="status">
+          If an account matches, we&apos;ve sent a reset link. Check your inbox and follow the
+          instructions.
+        </p>
+        <p className="text-muted-foreground text-center text-sm">
+          <Link href={ROUTES.login} className="text-primary hover:underline">
+            Back to sign in
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+      <div className="space-y-2">
+        <Label htmlFor="identifier">Email or username</Label>
+        <Input
+          id="identifier"
+          type="text"
+          autoComplete="username"
+          required
+          value={identifier}
+          onChange={(e) => setIdentifier(e.target.value)}
+          disabled={isSubmitting}
+        />
+      </div>
+      {error && (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      )}
+      <Button type="submit" className="w-full" disabled={isSubmitting}>
+        {isSubmitting ? 'Sending…' : 'Send reset link'}
+      </Button>
+      <p className="text-muted-foreground text-center text-sm">
+        Remembered it?{' '}
+        <Link href={ROUTES.login} className="text-primary hover:underline">
+          Back to sign in
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/app/forgot-password/__tests__/ForgotPasswordForm.test.tsx
+++ b/frontend/src/app/forgot-password/__tests__/ForgotPasswordForm.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ForgotPasswordForm } from '../ForgotPasswordForm';
+
+describe('ForgotPasswordForm', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('posts identifier and shows uniform success panel', async () => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+    const user = userEvent.setup();
+    render(<ForgotPasswordForm />);
+
+    await user.type(screen.getByLabelText(/Email or username/i), 'alice');
+    await user.click(screen.getByRole('button', { name: /Send reset link/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/forgot-password',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ identifier: 'alice' }),
+      })
+    );
+    expect(await screen.findByRole('status')).toHaveTextContent(/we've sent a reset link/i);
+    expect(screen.queryByLabelText(/Email or username/i)).not.toBeInTheDocument();
+  });
+
+  it('shows error alert on transport failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    const user = userEvent.setup();
+    render(<ForgotPasswordForm />);
+
+    await user.type(screen.getByLabelText(/Email or username/i), 'alice@example.com');
+    await user.click(screen.getByRole('button', { name: /Send reset link/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/network error/i);
+  });
+
+  it('shows error alert when API returns non-2xx', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 } as Response);
+    const user = userEvent.setup();
+    render(<ForgotPasswordForm />);
+
+    await user.type(screen.getByLabelText(/Email or username/i), 'alice');
+    await user.click(screen.getByRole('button', { name: /Send reset link/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/something went wrong/i);
+  });
+});

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from 'next/navigation';
+import { getServerSupabase } from '@/lib/supabase/server';
+import { ForgotPasswordForm } from './ForgotPasswordForm';
+import { ROUTES } from '@/lib/constants';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const metadata = {
+  title: 'Forgot password — WC2026',
+};
+
+export default async function ForgotPasswordPage() {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user) redirect(ROUTES.predictions);
+
+  return (
+    <PageLayout>
+      <div className="mx-auto max-w-md py-12">
+        <Card>
+          <CardHeader>
+            <CardTitle>Forgot password</CardTitle>
+            <CardDescription>
+              Enter your username or email and we&apos;ll send you a reset link.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ForgotPasswordForm />
+          </CardContent>
+        </Card>
+      </div>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -134,14 +134,14 @@ export function LeaderboardPageContent() {
       <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="mb-2 text-3xl font-bold">Leaderboard</h1>
-          <p className="text-muted-foreground flex items-center gap-2">
+          <div className="text-muted-foreground flex items-center gap-2">
             <Users className="h-4 w-4" />
             {isLoading ? (
               <Skeleton className="h-4 w-32" />
             ) : (
               <span>{total.toLocaleString()} participants</span>
             )}
-          </p>
+          </div>
         </div>
         {user && !hasRankedEntry && !isLoading && !meQuery.isLoading && (
           <Card className="border-dashed">

--- a/frontend/src/app/login/LoginForm.tsx
+++ b/frontend/src/app/login/LoginForm.tsx
@@ -69,6 +69,14 @@ export function LoginForm({ redirectTo }: LoginFormProps) {
           onChange={(e) => setPassword(e.target.value)}
           disabled={isSubmitting}
         />
+        <div className="flex justify-end">
+          <Link
+            href={ROUTES.forgotPassword}
+            className="text-primary text-xs hover:underline"
+          >
+            Forgot password?
+          </Link>
+        </div>
       </div>
       {error && (
         <p role="alert" className="text-destructive text-sm">

--- a/frontend/src/app/login/__tests__/LoginForm.test.tsx
+++ b/frontend/src/app/login/__tests__/LoginForm.test.tsx
@@ -32,6 +32,12 @@ describe('LoginForm', () => {
     });
   });
 
+  it('renders a forgot-password link', () => {
+    render(<LoginForm redirectTo="/predictions" />);
+    const link = screen.getByRole('link', { name: /Forgot password/i });
+    expect(link).toHaveAttribute('href', '/forgot-password');
+  });
+
   it('surfaces supabase errors', async () => {
     signInMock.mockResolvedValue({ error: { message: 'Invalid login credentials' } });
     const user = userEvent.setup();

--- a/frontend/src/app/reset-password/ResetPasswordForm.tsx
+++ b/frontend/src/app/reset-password/ResetPasswordForm.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { ROUTES } from '@/lib/constants';
+
+export function ResetPasswordForm() {
+  const router = useRouter();
+  const [password, setPassword] = React.useState('');
+  const [confirmPassword, setConfirmPassword] = React.useState('');
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const validate = (): string | null => {
+    if (password.length < 8) return 'Password must be at least 8 characters.';
+    if (password !== confirmPassword) return 'Passwords do not match.';
+    return null;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(body.error ?? 'Could not update password. Please try again.');
+        setIsSubmitting(false);
+        return;
+      }
+    } catch {
+      setError('Network error. Please try again.');
+      setIsSubmitting(false);
+      return;
+    }
+
+    toast.success('Password updated');
+    router.push(ROUTES.predictions);
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+      <div className="space-y-2">
+        <Label htmlFor="password">New password</Label>
+        <Input
+          id="password"
+          type="password"
+          autoComplete="new-password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={isSubmitting}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="confirmPassword">Confirm new password</Label>
+        <Input
+          id="confirmPassword"
+          type="password"
+          autoComplete="new-password"
+          required
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          disabled={isSubmitting}
+        />
+      </div>
+      {error && (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      )}
+      <Button type="submit" className="w-full" disabled={isSubmitting}>
+        {isSubmitting ? 'Updating…' : 'Update password'}
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/app/reset-password/__tests__/ResetPasswordForm.test.tsx
+++ b/frontend/src/app/reset-password/__tests__/ResetPasswordForm.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ResetPasswordForm } from '../ResetPasswordForm';
+import { mockPush, mockRefresh } from '../../../../jest.setup';
+
+const toastSuccessMock = jest.fn();
+jest.mock('sonner', () => ({
+  toast: { success: (...args: unknown[]) => toastSuccessMock(...args), error: jest.fn() },
+}));
+
+describe('ResetPasswordForm', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    toastSuccessMock.mockReset();
+    mockPush.mockReset();
+    mockRefresh.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('rejects passwords shorter than 8 chars', async () => {
+    const user = userEvent.setup();
+    render(<ResetPasswordForm />);
+
+    await user.type(screen.getByLabelText(/^New password/i), 'short');
+    await user.type(screen.getByLabelText(/Confirm new password/i), 'short');
+    await user.click(screen.getByRole('button', { name: /Update password/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/at least 8 characters/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects mismatched confirmation', async () => {
+    const user = userEvent.setup();
+    render(<ResetPasswordForm />);
+
+    await user.type(screen.getByLabelText(/^New password/i), 'longenough1');
+    await user.type(screen.getByLabelText(/Confirm new password/i), 'different1!');
+    await user.click(screen.getByRole('button', { name: /Update password/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/do not match/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts password and redirects to predictions on success', async () => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+    const user = userEvent.setup();
+    render(<ResetPasswordForm />);
+
+    await user.type(screen.getByLabelText(/^New password/i), 'longenough1');
+    await user.type(screen.getByLabelText(/Confirm new password/i), 'longenough1');
+    await user.click(screen.getByRole('button', { name: /Update password/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/reset-password',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ password: 'longenough1' }),
+      })
+    );
+    await screen.findByRole('button', { name: /Updating…|Update password/i });
+    expect(toastSuccessMock).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/predictions');
+  });
+
+  it('surfaces server errors', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'New password should be different' }),
+    } as Response);
+    const user = userEvent.setup();
+    render(<ResetPasswordForm />);
+
+    await user.type(screen.getByLabelText(/^New password/i), 'longenough1');
+    await user.type(screen.getByLabelText(/Confirm new password/i), 'longenough1');
+    await user.click(screen.getByRole('button', { name: /Update password/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/should be different/i);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('shows generic error on network failure', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    const user = userEvent.setup();
+    render(<ResetPasswordForm />);
+
+    await user.type(screen.getByLabelText(/^New password/i), 'longenough1');
+    await user.type(screen.getByLabelText(/Confirm new password/i), 'longenough1');
+    await user.click(screen.getByRole('button', { name: /Update password/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/network error/i);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from 'next/navigation';
+import { getServerSupabase } from '@/lib/supabase/server';
+import { ResetPasswordForm } from './ResetPasswordForm';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const metadata = {
+  title: 'Reset password — WC2026',
+};
+
+export default async function ResetPasswordPage() {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect('/forgot-password?error=expired');
+
+  return (
+    <PageLayout>
+      <div className="mx-auto max-w-md py-12">
+        <Card>
+          <CardHeader>
+            <CardTitle>Reset password</CardTitle>
+            <CardDescription>Choose a new password for your account.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResetPasswordForm />
+          </CardContent>
+        </Card>
+      </div>
+    </PageLayout>
+  );
+}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -24,6 +24,8 @@ export const ROUTES = {
   leaderboard: '/leaderboard',
   login: '/login',
   register: '/register',
+  forgotPassword: '/forgot-password',
+  resetPassword: '/reset-password',
   admin: '/admin',
 } as const;
 


### PR DESCRIPTION
## Summary
- Adds password recovery: `/forgot-password` (accepts email or username), Supabase recovery email, and `/reset-password` for setting a new password.
- Username → email lookup happens server-side via the service-role admin client; uniform 200 response avoids leaking account existence.
- `auth.updateUser` runs on a server route handler (`POST /api/auth/reset-password`) using the recovery session from cookies, sidestepping browser-client auth-lock contention with `AuthProvider`.
- Adds a "Forgot password?" link to the sign-in form.
- Bundled fix: leaderboard participants count was a `<div>` (Skeleton) inside a `<p>`, causing a hydration warning — swapped wrapper to `<div>`.

## Test plan
- [x] `npm run typecheck && npm run lint && npm test` — 216 passing
- [x] End-to-end against local Supabase + Mailpit:
  - [x] Submit by email → email arrives → link → `/reset-password` → submit → redirected to `/predictions` signed in.
  - [x] Submit by username → same.
  - [x] Sign in afterward with the new password.
- [ ] **Production setup (manual, before deploy):** add `https://<prod-origin>/auth/callback` to the Supabase project's redirect URL allow list.