### PR TITLE
feat: super admin role

### DIFF
--- a/frontend/src/app/admin/users/AdminUsersList.tsx
+++ b/frontend/src/app/admin/users/AdminUsersList.tsx
@@ -37,6 +37,7 @@ interface AdminUser {
   id: string;
   username: string;
   isAdmin: boolean;
+  isSuperAdmin: boolean;
   hasPrediction: boolean;
   submittedAt: string | null;
   isPaid: boolean;
@@ -174,7 +175,13 @@ export function AdminUsersList() {
                   <TableRow key={u.id}>
                     <TableCell className="font-medium">{u.username}</TableCell>
                     <TableCell>
-                      {u.isAdmin ? <Badge>admin</Badge> : <Badge variant="outline">user</Badge>}
+                      {u.isSuperAdmin ? (
+                        <Badge title="Cannot be demoted or deleted">super admin</Badge>
+                      ) : u.isAdmin ? (
+                        <Badge>admin</Badge>
+                      ) : (
+                        <Badge variant="outline">user</Badge>
+                      )}
                     </TableCell>
                     <TableCell className="text-muted-foreground text-sm">
                       {u.hasPrediction ? (u.submittedAt ?? 'yes') : '—'}
@@ -204,7 +211,13 @@ export function AdminUsersList() {
                       >
                         {u.isPaid ? 'Mark unpaid' : 'Mark paid'}
                       </Button>
-                      <Button variant="outline" size="sm" onClick={() => toggleAdmin(u)}>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => toggleAdmin(u)}
+                        disabled={u.isSuperAdmin}
+                        title={u.isSuperAdmin ? 'Super admin cannot be demoted' : undefined}
+                      >
                         {u.isAdmin ? 'Demote' : 'Promote'}
                       </Button>
                       <Button variant="outline" size="sm" onClick={() => setEditTarget(u)}>
@@ -220,13 +233,15 @@ export function AdminUsersList() {
                       <Button
                         variant="destructive"
                         size="sm"
-                        disabled={u.isAdmin || isSelf(u)}
+                        disabled={u.isSuperAdmin || u.isAdmin || isSelf(u)}
                         title={
-                          u.isAdmin
-                            ? 'Demote first'
-                            : isSelf(u)
-                              ? 'Cannot delete yourself'
-                              : undefined
+                          u.isSuperAdmin
+                            ? 'Super admin cannot be deleted'
+                            : u.isAdmin
+                              ? 'Demote first'
+                              : isSelf(u)
+                                ? 'Cannot delete yourself'
+                                : undefined
                         }
                         onClick={() => setDeleteTarget(u)}
                       >

--- a/frontend/src/app/api/admin/users/[id]/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/users/[id]/__tests__/route.test.ts
@@ -146,6 +146,19 @@ describe('DELETE /api/admin/users/[id]', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 400 when target is super admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'cannot delete super admin' },
+    });
+    const res = await DELETE(deleteReq(), { params: Promise.resolve({ id: 'u2' }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('cannot delete super admin');
+  });
+
   it('returns 400 when target is admin', async () => {
     supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
     mockAdminProfile(true);

--- a/frontend/src/app/api/admin/users/[id]/admin/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/users/[id]/admin/__tests__/route.test.ts
@@ -55,6 +55,21 @@ describe('PATCH /api/admin/users/[id]/admin', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 400 with rpc error when demoting super admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'cannot demote super admin' },
+    });
+    const res = await PATCH(patchReq({ isAdmin: false }), {
+      params: Promise.resolve({ id: 'u2' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('super admin');
+  });
+
   it('returns 400 with rpc error when demoting last admin', async () => {
     supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
     mockAdminProfile(true);

--- a/frontend/src/app/api/admin/users/[id]/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/route.ts
@@ -63,7 +63,11 @@ export async function DELETE(
     if (msg.includes('user not found')) {
       return NextResponse.json({ error: msg }, { status: 404 });
     }
-    if (msg.includes('cannot delete self') || msg.includes('cannot delete admin')) {
+    if (
+      msg.includes('cannot delete self') ||
+      msg.includes('cannot delete admin') ||
+      msg.includes('cannot delete super admin')
+    ) {
       return NextResponse.json({ error: msg }, { status: 400 });
     }
     return NextResponse.json({ error: msg }, { status: 400 });

--- a/frontend/src/app/api/admin/users/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/users/__tests__/route.test.ts
@@ -81,6 +81,7 @@ describe('GET /api/admin/users', () => {
           id: 'a',
           username: 'alice',
           is_admin: false,
+          is_super_admin: false,
           has_prediction: true,
           submitted_at: '2026-04-30T00:00:00Z',
           is_paid: true,
@@ -91,6 +92,7 @@ describe('GET /api/admin/users', () => {
           id: 'b',
           username: 'bob',
           is_admin: true,
+          is_super_admin: true,
           has_prediction: false,
           submitted_at: null,
           is_paid: false,
@@ -108,9 +110,15 @@ describe('GET /api/admin/users', () => {
     expect(body.users[0]).toMatchObject({
       username: 'alice',
       isPaid: true,
+      isSuperAdmin: false,
       paidAt: '2026-04-29T00:00:00Z',
     });
-    expect(body.users[1]).toMatchObject({ username: 'bob', isAdmin: true, isPaid: false });
+    expect(body.users[1]).toMatchObject({
+      username: 'bob',
+      isAdmin: true,
+      isSuperAdmin: true,
+      isPaid: false,
+    });
     expect(body.tournament).toEqual({ id: 't1', lockTime: '2026-06-01T00:00:00Z' });
   });
 });

--- a/frontend/src/app/api/admin/users/route.ts
+++ b/frontend/src/app/api/admin/users/route.ts
@@ -32,6 +32,7 @@ export async function GET(request: NextRequest) {
     id: string;
     username: string;
     is_admin: boolean;
+    is_super_admin: boolean;
     has_prediction: boolean;
     submitted_at: string | null;
     is_paid: boolean;
@@ -44,6 +45,7 @@ export async function GET(request: NextRequest) {
       id: r.id,
       username: r.username,
       isAdmin: r.is_admin,
+      isSuperAdmin: r.is_super_admin,
       hasPrediction: r.has_prediction,
       submittedAt: r.submitted_at,
       isPaid: r.is_paid,

--- a/supabase/migrations/0010_super_admin.sql
+++ b/supabase/migrations/0010_super_admin.sql
@@ -1,0 +1,195 @@
+-- WC2026 — Super Admin
+--
+-- One designated super admin. Cannot be demoted or deleted by any other
+-- admin. The is_super_admin flag itself can only be flipped via direct
+-- SQL with session_replication_role = 'replica'; no RPC or app code path
+-- is provided. Designated user: leedium@me.com.
+
+-- ========== Column ==========
+alter table public.profiles
+    add column if not exists is_super_admin boolean not null default false;
+
+-- ========== Initial designation (before the trigger that would block it) ==========
+-- No-op if the user doesn't exist yet (e.g., fresh local DB).
+update public.profiles
+    set is_super_admin = true
+    where id = (select id from auth.users where email = 'leedium@me.com');
+
+-- ========== Trigger: block is_super_admin flips from app context ==========
+create or replace function public.prevent_super_admin_change()
+returns trigger
+language plpgsql
+as $$
+begin
+    if old.is_super_admin is distinct from new.is_super_admin then
+        raise exception 'cannot modify is_super_admin from app context'
+            using errcode = 'P0001';
+    end if;
+    return new;
+end;
+$$;
+
+drop trigger if exists profiles_block_super_admin_change on public.profiles;
+create trigger profiles_block_super_admin_change
+    before update on public.profiles
+    for each row execute function public.prevent_super_admin_change();
+
+-- ========== Replace admin_set_user_admin: refuse demoting a super admin ==========
+create or replace function public.admin_set_user_admin(p_user_id uuid, p_is_admin boolean)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_other_admin_count int;
+    v_target_is_super_admin boolean;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    if p_is_admin = false then
+        select is_super_admin into v_target_is_super_admin
+        from public.profiles where id = p_user_id;
+        if coalesce(v_target_is_super_admin, false) then
+            raise exception 'cannot demote super admin' using errcode = 'P0001';
+        end if;
+
+        select count(*) into v_other_admin_count
+        from public.profiles
+        where is_admin = true and id <> p_user_id;
+        if v_other_admin_count = 0 then
+            raise exception 'cannot demote last admin' using errcode = 'P0001';
+        end if;
+    end if;
+
+    update public.profiles set is_admin = p_is_admin where id = p_user_id;
+end;
+$$;
+
+grant execute on function public.admin_set_user_admin(uuid, boolean) to authenticated;
+
+-- ========== Replace admin_delete_user: refuse deleting a super admin ==========
+create or replace function public.admin_delete_user(p_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_target_is_admin boolean;
+    v_target_is_super_admin boolean;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_user_id is null then
+        raise exception 'user_id is required' using errcode = 'P0001';
+    end if;
+    if p_user_id = auth.uid() then
+        raise exception 'cannot delete self' using errcode = 'P0001';
+    end if;
+
+    select is_admin, is_super_admin
+        into v_target_is_admin, v_target_is_super_admin
+    from public.profiles where id = p_user_id;
+
+    if v_target_is_admin is null then
+        raise exception 'user not found' using errcode = 'P0001';
+    end if;
+
+    if coalesce(v_target_is_super_admin, false) then
+        raise exception 'cannot delete super admin' using errcode = 'P0001';
+    end if;
+
+    if v_target_is_admin then
+        raise exception 'cannot delete admin' using errcode = 'P0001';
+    end if;
+
+    delete from auth.users where id = p_user_id;
+end;
+$$;
+
+grant execute on function public.admin_delete_user(uuid) to authenticated;
+
+-- ========== Replace admin_list_users: surface is_super_admin ==========
+-- Return signature gains is_super_admin; CREATE OR REPLACE can't change
+-- OUT params, so drop first.
+drop function if exists public.admin_list_users(text, int, int);
+
+create or replace function public.admin_list_users(
+    p_search text,
+    p_page int,
+    p_page_size int
+)
+returns table (
+    id uuid,
+    username text,
+    is_admin boolean,
+    is_super_admin boolean,
+    has_prediction boolean,
+    submitted_at timestamptz,
+    is_paid boolean,
+    paid_at timestamptz,
+    total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid;
+    v_offset int;
+    v_limit int;
+    v_search text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    v_limit := greatest(1, least(coalesce(p_page_size, 25), 100));
+    v_offset := greatest(0, (coalesce(p_page, 1) - 1) * v_limit);
+    v_search := nullif(trim(coalesce(p_search, '')), '');
+
+    select t.id into v_tournament_id from public.tournaments t where t.is_active limit 1;
+
+    return query
+    with filtered as (
+        select
+            p.id,
+            p.username::text as username,
+            p.is_admin,
+            p.is_super_admin,
+            pr.id is not null as has_prediction,
+            pr.submitted_at,
+            tp.id is not null as is_paid,
+            tp.paid_at
+        from public.profiles p
+        left join public.predictions pr
+            on pr.user_id = p.id and pr.tournament_id = v_tournament_id
+        left join public.tournament_payments tp
+            on tp.user_id = p.id and tp.tournament_id = v_tournament_id
+        where v_search is null or p.username::text ilike '%' || v_search || '%'
+    ),
+    counted as (
+        select count(*) as total from filtered
+    )
+    select
+        f.id,
+        f.username,
+        f.is_admin,
+        f.is_super_admin,
+        f.has_prediction,
+        f.submitted_at,
+        f.is_paid,
+        f.paid_at,
+        c.total
+    from filtered f
+    cross join counted c
+    order by f.username asc
+    limit v_limit offset v_offset;
+end;
+$$;
+
+grant execute on function public.admin_list_users(text, int, int) to authenticated;


### PR DESCRIPTION
## Summary
- New \`profiles.is_super_admin\` flag (migration 0010) with a trigger that blocks any flip from app context — only direct SQL with \`session_replication_role = 'replica'\` can change it.
- \`admin_set_user_admin\` and \`admin_delete_user\` refuse to demote/delete a super admin.
- \`admin_list_users\` surfaces the flag; the API maps it to \`isSuperAdmin\`.
- AdminUsersList shows a \`super admin\` badge and disables Demote / Delete buttons on the super-admin row with explanatory tooltips.
- \`leedium@me.com\` is designated as the initial super admin. The seed UPDATE is a no-op when that account isn't present (fresh local DBs), so the migration is safe everywhere.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 256/256 passing (was 254; +2 for the new error-mapping branches)
- [x] \`supabase db push\` applied 0010; \`supabase migration list\` shows local/remote both at 0010
- [x] Verified locally: \`leedium\` row has \`is_super_admin = true\`
- [ ] Manual: super-admin row in /admin/users shows \`super admin\` badge, both Demote and Delete buttons disabled with tooltips
- [ ] Manual: forced demote/delete via API returns 400 with \`cannot demote/delete super admin\`