### PR TITLE
chore(security): pre-launch hardening pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,21 @@ Admin-controlled v1: an admin (`profiles.is_admin = true`) submits final group s
 - **Never import `lib/supabase/admin.ts` from a client component** — service-role key would leak.
 - **Cloudflare Workers runtime**: `npm run preview` builds with OpenNext and runs locally on the Worker runtime. If you add a Node-only dep, expect to need `compatibility_flags = ["nodejs_compat"]` in `wrangler.toml` (already set) or to find an edge-friendly alternative.
 
+## Production rate limits (Cloudflare WAF)
+
+App-level rate limiting isn't implemented (Cloudflare Workers' multi-instance model makes in-memory counters unreliable). Configure these rules in **Cloudflare Dashboard → Security → WAF → Rate limiting rules** before launch:
+
+| Path | Threshold | Window | Action |
+|------|-----------|--------|--------|
+| `/api/auth/forgot-password` | 5 requests | 1 minute | Block |
+| `/api/auth/reset-password` | 5 requests | 1 minute | Block |
+| `/login`, `/register` (POST) | 10 requests | 1 minute | Challenge |
+| `/api/admin/users/*/password-reset` | 10 requests | 5 minutes | Block |
+| `/api/admin/*` | 100 requests | 1 minute | Block |
+| Site-wide | 600 requests | 1 minute | Challenge |
+
+All by client IP. The first three protect against email enumeration / mailbox flooding; the admin rules cap blast radius if an admin account is compromised; the site-wide rule absorbs basic scraping.
+
 ## Git Commits
 
 - Do not include "Co-Authored-By" lines in commit messages.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,59 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {};
+const isDev = process.env.NODE_ENV === 'development';
+
+// Hosts the app talks to. Supabase project is on *.supabase.co; in dev we
+// also allow the local stack at 127.0.0.1:54321 / localhost:* for SSR
+// fetches and websocket realtime channels.
+const supabaseConnect = ['https://*.supabase.co', 'wss://*.supabase.co'];
+const devConnect = isDev
+  ? [
+      'http://127.0.0.1:*',
+      'ws://127.0.0.1:*',
+      'http://localhost:*',
+      'ws://localhost:*',
+    ]
+  : [];
+
+// Note: Next.js App Router embeds inline scripts for hydration data, and
+// Radix UI / Tailwind use inline styles. 'unsafe-inline' is currently
+// required for both. Tightening with nonces is a separate workstream.
+const csp = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  `connect-src 'self' ${[...supabaseConnect, ...devConnect].join(' ')}`,
+  "font-src 'self' data:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  'upgrade-insecure-requests',
+].join('; ');
+
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: csp },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()',
+  },
+  // Start at 1 year. Bump to 2 years + preload after a confidence period.
+  { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
+];
+
+const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/frontend/src/app/api/admin/group-standings/route.ts
+++ b/frontend/src/app/api/admin/group-standings/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
 
 interface Body {
   tournamentId?: string;
@@ -25,7 +26,7 @@ export async function GET(request: NextRequest) {
     .select('group_id, first_team_id, second_team_id, third_team_id, fourth_team_id, submitted_at')
     .eq('tournament_id', tournamentId);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 500 });
   return NextResponse.json(data ?? []);
 }
 
@@ -53,6 +54,6 @@ export async function POST(request: NextRequest) {
     p_fourth: body.fourth,
   });
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
   return NextResponse.json({ ok: true });
 }

--- a/frontend/src/app/api/admin/knockout-results/route.ts
+++ b/frontend/src/app/api/admin/knockout-results/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
 
 interface Body {
   tournamentId?: string;
@@ -24,7 +25,7 @@ export async function GET(request: NextRequest) {
     .select('match_id, winner_team_id, loser_team_id, total_goals, submitted_at')
     .eq('tournament_id', tournamentId);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 500 });
   return NextResponse.json(data ?? []);
 }
 
@@ -48,6 +49,6 @@ export async function POST(request: NextRequest) {
     p_total_goals: body.totalGoals ?? null,
   });
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
   return NextResponse.json({ ok: true });
 }

--- a/frontend/src/app/api/admin/users/[id]/admin/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/admin/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
 
 export async function PATCH(
   request: NextRequest,
@@ -20,8 +21,8 @@ export async function PATCH(
   });
 
   if (error) {
-    const status = error.message.includes('cannot demote') ? 400 : 400;
-    return NextResponse.json({ error: error.message }, { status });
+    const status = error.message?.includes('forbidden') ? 403 : 400;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
   }
 
   return NextResponse.json({ ok: true });

