### PR TITLE
feat: admin CRUD on non-admin user accounts

### DIFF
--- a/frontend/src/app/admin/users/AdminUsersList.tsx
+++ b/frontend/src/app/admin/users/AdminUsersList.tsx
@@ -9,9 +9,19 @@ import { PageLayout } from '@/components/layout/PageLayout';
 import { AdminNav } from '@/components/admin/AdminNav';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { FieldError } from '@/components/ui/field-error';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import {
   Table,
   TableBody,
@@ -20,6 +30,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { useAuthContext } from '@/providers/AuthProvider';
+import { EMAIL_REGEX, PASSWORD_MIN_LENGTH, USERNAME_REGEX } from '@/lib/constants';
 
 interface AdminUser {
   id: string;
@@ -41,11 +53,22 @@ interface UsersResponse {
 
 const PAGE_SIZE = 25;
 
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return body.error ?? 'Failed';
+}
+
 export function AdminUsersList() {
   const queryClient = useQueryClient();
+  const { user: currentUser } = useAuthContext();
   const [search, setSearch] = React.useState('');
   const [debounced, setDebounced] = React.useState('');
   const [page, setPage] = React.useState(1);
+
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const [editTarget, setEditTarget] = React.useState<AdminUser | null>(null);
+  const [resetTarget, setResetTarget] = React.useState<AdminUser | null>(null);
+  const [deleteTarget, setDeleteTarget] = React.useState<AdminUser | null>(null);
 
   React.useEffect(() => {
     const t = setTimeout(() => setDebounced(search), 250);
@@ -64,6 +87,9 @@ export function AdminUsersList() {
   });
 
   const totalPages = Math.max(1, Math.ceil((query.data?.total ?? 0) / PAGE_SIZE));
+  const tournament = query.data?.tournament ?? null;
+
+  const refetchUsers = () => queryClient.invalidateQueries({ queryKey: ['admin-users'] });
 
   const toggleAdmin = async (user: AdminUser) => {
     try {
@@ -72,18 +98,13 @@ export function AdminUsersList() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ isAdmin: !user.isAdmin }),
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error ?? 'Failed');
-      }
+      if (!res.ok) throw new Error(await readError(res));
       toast.success(`${user.username} ${!user.isAdmin ? 'promoted to admin' : 'demoted'}`);
-      await queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+      await refetchUsers();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed');
     }
   };
-
-  const tournament = query.data?.tournament ?? null;
 
   const togglePaid = async (user: AdminUser) => {
     if (!tournament) {
@@ -96,12 +117,9 @@ export function AdminUsersList() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ tournamentId: tournament.id, paid: !user.isPaid }),
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error ?? 'Failed');
-      }
+      if (!res.ok) throw new Error(await readError(res));
       toast.success(`${user.username} marked ${!user.isPaid ? 'paid' : 'unpaid'}`);
-      await queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+      await refetchUsers();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed');
     }
@@ -112,6 +130,8 @@ export function AdminUsersList() {
     return new Date(user.paidAt) > new Date(tournament.lockTime);
   };
 
