### PR TITLE
fix: use local-scope signOut to avoid intermittent hang

### DIFF
--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -66,7 +66,7 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
   const signOut = React.useCallback(async () => {
     setLoading(true);
     const userId = user?.id;
-    await supabase.auth.signOut();
+    await supabase.auth.signOut({ scope: 'local' });
     if (userId) clearAllDrafts(userId);
     setUser(null);
     setProfile(null);


### PR DESCRIPTION
## Summary
- The default `signOut()` makes an HTTP call to Supabase to revoke sessions; that call interacts poorly with the browser client's auth-lock machinery and intermittently never resolves, leaving the sign-out button stuck.
- Switch to `signOut({ scope: 'local' })` — clears cookies + local storage synchronously, no HTTP round-trip, no hang.
- JWT expires naturally within `jwt_expiry` (1h per `supabase/config.toml`). Acceptable for this app — no admin actions, no payments, low-stakes data.

## Test plan
- [x] `npm run typecheck && npm test` — 216 passing, AuthProvider tests still green.
- [x] Manual: sign in, click sign-out — instant, redirects to home, AuthMenu shows Sign in / Sign up. No hang on repeated attempts.