--- a/frontend/src/app/api/admin/users/[id]/payment/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/payment/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
 
 export async function GET(
   request: NextRequest,
@@ -21,7 +22,7 @@ export async function GET(
     .eq('tournament_id', tournamentId)
     .maybeSingle();
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
 
   return NextResponse.json({
     paid: !!data,
@@ -68,7 +69,7 @@ export async function PATCH(
   });
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
   }
 
   return NextResponse.json({ paid: body.paid, paidAt: body.paid ? paidAt : null });

--- a/frontend/src/app/api/admin/users/[id]/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+const MAX_DISPLAY_NAME_LENGTH = 50;
 
 export async function PATCH(
   request: NextRequest,
@@ -21,6 +24,16 @@ export async function PATCH(
     );
   }
 
+  if (
+    typeof body.displayName === 'string' &&
+    body.displayName.length > MAX_DISPLAY_NAME_LENGTH
+  ) {
+    return NextResponse.json(
+      { error: `displayName must be ${MAX_DISPLAY_NAME_LENGTH} characters or fewer` },
+      { status: 400 }
+    );
+  }
+
   const { error } = await ctx.supabase.rpc('admin_update_profile', {
     p_user_id: id,
     p_username: body.username ?? null,
@@ -28,14 +41,14 @@ export async function PATCH(
   });
 
   if (error) {
-    const msg = error.message || '';
-    if (msg.includes('forbidden')) {
+    const msg = safeMessage(error);
+    if (error.message?.includes('forbidden')) {
       return NextResponse.json({ error: msg }, { status: 403 });
     }
-    if (msg.includes('user not found')) {
+    if (error.message?.includes('user not found')) {
       return NextResponse.json({ error: msg }, { status: 404 });
     }
-    if (msg.includes('username taken')) {
+    if (error.message?.includes('username taken')) {
       return NextResponse.json({ error: msg }, { status: 409 });
     }
     return NextResponse.json({ error: msg }, { status: 400 });
@@ -56,19 +69,13 @@ export async function DELETE(
   const { error } = await ctx.supabase.rpc('admin_delete_user', { p_user_id: id });
 
   if (error) {
-    const msg = error.message || '';
-    if (msg.includes('forbidden')) {
+    const msg = safeMessage(error);
+    const raw = error.message ?? '';
+    if (raw.includes('forbidden')) {
       return NextResponse.json({ error: msg }, { status: 403 });
     }
-    if (msg.includes('user not found')) {
+    if (raw.includes('user not found')) {
       return NextResponse.json({ error: msg }, { status: 404 });
-    }
-    if (
-      msg.includes('cannot delete self') ||
-      msg.includes('cannot delete admin') ||
-      msg.includes('cannot delete super admin')
-    ) {
-      return NextResponse.json({ error: msg }, { status: 400 });
     }
     return NextResponse.json({ error: msg }, { status: 400 });
   }

--- a/frontend/src/app/api/admin/users/route.ts
+++ b/frontend/src/app/api/admin/users/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
 import { createAdminSupabaseClient } from '@/lib/supabase/admin';
+import { safeMessage } from '@/lib/api/errors';
 
 export async function GET(request: NextRequest) {
   const ctx = await requireAdmin();
@@ -25,7 +26,7 @@ export async function GET(request: NextRequest) {
   ]);
 
   if (usersResult.error) {
-    return NextResponse.json({ error: usersResult.error.message }, { status: 500 });
+    return NextResponse.json({ error: safeMessage(usersResult.error) }, { status: 500 });
   }
 
   const rows = (usersResult.data ?? []) as Array<{
@@ -61,6 +62,9 @@ export async function GET(request: NextRequest) {
 }
 
 const USERNAME_RE = /^[A-Za-z0-9_]+$/;
+const MAX_DISPLAY_NAME_LENGTH = 50;
+const MAX_EMAIL_LENGTH = 254;
+const MAX_PASSWORD_LENGTH = 128;
 
 export async function POST(request: NextRequest) {
   const ctx = await requireAdmin();
@@ -81,14 +85,23 @@ export async function POST(request: NextRequest) {
       ? body.displayName.trim()
       : null;
 
-  if (!email || !email.includes('@')) {
+  if (!email || !email.includes('@') || email.length > MAX_EMAIL_LENGTH) {
     return NextResponse.json({ error: 'valid email is required' }, { status: 400 });
   }
-  if (!password || password.length < 8) {
-    return NextResponse.json({ error: 'password must be at least 8 characters' }, { status: 400 });
+  if (!password || password.length < 8 || password.length > MAX_PASSWORD_LENGTH) {
+    return NextResponse.json(
+      { error: `password must be 8-${MAX_PASSWORD_LENGTH} characters` },
+      { status: 400 }
+    );
   }
   if (!username || username.length < 3 || username.length > 24 || !USERNAME_RE.test(username)) {
     return NextResponse.json({ error: 'username invalid format' }, { status: 400 });
+  }
+  if (displayName !== null && displayName.length > MAX_DISPLAY_NAME_LENGTH) {
+    return NextResponse.json(
+      { error: `displayName must be ${MAX_DISPLAY_NAME_LENGTH} characters or fewer` },
+      { status: 400 }
+    );
   }
 
   const admin = createAdminSupabaseClient();
@@ -107,7 +120,7 @@ export async function POST(request: NextRequest) {
     if (msg.includes('username invalid format')) {
       return NextResponse.json({ error: 'username invalid format' }, { status: 400 });
     }
-    return NextResponse.json({ error: msg || 'failed to create user' }, { status: 400 });
+    return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
   }
 
   return NextResponse.json({ id: data.user?.id ?? null }, { status: 201 });

--- a/frontend/src/app/api/predictions/route.ts
+++ b/frontend/src/app/api/predictions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerSupabase } from '@/lib/supabase/server';
+import { safeMessage } from '@/lib/api/errors';
 
 interface SubmitPayload {
   tournamentId?: string;
@@ -115,8 +116,8 @@ export async function POST(request: NextRequest) {
 
   const { data, error } = await supabase.rpc('submit_predictions', { payload });
   if (error) {
-    const status = error.message.includes('locked') ? 403 : 400;
-    return NextResponse.json({ error: error.message }, { status });
+    const status = error.message?.includes('locked') ? 403 : 400;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
   }
 
   return NextResponse.json({ predictionId: data });

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -1,0 +1,42 @@
+/**
+ * Whitelist of error substrings the API is allowed to surface to clients.
+ * These are intentional, app-defined errors raised by our SECURITY DEFINER
+ * RPCs and trigger functions (see supabase/migrations/*) — safe and useful
+ * for the UI to render verbatim.
+ *
+ * Anything not on this list is treated as opaque (Postgres internals,
+ * constraint names, JWT/auth library messages, etc.) and replaced with
+ * a generic 'request failed' to avoid leaking schema or library details.
+ */
+const KNOWN_ERROR_FRAGMENTS = [
+  'forbidden',
+  'user not found',
+  'username taken',
+  'username invalid format',
+  'username is required',
+  'cannot delete self',
+  'cannot delete admin',
+  'cannot delete super admin',
+  'cannot demote last admin',
+  'cannot demote super admin',
+  'cannot modify is_admin',
+  'cannot modify is_super_admin',
+  'predictions are locked',
+  'not authenticated',
+  'all four teams must be distinct',
+  'does not belong to group',
+  'winner and loser must differ',
+] as const;
+
+export function safeMessage(
+  error: { message?: string | null } | null | undefined
+): string {
+  const raw = error?.message ?? '';
+  if (!raw) return 'request failed';
+  const lower = raw.toLowerCase();
+  for (const fragment of KNOWN_ERROR_FRAGMENTS) {
+    if (lower.includes(fragment)) return raw;
+  }
+  console.error('[safeMessage] unmapped error:', raw);
+  return 'request failed';
+}


### PR DESCRIPTION
## Summary
Items 1-4 from the pre-launch security audit:

1. **Security headers** in \`next.config.ts\` — CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, HSTS. CSP allows \`*.supabase.co\` (and local 127.0.0.1 in dev) for fetch + websockets.
2. **Cloudflare WAF rate-limit rules** documented in \`CLAUDE.md\` for dashboard config (auth endpoints, admin endpoints, site-wide).
3. **\`safeMessage()\` helper** in \`frontend/src/lib/api/errors.ts\` — known-fragment whitelist; everything else returns \`'request failed'\` and logs server-side. Applied to every admin route and the predictions route, replacing bare \`{error: error.message}\` echoes.
4. **Length caps** on free-text inputs: displayName ≤ 50, email ≤ 254, password ≤ 128.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean (no new errors in src/)
- [x] \`npm test\` — 256/256 passing (no test deltas; existing tests assert on whitelisted error strings which still pass through)
- [ ] Smoke: load any page in prod after deploy, confirm response headers via DevTools include CSP / X-Frame-Options / HSTS / Referrer-Policy
- [ ] Cloudflare Dashboard: configure rate-limit rules per the new CLAUDE.md table before launch