+  const isSelf = (user: AdminUser) => currentUser?.id === user.id;
+
   return (
     <PageLayout>
       <h1 className="mb-2 text-3xl font-bold">Admin</h1>
@@ -119,15 +139,18 @@ export function AdminUsersList() {
 
       <Card>
         <CardContent className="space-y-4 p-4">
-          <Input
-            placeholder="Search username…"
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-              setPage(1);
-            }}
-            className="max-w-sm"
-          />
+          <div className="flex items-center justify-between gap-2">
+            <Input
+              placeholder="Search username…"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+              className="max-w-sm"
+            />
+            <Button onClick={() => setCreateOpen(true)}>Create user</Button>
+          </div>
 
           {query.isLoading ? (
             <div className="space-y-2">
@@ -184,6 +207,31 @@ export function AdminUsersList() {
                       <Button variant="outline" size="sm" onClick={() => toggleAdmin(u)}>
                         {u.isAdmin ? 'Demote' : 'Promote'}
                       </Button>
+                      <Button variant="outline" size="sm" onClick={() => setEditTarget(u)}>
+                        Edit
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setResetTarget(u)}
+                      >
+                        Reset password
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        disabled={u.isAdmin || isSelf(u)}
+                        title={
+                          u.isAdmin
+                            ? 'Demote first'
+                            : isSelf(u)
+                              ? 'Cannot delete yourself'
+                              : undefined
+                        }
+                        onClick={() => setDeleteTarget(u)}
+                      >
+                        Delete
+                      </Button>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -225,6 +273,398 @@ export function AdminUsersList() {
           )}
         </CardContent>
       </Card>
+
+      <CreateUserDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={refetchUsers}
+      />
+      <EditUserDialog
+        target={editTarget}
+        onOpenChange={(open) => !open && setEditTarget(null)}
+        onSaved={refetchUsers}
+      />
+      <ResetPasswordDialog
+        target={resetTarget}
+        onOpenChange={(open) => !open && setResetTarget(null)}
+      />
+      <DeleteUserDialog
+        target={deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        onDeleted={refetchUsers}
+      />
     </PageLayout>
+  );
+}
+
+function CreateUserDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: () => void;
+}) {
+  const [email, setEmail] = React.useState('');
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [displayName, setDisplayName] = React.useState('');
+  const [touched, setTouched] = React.useState<Record<string, boolean>>({});
+  const [serverError, setServerError] = React.useState<string | null>(null);
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!open) {
+      setEmail('');
+      setUsername('');
+      setPassword('');
+      setDisplayName('');
+      setTouched({});
+      setServerError(null);
+      setSubmitting(false);
+    }
+  }, [open]);
+
+  const errors = {
+    email: !email.trim()
+      ? 'Email is required.'
+      : !EMAIL_REGEX.test(email.trim())
+        ? 'Enter a valid email address.'
+        : null,
+    username: !username.trim()
+      ? 'Username is required.'
+      : !USERNAME_REGEX.test(username.trim())
+        ? 'Username must be 3–24 chars, letters/numbers/underscore only.'
+        : null,
+    password:
+      password.length < PASSWORD_MIN_LENGTH
+        ? `Password must be at least ${PASSWORD_MIN_LENGTH} characters.`
+        : null,
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setTouched({ email: true, username: true, password: true });
+    setServerError(null);
+    if (errors.email || errors.username || errors.password) return;
+
+    setSubmitting(true);
+    const res = await fetch('/api/admin/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: email.trim(),
+        username: username.trim(),
+        password,
+        displayName: displayName.trim() || null,
+      }),
+    });
+    setSubmitting(false);
+
+    if (!res.ok) {
+      setServerError(await readError(res));
+      return;
+    }
+    toast.success(`Created ${username}`);
+    onCreated();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create user</DialogTitle>
+          <DialogDescription>Provision an account on behalf of a participant.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="create-email">Email</Label>
+            <Input
+              id="create-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, email: true }))}
+            />
+            {touched.email && (
+              <FieldError id="create-email-error" message={errors.email} />
+            )}
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="create-username">Username</Label>
+            <Input
+              id="create-username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, username: true }))}
+            />
+            {touched.username && (
+              <FieldError id="create-username-error" message={errors.username} />
+            )}
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="create-password">Password</Label>
+            <Input
+              id="create-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onBlur={() => setTouched((t) => ({ ...t, password: true }))}
+            />
+            {touched.password && (
+              <FieldError id="create-password-error" message={errors.password} />
+            )}
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="create-display-name">Display name (optional)</Label>
+            <Input
+              id="create-display-name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+            />
+          </div>
+          <FieldError id="create-server-error" message={serverError} />
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? 'Creating…' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditUserDialog({
+  target,
+  onOpenChange,
+  onSaved,
+}: {
+  target: AdminUser | null;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+}) {
+  const open = target !== null;
+  const [username, setUsername] = React.useState('');
+  const [displayName, setDisplayName] = React.useState('');
+  const [touched, setTouched] = React.useState(false);
+  const [serverError, setServerError] = React.useState<string | null>(null);
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (target) {
+      setUsername(target.username);
+      setDisplayName('');
+      setTouched(false);
+      setServerError(null);
+      setSubmitting(false);
+    }
+  }, [target]);
+
+  const usernameError =
+    !username.trim()
+      ? 'Username is required.'
+      : !USERNAME_REGEX.test(username.trim())
+        ? 'Username must be 3–24 chars, letters/numbers/underscore only.'
+        : null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!target) return;
+    setTouched(true);
+    setServerError(null);
+    if (usernameError) return;
+
+    setSubmitting(true);
+    const res = await fetch(`/api/admin/users/${target.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: username.trim(),
+        displayName: displayName.trim() || null,
+      }),
+    });
+    setSubmitting(false);
+
+    if (!res.ok) {
+      setServerError(await readError(res));
+      return;
+    }
+    toast.success(`Updated ${target.username}`);
+    onSaved();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit user</DialogTitle>
+          <DialogDescription>
+            {target ? `Update profile for ${target.username}.` : ''}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="edit-username">Username</Label>
+            <Input
+              id="edit-username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              onBlur={() => setTouched(true)}
+            />
+            {touched && <FieldError id="edit-username-error" message={usernameError} />}
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="edit-display-name">Display name (optional)</Label>
+            <Input
+              id="edit-display-name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="Leave blank to clear"
+            />
+          </div>
+          <FieldError id="edit-server-error" message={serverError} />
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ResetPasswordDialog({
+  target,
+  onOpenChange,
+}: {
+  target: AdminUser | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const open = target !== null;
+  const [submitting, setSubmitting] = React.useState(false);
+
+  const handleConfirm = async () => {
+    if (!target) return;
+    setSubmitting(true);
+    const res = await fetch(`/api/admin/users/${target.id}/password-reset`, {
+      method: 'POST',
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      toast.error(await readError(res));
+      return;
+    }
+    toast.success(`Recovery email sent to ${target.username}`);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Send password reset?</DialogTitle>
+          <DialogDescription>
+            {target
+              ? `Email a recovery link to ${target.username}. They'll set a new password themselves.`
+              : ''}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleConfirm} disabled={submitting}>
+            {submitting ? 'Sending…' : 'Send'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeleteUserDialog({
+  target,
+  onOpenChange,
+  onDeleted,
+}: {
+  target: AdminUser | null;
+  onOpenChange: (open: boolean) => void;
+  onDeleted: () => void;
+}) {
+  const open = target !== null;
+  const [confirmText, setConfirmText] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (target) {
+      setConfirmText('');
+      setSubmitting(false);
+    }
+  }, [target]);
+
+  const matches = !!target && confirmText === target.username;
+
+  const handleConfirm = async () => {
+    if (!target || !matches) return;
+    setSubmitting(true);
+    const res = await fetch(`/api/admin/users/${target.id}`, { method: 'DELETE' });
+    setSubmitting(false);
+    if (!res.ok) {
+      toast.error(await readError(res));
+      return;
+    }
+    toast.success(`Deleted ${target.username}`);
+    onDeleted();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete user?</DialogTitle>
+          <DialogDescription>
+            {target
+              ? `This will permanently delete ${target.username} and all their predictions and payments. To confirm, type the username below.`
+              : ''}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1">
+          <Label htmlFor="delete-confirm">
+            Type <span className="font-mono">{target?.username}</span> to confirm
+          </Label>
+          <Input
+            id="delete-confirm"
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            autoComplete="off"
+          />
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={!matches || submitting}
+          >
+            {submitting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/app/api/admin/users/[id]/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/users/[id]/__tests__/route.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { PATCH, DELETE } = require('../route');
+
+function patchReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/users/u2', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function deleteReq() {
+  return new NextRequest('http://localhost:3000/api/admin/users/u2', {
+    method: 'DELETE',
+  });
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('PATCH /api/admin/users/[id]', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await PATCH(patchReq({ username: 'newname' }), {
+      params: Promise.resolve({ id: 'u2' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin caller', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await PATCH(patchReq({ username: 'newname' }), {
+      params: Promise.resolve({ id: 'u2' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when neither username nor displayName provided', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await PATCH(patchReq({}), { params: Promise.resolve({ id: 'u2' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 when username taken', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: { message: 'username taken' } });
+    const res = await PATCH(patchReq({ username: 'taken' }), {
+      params: Promise.resolve({ id: 'u2' }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 400 when username invalid format', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'username invalid format' },
+    });
+    const res = await PATCH(patchReq({ username: '!!' }), {
+      params: Promise.resolve({ id: 'u2' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when user not found', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: { message: 'user not found' } });
+    const res = await PATCH(patchReq({ username: 'newname' }), {
+      params: Promise.resolve({ id: 'missing' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 on success and forwards both fields', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: null });
+    const res = await PATCH(patchReq({ username: 'newname', displayName: 'New' }), {
+      params: Promise.resolve({ id: 'u2' }),
+    });
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_update_profile', {
+      p_user_id: 'u2',
+      p_username: 'newname',
+      p_display_name: 'New',
+    });
+  });
+});
+
+describe('DELETE /api/admin/users/[id]', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await DELETE(deleteReq(), { params: Promise.resolve({ id: 'u2' }) });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin caller', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await DELETE(deleteReq(), { params: Promise.resolve({ id: 'u2' }) });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when admin tries to delete self', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: { message: 'cannot delete self' } });
+    const res = await DELETE(deleteReq(), { params: Promise.resolve({ id: 'u1' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when target is admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'cannot delete admin' },
+    });
+    const res = await DELETE(deleteReq(), { params: Promise.resolve({ id: 'u2' }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('cannot delete admin');
+  });
+
+  it('returns 404 when user not found', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: { message: 'user not found' } });
+    const res = await DELETE(deleteReq(), { params: Promise.resolve({ id: 'gone' }) });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: null });
+    const res = await DELETE(deleteReq(), { params: Promise.resolve({ id: 'u2' }) });
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_delete_user', { p_user_id: 'u2' });
+  });
+});

--- a/frontend/src/app/api/admin/users/[id]/password-reset/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/users/[id]/password-reset/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: {
+    getUser: jest.fn(),
+    resetPasswordForEmail: jest.fn(),
+  },
+  from: jest.fn(),
+};
+
+const adminMock = {
+  auth: {
+    admin: {
+      getUserById: jest.fn(),
+    },
+  },
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+jest.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => adminMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function postReq() {
+  return new NextRequest('http://localhost:3000/api/admin/users/u2/password-reset', {
+    method: 'POST',
+  });
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('POST /api/admin/users/[id]/password-reset', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.auth.resetPasswordForEmail.mockReset();
+    supabaseMock.from.mockReset();
+    adminMock.auth.admin.getUserById.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(postReq(), { params: Promise.resolve({ id: 'u2' }) });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin caller', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await POST(postReq(), { params: Promise.resolve({ id: 'u2' }) });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when target user has no email / does not exist', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    adminMock.auth.admin.getUserById.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'not found' },
+    });
+    const res = await POST(postReq(), { params: Promise.resolve({ id: 'gone' }) });
+    expect(res.status).toBe(404);
+  });
+
+  it('triggers reset email and returns 200', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    adminMock.auth.admin.getUserById.mockResolvedValue({
+      data: { user: { id: 'u2', email: 'target@example.com' } },
+      error: null,
+    });
+    supabaseMock.auth.resetPasswordForEmail.mockResolvedValue({ data: {}, error: null });
+    const res = await POST(postReq(), { params: Promise.resolve({ id: 'u2' }) });
+    expect(res.status).toBe(200);
+    expect(supabaseMock.auth.resetPasswordForEmail).toHaveBeenCalledWith(
+      'target@example.com',
+      expect.objectContaining({
+        redirectTo: expect.stringContaining('/auth/callback?next=/reset-password'),
+      })
+    );
+  });
+});

