### PR TITLE
fix: surface unhandled errors in admin password-reset route

### DIFF
--- a/frontend/src/app/api/admin/users/[id]/password-reset/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/password-reset/route.ts
@@ -11,31 +11,37 @@ export async function POST(
 
   const { id } = await params;
 
-  const admin = createAdminSupabaseClient();
-  const { data, error } = await admin.auth.admin.getUserById(id);
-  if (error) {
-    return NextResponse.json(
-      { error: `lookup failed: ${error.message}` },
-      { status: 500 }
-    );
-  }
-  if (!data?.user) {
-    return NextResponse.json({ error: 'user not found' }, { status: 404 });
-  }
-  if (!data.user.email) {
-    return NextResponse.json(
-      { error: 'user has no email on file' },
-      { status: 400 }
-    );
-  }
+  try {
+    const admin = createAdminSupabaseClient();
+    const { data, error } = await admin.auth.admin.getUserById(id);
+    if (error) {
+      return NextResponse.json(
+        { error: `lookup failed: ${error.message}` },
+        { status: 500 }
+      );
+    }
+    if (!data?.user) {
+      return NextResponse.json({ error: 'user not found' }, { status: 404 });
+    }
+    if (!data.user.email) {
+      return NextResponse.json(
+        { error: 'user has no email on file' },
+        { status: 400 }
+      );
+    }
 
-  const origin = new URL(request.url).origin;
-  const { error: sendError } = await ctx.supabase.auth.resetPasswordForEmail(data.user.email, {
-    redirectTo: `${origin}/auth/callback?next=/reset-password`,
-  });
-  if (sendError) {
-    return NextResponse.json({ error: sendError.message }, { status: 400 });
-  }
+    const origin = new URL(request.url).origin;
+    const { error: sendError } = await ctx.supabase.auth.resetPasswordForEmail(data.user.email, {
+      redirectTo: `${origin}/auth/callback?next=/reset-password`,
+    });
+    if (sendError) {
+      return NextResponse.json({ error: sendError.message }, { status: 400 });
+    }
 
-  return NextResponse.json({ ok: true });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error('[admin/password-reset] unhandled error:', message);
+    return NextResponse.json({ error: `password reset failed: ${message}` }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Summary
- Wraps the body of `POST /api/admin/users/[id]/password-reset` in `try/catch`. Uncaught throws now return a JSON 500 with the underlying message (and `console.error` for `wrangler tail`) instead of an opaque worker-level 500.
- Existing 500 / 404 / 400 / 200 status mapping is unchanged.

## Why
On production (Cloudflare Workers) this endpoint was returning a bare 500 with no response body, while working locally. The route had no exception handler, so any throw inside `getUserById` or `resetPasswordForEmail` fell through to the worker runtime — leaving no signal about which Supabase call was failing or why. With this change, re-triggering the failure surfaces Supabase's actual reason (e.g. SMTP / rate limit / redirect URL not allow-listed) in both the JSON body and worker logs, so it can be fixed at the Supabase Dashboard level (Auth → URL Configuration, Auth → SMTP) without further code changes.

## Test plan
- [x] `cd frontend && npm test -- password-reset` — all 6 existing tests pass
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm run lint` — clean for the edited file (pre-existing lint issues are all in `.open-next/` build output and `coverage/`)
- [ ] After merge + deploy: re-click "Send password reset" on prod, confirm the 500 body now contains a useful Supabase error message