--- a/frontend/src/app/api/admin/users/[id]/password-reset/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/password-reset/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { createAdminSupabaseClient } from '@/lib/supabase/admin';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const { id } = await params;
+
+  const admin = createAdminSupabaseClient();
+  const { data, error } = await admin.auth.admin.getUserById(id);
+  if (error || !data?.user?.email) {
+    return NextResponse.json({ error: 'user not found' }, { status: 404 });
+  }
+
+  const origin = new URL(request.url).origin;
+  const { error: sendError } = await ctx.supabase.auth.resetPasswordForEmail(data.user.email, {
+    redirectTo: `${origin}/auth/callback?next=/reset-password`,
+  });
+  if (sendError) {
+    return NextResponse.json({ error: sendError.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/api/admin/users/[id]/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const { id } = await params;
+  const body = (await request.json().catch(() => ({}))) as {
+    username?: string | null;
+    displayName?: string | null;
+  };
+
+  if (body.username === undefined && body.displayName === undefined) {
+    return NextResponse.json(
+      { error: 'username or displayName is required' },
+      { status: 400 }
+    );
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_update_profile', {
+    p_user_id: id,
+    p_username: body.username ?? null,
+    p_display_name: body.displayName ?? null,
+  });
+
+  if (error) {
+    const msg = error.message || '';
+    if (msg.includes('forbidden')) {
+      return NextResponse.json({ error: msg }, { status: 403 });
+    }
+    if (msg.includes('user not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    if (msg.includes('username taken')) {
+      return NextResponse.json({ error: msg }, { status: 409 });
+    }
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const { id } = await params;
+
+  const { error } = await ctx.supabase.rpc('admin_delete_user', { p_user_id: id });
+
+  if (error) {
+    const msg = error.message || '';
+    if (msg.includes('forbidden')) {
+      return NextResponse.json({ error: msg }, { status: 403 });
+    }
+    if (msg.includes('user not found')) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    if (msg.includes('cannot delete self') || msg.includes('cannot delete admin')) {
+      return NextResponse.json({ error: msg }, { status: 400 });
+    }
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/api/admin/users/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/users/__tests__/route.test.ts
@@ -9,12 +9,24 @@ const supabaseMock = {
   rpc: jest.fn(),
 };
 
+const adminMock = {
+  auth: {
+    admin: {
+      createUser: jest.fn(),
+    },
+  },
+};
+
 jest.mock('@/lib/supabase/server', () => ({
   getServerSupabase: async () => supabaseMock,
 }));
 
+jest.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => adminMock,
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { GET } = require('../route');
+const { GET, POST } = require('../route');
 
 function req(qs = '') {
   return new NextRequest(`http://localhost:3000/api/admin/users${qs}`);
@@ -100,5 +112,98 @@ describe('GET /api/admin/users', () => {
     });
     expect(body.users[1]).toMatchObject({ username: 'bob', isAdmin: true, isPaid: false });
     expect(body.tournament).toEqual({ id: 't1', lockTime: '2026-06-01T00:00:00Z' });
+  });
+});
+
+function postReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/users', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/admin/users', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    adminMock.auth.admin.createUser.mockReset();
+  });
+
+  it('returns 403 for non-admin caller', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await POST(
+      postReq({ email: 'a@b.co', password: 'longenough', username: 'alice' })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid email', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await POST(
+      postReq({ email: 'not-an-email', password: 'longenough', username: 'alice' })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for short password', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await POST(
+      postReq({ email: 'a@b.co', password: 'short', username: 'alice' })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid username format', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await POST(
+      postReq({ email: 'a@b.co', password: 'longenough', username: '!!' })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 when username taken', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    adminMock.auth.admin.createUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'username taken' },
+    });
+    const res = await POST(
+      postReq({ email: 'a@b.co', password: 'longenough', username: 'taken' })
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 201 with new user id on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    adminMock.auth.admin.createUser.mockResolvedValue({
+      data: { user: { id: 'new-user-id' } },
+      error: null,
+    });
+    const res = await POST(
+      postReq({
+        email: 'a@b.co',
+        password: 'longenough',
+        username: 'alice',
+        displayName: 'Alice',
+      })
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual({ id: 'new-user-id' });
+    expect(adminMock.auth.admin.createUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'a@b.co',
+        password: 'longenough',
+        email_confirm: true,
+        user_metadata: { username: 'alice', display_name: 'Alice' },
+      })
+    );
   });
 });

--- a/frontend/src/app/api/admin/users/route.ts
+++ b/frontend/src/app/api/admin/users/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { createAdminSupabaseClient } from '@/lib/supabase/admin';
 
 export async function GET(request: NextRequest) {
   const ctx = await requireAdmin();
@@ -55,4 +56,57 @@ export async function GET(request: NextRequest) {
       ? { id: tournamentResult.data.id as string, lockTime: tournamentResult.data.lock_time as string }
       : null,
   });
+}
+
+const USERNAME_RE = /^[A-Za-z0-9_]+$/;
+
+export async function POST(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json().catch(() => ({}))) as {
+    email?: string;
+    password?: string;
+    username?: string;
+    displayName?: string | null;
+  };
+
+  const email = typeof body.email === 'string' ? body.email.trim() : '';
+  const password = typeof body.password === 'string' ? body.password : '';
+  const username = typeof body.username === 'string' ? body.username.trim() : '';
+  const displayName =
+    typeof body.displayName === 'string' && body.displayName.trim() !== ''
+      ? body.displayName.trim()
+      : null;
+
+  if (!email || !email.includes('@')) {
+    return NextResponse.json({ error: 'valid email is required' }, { status: 400 });
+  }
+  if (!password || password.length < 8) {
+    return NextResponse.json({ error: 'password must be at least 8 characters' }, { status: 400 });
+  }
+  if (!username || username.length < 3 || username.length > 24 || !USERNAME_RE.test(username)) {
+    return NextResponse.json({ error: 'username invalid format' }, { status: 400 });
+  }
+
+  const admin = createAdminSupabaseClient();
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: { username, display_name: displayName },
+  });
+
+  if (error) {
+    const msg = error.message || '';
+    if (msg.includes('username taken') || msg.includes('already')) {
+      return NextResponse.json({ error: 'username taken' }, { status: 409 });
+    }
+    if (msg.includes('username invalid format')) {
+      return NextResponse.json({ error: 'username invalid format' }, { status: 400 });
+    }
+    return NextResponse.json({ error: msg || 'failed to create user' }, { status: 400 });
+  }
+
+  return NextResponse.json({ id: data.user?.id ?? null }, { status: 201 });
 }

--- a/supabase/migrations/0009_admin_user_crud.sql
+++ b/supabase/migrations/0009_admin_user_crud.sql
@@ -1,0 +1,112 @@
+-- WC2026 — Admin CRUD on non-admin user accounts
+--
+-- Adds two RPCs that let an admin remove or rename other accounts.
+-- Account creation and password reset are handled by the route layer
+-- via the Supabase Admin API (auth.admin.createUser / generateLink) —
+-- no SQL needed for those because the existing handle_new_user trigger
+-- (0003) populates profiles from user_metadata on insert.
+
+-- ========== RPC: admin_delete_user ==========
+-- Hard-deletes an account. Cascades wipe profiles, predictions,
+-- group_predictions, knockout_predictions, tournament_payments via
+-- the FKs declared in 0001 / 0008.
+create or replace function public.admin_delete_user(p_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_target_is_admin boolean;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    if p_user_id is null then
+        raise exception 'user_id is required' using errcode = 'P0001';
+    end if;
+
+    if p_user_id = auth.uid() then
+        raise exception 'cannot delete self' using errcode = 'P0001';
+    end if;
+
+    select is_admin into v_target_is_admin
+    from public.profiles
+    where id = p_user_id;
+
+    if v_target_is_admin is null then
+        raise exception 'user not found' using errcode = 'P0001';
+    end if;
+
+    if v_target_is_admin then
+        raise exception 'cannot delete admin' using errcode = 'P0001';
+    end if;
+
+    delete from auth.users where id = p_user_id;
+end;
+$$;
+
+grant execute on function public.admin_delete_user(uuid) to authenticated;
+
+-- ========== RPC: admin_update_profile ==========
+-- Edit username and/or display_name on another account. The
+-- prevent_admin_self_elevation trigger (0002) only fires when is_admin
+-- changes, so non-admin profile fields update cleanly. SECURITY DEFINER
+-- bypasses the profiles_update_own policy that otherwise restricts
+-- updates to auth.uid() = id.
+create or replace function public.admin_update_profile(
+    p_user_id uuid,
+    p_username text,
+    p_display_name text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_username citext;
+    v_exists boolean;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    if p_user_id is null then
+        raise exception 'user_id is required' using errcode = 'P0001';
+    end if;
+
+    select true into v_exists from public.profiles where id = p_user_id;
+    if not coalesce(v_exists, false) then
+        raise exception 'user not found' using errcode = 'P0001';
+    end if;
+
+    -- Username update is optional; null/empty = leave alone.
+    v_username := nullif(trim(coalesce(p_username, '')), '')::citext;
+
+    if v_username is not null then
+        if length(v_username::text) < 3 or length(v_username::text) > 24
+           or v_username::text !~ '^[A-Za-z0-9_]+$' then
+            raise exception 'username invalid format' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.profiles
+                set username = v_username
+                where id = p_user_id;
+        exception
+            when unique_violation then
+                raise exception 'username taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    -- display_name: pass null to clear, empty string treated as null,
+    -- otherwise set to the trimmed value.
+    update public.profiles
+        set display_name = nullif(trim(coalesce(p_display_name, '')), '')
+        where id = p_user_id;
+end;
+$$;
+
+grant execute on function public.admin_update_profile(uuid, text, text) to authenticated;


### PR DESCRIPTION
## Summary
- Migration `0009_admin_user_crud.sql` adds `admin_delete_user` (hard-delete with self / admin / not-found guards) and `admin_update_profile` (username + display_name with format/uniqueness checks reusing the signup rules).
- New routes: `POST /api/admin/users` (create via `auth.admin.createUser`), `PATCH /api/admin/users/[id]` (rename), `DELETE /api/admin/users/[id]` (cascade delete), `POST /api/admin/users/[id]/password-reset` (Supabase recovery email).
- AdminUsersList: Create-user button + per-row Edit / Reset password / Delete. Delete uses a typed-confirmation modal and is disabled on admins ("Demote first") and on self.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 252/252 passing (was 229; 23 new tests across the four routes)
- [x] `supabase db push` applied 0009; `supabase migration list` shows local/remote both at 0009
- [ ] Manual: create user → can sign in with provided password
- [ ] Manual: edit username → list reflects new value; reusing username → 409 inline
- [ ] Manual: send recovery email → received and link works
- [ ] Manual: typed-confirm delete on a non-admin → row gone, predictions/payments cascade-cleaned
- [ ] Manual: delete button disabled on admin row and on own row