### PR TITLE
feat(predictions): progressive 8-step wizard with hierarchical stepper

### DIFF
--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -7,7 +7,11 @@ import { toast } from 'sonner';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { AdminNav } from '@/components/admin/AdminNav';
 import { GroupStageForm } from '@/components/predictions/GroupStageForm';
-import { KnockoutBracket } from '@/components/predictions/KnockoutBracket';
+import {
+  KnockoutBracket,
+  STAGE_CONFIG,
+  STAGE_ORDER,
+} from '@/components/predictions/KnockoutBracket';
 import { TiebreakerInput } from '@/components/predictions/TiebreakerInput';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -138,6 +142,9 @@ export function AdminUserBracket({ userId }: { userId: string }) {
   const [totalGoals, setTotalGoals] = React.useState<number | null>(null);
   const [hydrated, setHydrated] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
+  const [knockoutStage, setKnockoutStage] = React.useState<
+    (typeof STAGE_ORDER)[number]
+  >('round_of_32');
 
   React.useEffect(() => {
     if (!groupsQuery.data || !matchesQuery.data || !predQuery.data || hydrated) return;
@@ -348,14 +355,25 @@ export function AdminUserBracket({ userId }: { userId: string }) {
           />
         </TabsContent>
         <TabsContent value="knockout">
-          <KnockoutBracket
-            matches={matchesQuery.data}
-            teams={teamsQuery.data}
-            groupPredictions={groupPreds}
-            knockoutPredictions={knockoutPreds}
-            onPredictionChange={handleKnockoutChange}
-            disabled={!editing}
-          />
+          <Tabs value={knockoutStage} onValueChange={(v) => setKnockoutStage(v as typeof knockoutStage)}>
+            <TabsList className="mb-4 flex h-auto w-full flex-wrap justify-start gap-1">
+              {STAGE_ORDER.map((s) => (
+                <TabsTrigger key={s} value={s} className="flex-shrink-0">
+                  <span className="hidden sm:inline">{STAGE_CONFIG[s].label}</span>
+                  <span className="sm:hidden">{STAGE_CONFIG[s].shortLabel}</span>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            <KnockoutBracket
+              matches={matchesQuery.data}
+              teams={teamsQuery.data}
+              groupPredictions={groupPreds}
+              knockoutPredictions={knockoutPreds}
+              onPredictionChange={handleKnockoutChange}
+              disabled={!editing}
+              stage={knockoutStage}
+            />
+          </Tabs>
         </TabsContent>
         <TabsContent value="tiebreaker">
           <TiebreakerInput value={totalGoals} onChange={setTotalGoals} disabled={!editing} />

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -14,7 +14,6 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { Tabs, TabsContent } from '@/components/ui/tabs';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthContext } from '@/providers/AuthProvider';
 import { useDraftPersistence } from '@/hooks/useDraftPersistence';
@@ -23,19 +22,81 @@ import type {
   GroupPrediction,
   KnockoutMatch,
   KnockoutMatchPrediction,
+  KnockoutStage,
   Team,
   TournamentInfo,
 } from '@/types/tournament';
 
 type PositionKey = 'first' | 'second' | 'third' | 'fourth';
-type StepValue = 'groups' | 'knockout' | 'tiebreaker';
 
-const STEP_ORDER: StepValue[] = ['groups', 'knockout', 'tiebreaker'];
-const STEP_LABELS: Record<StepValue, string> = {
+type Step =
+  | 'groups'
+  | 'round_of_32'
+  | 'round_of_16'
+  | 'quarter_finals'
+  | 'semi_finals'
+  | 'final'
+  | 'third_place'
+  | 'tiebreaker';
+
+type TopStep = 'groups' | 'knockout' | 'tiebreaker';
+
+const STEP_ORDER: Step[] = [
+  'groups',
+  'round_of_32',
+  'round_of_16',
+  'quarter_finals',
+  'semi_finals',
+  'final',
+  'third_place',
+  'tiebreaker',
+];
+
+const STEP_LABELS: Record<Step, string> = {
+  groups: 'Group Stage',
+  round_of_32: 'Round of 32',
+  round_of_16: 'Round of 16',
+  quarter_finals: 'Quarter-finals',
+  semi_finals: 'Semi-finals',
+  final: 'Final',
+  third_place: 'Third Place',
+  tiebreaker: 'Tiebreaker',
+};
+
+const KNOCKOUT_STAGE_LIST: KnockoutStage[] = [
+  'round_of_32',
+  'round_of_16',
+  'quarter_finals',
+  'semi_finals',
+  'final',
+  'third_place',
+];
+
+const SUB_STEP_LABELS: Record<KnockoutStage, string> = {
+  round_of_32: 'R32',
+  round_of_16: 'R16',
+  quarter_finals: 'QF',
+  semi_finals: 'SF',
+  final: 'Final',
+  third_place: '3rd',
+};
+
+const TOP_STEPS: TopStep[] = ['groups', 'knockout', 'tiebreaker'];
+const TOP_STEP_LABELS: Record<TopStep, string> = {
   groups: 'Group Stage',
   knockout: 'Knockout',
   tiebreaker: 'Tiebreaker',
 };
+
+function isKnockoutStage(step: Step): step is KnockoutStage {
+  return (KNOCKOUT_STAGE_LIST as Step[]).includes(step);
+}
+
+function topOf(step: Step): TopStep {
+  if (step === 'groups') return 'groups';
+  if (step === 'tiebreaker') return 'tiebreaker';
+  return 'knockout';
+}
 
 interface StoredPredictions {
   tournamentId: string;
@@ -201,7 +262,7 @@ export function PredictionsPageContent() {
   const [totalGoals, setTotalGoals] = React.useState<number | null>(null);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [hydrated, setHydrated] = React.useState(false);
-  const [currentStep, setCurrentStep] = React.useState<StepValue>('groups');
+  const [currentStep, setCurrentStep] = React.useState<Step>('groups');
   const tabsContentRef = React.useRef<HTMLDivElement | null>(null);
   const userInteractedRef = React.useRef(false);
 
@@ -319,22 +380,77 @@ export function PredictionsPageContent() {
   const isTiebreakerComplete = totalGoals !== null;
   const isPredictionsComplete = isGroupsComplete && isBracketComplete && isTiebreakerComplete;
 
-  const stepStatus: Record<StepValue, boolean> = {
+  const matchesByStage = React.useMemo(() => {
+    const grouped: Record<KnockoutStage, KnockoutMatch[]> = {
+      round_of_32: [],
+      round_of_16: [],
+      quarter_finals: [],
+      semi_finals: [],
+      third_place: [],
+      final: [],
+    };
+    (matches ?? []).forEach((m) => {
+      grouped[m.stage].push(m);
+    });
+    return grouped;
+  }, [matches]);
+
+  const stageCompletion: Record<KnockoutStage, boolean> = React.useMemo(() => {
+    const out = {} as Record<KnockoutStage, boolean>;
+    for (const s of KNOCKOUT_STAGE_LIST) {
+      const stageMatches = matchesByStage[s];
+      if (stageMatches.length === 0) {
+        out[s] = false;
+        continue;
+      }
+      out[s] = stageMatches.every((m) =>
+        knockoutPredictions.some((p) => p.matchId === m.id && p.winnerId !== null)
+      );
+    }
+    return out;
+  }, [matchesByStage, knockoutPredictions]);
+
+  const stepStatus: Record<Step, boolean> = {
     groups: isGroupsComplete,
-    knockout: isBracketComplete,
+    round_of_32: stageCompletion.round_of_32,
+    round_of_16: stageCompletion.round_of_16,
+    quarter_finals: stageCompletion.quarter_finals,
+    semi_finals: stageCompletion.semi_finals,
+    final: stageCompletion.final,
+    third_place: stageCompletion.third_place,
     tiebreaker: isTiebreakerComplete,
   };
 
-  const steps: StepperStep[] = STEP_ORDER.map((value) => {
-    const status: StepperStep['status'] = isLocked
-      ? 'locked'
-      : stepStatus[value]
-        ? 'done'
-        : value === currentStep
-          ? 'current'
-          : 'upcoming';
-    return { value, label: STEP_LABELS[value], status };
+  const stepperStatus = (value: Step): StepperStep['status'] => {
+    if (isLocked) return 'locked';
+    if (stepStatus[value]) return 'done';
+    if (value === currentStep) return 'current';
+    return 'upcoming';
+  };
+
+  const topValue: TopStep = topOf(currentStep);
+
+  const topSteps: StepperStep[] = TOP_STEPS.map((value) => {
+    let status: StepperStep['status'];
+    if (isLocked) {
+      status = 'locked';
+    } else if (value === topValue) {
+      status = 'current';
+    } else if (value === 'groups') {
+      status = isGroupsComplete ? 'done' : 'upcoming';
+    } else if (value === 'knockout') {
+      status = isBracketComplete ? 'done' : 'upcoming';
+    } else {
+      status = isTiebreakerComplete ? 'done' : 'upcoming';
+    }
+    return { value, label: TOP_STEP_LABELS[value], status };
   });
+
+  const subSteps: StepperStep[] = KNOCKOUT_STAGE_LIST.map((value) => ({
+    value,
+    label: SUB_STEP_LABELS[value],
+    status: stepperStatus(value),
+  }));
 
   const persistDraft = React.useCallback(
     (next: Partial<DraftData>) => {
@@ -379,10 +495,24 @@ export function PredictionsPageContent() {
     persistDraft({ totalGoals: value });
   };
 
-  const handleStepChange = (value: string) => {
-    if (!STEP_ORDER.includes(value as StepValue)) return;
-    setCurrentStep(value as StepValue);
+  const goToStep = (value: Step) => {
+    setCurrentStep(value);
     userInteractedRef.current = true;
+  };
+
+  const handleTopChange = (value: string) => {
+    if (!TOP_STEPS.includes(value as TopStep)) return;
+    if (value === 'groups') return goToStep('groups');
+    if (value === 'tiebreaker') return goToStep('tiebreaker');
+    // Knockout: jump to the first incomplete knockout stage, or R32 if all empty.
+    const target =
+      KNOCKOUT_STAGE_LIST.find((s) => !stageCompletion[s]) ?? 'round_of_32';
+    goToStep(target);
+  };
+
+  const handleSubChange = (value: string) => {
+    if (!KNOCKOUT_STAGE_LIST.includes(value as KnockoutStage)) return;
+    goToStep(value as Step);
   };
 
   React.useEffect(() => {
@@ -394,16 +524,14 @@ export function PredictionsPageContent() {
   const goToNextStep = () => {
     const idx = STEP_ORDER.indexOf(currentStep);
     if (idx >= 0 && idx < STEP_ORDER.length - 1) {
-      setCurrentStep(STEP_ORDER[idx + 1]);
-      userInteractedRef.current = true;
+      goToStep(STEP_ORDER[idx + 1]);
     }
   };
 
   const goToPreviousStep = () => {
     const idx = STEP_ORDER.indexOf(currentStep);
     if (idx > 0) {
-      setCurrentStep(STEP_ORDER[idx - 1]);
-      userInteractedRef.current = true;
+      goToStep(STEP_ORDER[idx - 1]);
     }
   };
 
@@ -529,20 +657,27 @@ export function PredictionsPageContent() {
         <Progress value={overallPercent} aria-label="Overall predictions progress" />
       </div>
 
-      <Tabs value={currentStep} onValueChange={handleStepChange} className="mb-8">
-        <PredictionStepper steps={steps} />
+      <div className="mb-8">
+        <PredictionStepper
+          topSteps={topSteps}
+          topValue={topValue}
+          onTopChange={handleTopChange}
+          subSteps={topValue === 'knockout' ? subSteps : undefined}
+          subValue={topValue === 'knockout' && isKnockoutStage(currentStep) ? currentStep : undefined}
+          onSubChange={topValue === 'knockout' ? handleSubChange : undefined}
+        />
 
         <div ref={tabsContentRef}>
-          <TabsContent value="groups">
+          {currentStep === 'groups' && (
             <GroupStageForm
               groups={groups}
               predictions={groupPredictions}
               onPredictionChange={handleGroupPredictionChange}
               disabled={isLocked}
             />
-          </TabsContent>
+          )}
 
-          <TabsContent value="knockout">
+          {isKnockoutStage(currentStep) && (
             <KnockoutBracket
               matches={matches}
               teams={teams}
@@ -550,16 +685,17 @@ export function PredictionsPageContent() {
               knockoutPredictions={knockoutPredictions}
               onPredictionChange={handleKnockoutPredictionChange}
               disabled={isLocked}
+              stage={currentStep}
             />
-          </TabsContent>
+          )}
 
-          <TabsContent value="tiebreaker">
+          {currentStep === 'tiebreaker' && (
             <TiebreakerInput
               value={totalGoals}
               onChange={handleTotalGoalsChange}
               disabled={isLocked}
             />
-          </TabsContent>
+          )}
         </div>
 
         <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -595,7 +731,7 @@ export function PredictionsPageContent() {
             </Button>
           )}
         </div>
-      </Tabs>
+      </div>
 
       <Card id="submit-predictions-card" className="border-primary/20 bg-primary/5">
         <CardContent className="flex flex-col items-center gap-4 py-6 sm:flex-row sm:justify-between">

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -212,32 +212,61 @@ describe('PredictionsPageContent — stepper navigation', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent />);
 
-    const continueBtn = await screen.findByRole('button', { name: /Continue to Knockout/ });
+    const continueBtn = await screen.findByRole('button', { name: /Continue to Round of 32/ });
     expect(continueBtn).toBeDisabled();
 
     await user.click(screen.getByTestId('fill-all-groups'));
-    expect(screen.getByRole('button', { name: /Continue to Knockout/ })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /Continue to Round of 32/ })).toBeEnabled();
   });
 
-  it('advances to the next step when Continue is clicked', async () => {
+  it('advances to Round of 32 when Continue is clicked from groups', async () => {
     configureQueries();
     const user = userEvent.setup();
     render(<PredictionsPageContent />);
 
     await user.click(await screen.findByTestId('fill-all-groups'));
-    await user.click(screen.getByRole('button', { name: /Continue to Knockout/ }));
+    await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
 
+    // Top "Knockout" chip is now current; sub row appears with R32 selected.
     expect(screen.getByRole('tab', { name: /Knockout/ })).toHaveAttribute(
       'aria-selected',
       'true'
     );
+    expect(screen.getByTestId('prediction-substepper')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /R32/ })).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('renders all stepper triggers as disabled when the tournament is locked', async () => {
+  it('walks through all 8 steps with Continue and reaches the tiebreaker', async () => {
+    configureQueries();
+    const user = userEvent.setup();
+    render(<PredictionsPageContent />);
+
+    await user.click(await screen.findByTestId('fill-all-groups'));
+    await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
+    // Filling all knockout matches at once satisfies every knockout sub-step.
+    await user.click(screen.getByTestId('fill-all-knockout'));
+
+    const stages = ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Third Place'];
+    for (const next of stages) {
+      const btn = await screen.findByRole('button', {
+        name: new RegExp(`Continue to ${next}`, 'i'),
+      });
+      await user.click(btn);
+    }
+    await user.click(
+      await screen.findByRole('button', { name: /Continue to Tiebreaker/ })
+    );
+    expect(screen.getByTestId('tiebreaker-input')).toBeInTheDocument();
+    // Final step shows "Review & submit" instead of "Continue to ...".
+    expect(screen.getByRole('button', { name: /Review & submit/ })).toBeInTheDocument();
+  });
+
+  it('renders all top stepper triggers as disabled when the tournament is locked', async () => {
     configureQueries({ tournamentLockTime: new Date(Date.now() - 1000).toISOString() });
     render(<PredictionsPageContent />);
 
     await screen.findByText(/Predictions Locked/);
+    // Only the top row is rendered when not on a knockout step; assert all top tabs are disabled.
     const tabs = screen.getAllByRole('tab');
     tabs.forEach((tab) => expect(tab).toBeDisabled());
   });
@@ -368,9 +397,23 @@ describe('PredictionsPageContent — autosave', () => {
     render(<PredictionsPageContent />);
 
     await user.click(await screen.findByTestId('fill-all-groups'));
-    await user.click(screen.getByRole('button', { name: /Continue to Knockout/ }));
+    await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
     await user.click(screen.getByTestId('fill-all-knockout'));
-    await user.click(screen.getByRole('button', { name: /Continue to Tiebreaker/ }));
+    // Walk through R16 → QF → SF → Final → 3rd → Tiebreaker via Continue.
+    for (const next of [
+      'Round of 16',
+      'Quarter-finals',
+      'Semi-finals',
+      'Final',
+      'Third Place',
+      'Tiebreaker',
+    ]) {
+      await user.click(
+        await screen.findByRole('button', {
+          name: new RegExp(`Continue to ${next}`, 'i'),
+        })
+      );
+    }
     await user.click(screen.getByTestId('set-tiebreaker'));
 
     act(() => {

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -6,7 +6,6 @@ import { CheckCircle2, Circle, Trophy } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { TeamFlag } from '@/components/shared/TeamFlag';
 import { cn } from '@/lib/utils';
 import type {
@@ -21,7 +20,7 @@ import type {
 // Round-of-32 picks aren't scored directly — they decide R16 slots — so the
 // hint reflects that. Other rounds score the round's advancing teams (correct
 // slot / wrong slot tiers); we surface that as a single hint per match card.
-const STAGE_CONFIG: Record<
+export const STAGE_CONFIG: Record<
   KnockoutStage,
   { label: string; shortLabel: string; pointsHint: string; subtitle: string }
 > = {
@@ -64,8 +63,9 @@ const STAGE_CONFIG: Record<
   },
 };
 
-// Stage order for tabs
-const STAGE_ORDER: KnockoutStage[] = [
+// Stage order. Used by the parent stepper; the bracket itself now renders one
+// stage at a time controlled by the `stage` prop.
+export const STAGE_ORDER: KnockoutStage[] = [
   'round_of_32',
   'round_of_16',
   'quarter_finals',
@@ -81,6 +81,7 @@ interface KnockoutBracketProps {
   knockoutPredictions: KnockoutMatchPrediction[];
   onPredictionChange: (matchId: string, winnerId: string | null) => void;
   disabled?: boolean;
+  stage: KnockoutStage;
 }
 
 // Helper to resolve a team source to team ID or null
@@ -357,21 +358,12 @@ export function KnockoutBracket({
   knockoutPredictions,
   onPredictionChange,
   disabled = false,
+  stage,
 }: KnockoutBracketProps) {
-  const matchesByStage = React.useMemo(() => {
-    const grouped: Record<KnockoutStage, KnockoutMatch[]> = {
-      round_of_32: [],
-      round_of_16: [],
-      quarter_finals: [],
-      semi_finals: [],
-      third_place: [],
-      final: [],
-    };
-    matches.forEach((match) => {
-      grouped[match.stage].push(match);
-    });
-    return grouped;
-  }, [matches]);
+  const stageMatches = React.useMemo(
+    () => matches.filter((m) => m.stage === stage),
+    [matches, stage]
+  );
 
   const totalMatches = matches.length;
   const completedMatches = knockoutPredictions.filter((p) => p.winnerId !== null).length;
@@ -418,7 +410,7 @@ export function KnockoutBracket({
         </div>
       </details>
 
-      {/* Persistent scoring summary — visible across all stage tabs. */}
+      {/* Persistent scoring summary. */}
       <div className="text-muted-foreground bg-muted/20 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border px-3 py-2 font-mono text-xs">
         <span>R16 +5/+3</span>
         <span>·</span>
@@ -433,50 +425,16 @@ export function KnockoutBracket({
         <span>3rd-place +5</span>
       </div>
 
-      {/* Tabs for stages (responsive) */}
-      <Tabs defaultValue="round_of_32" className="w-full">
-        <TabsList className="mb-4 flex h-auto w-full flex-wrap justify-start gap-1">
-          {STAGE_ORDER.map((stage) => {
-            const config = STAGE_CONFIG[stage];
-            const matches = matchesByStage[stage];
-            const completedCount = matches.filter((match) => {
-              const prediction = knockoutPredictions.find((p) => p.matchId === match.id);
-              return prediction?.winnerId !== null && prediction?.winnerId !== undefined;
-            }).length;
-            const isComplete = completedCount === matches.length;
-
-            return (
-              <TabsTrigger
-                key={stage}
-                value={stage}
-                className={cn(
-                  'flex-shrink-0',
-                  isComplete && 'data-[state=active]:bg-green-600 data-[state=active]:text-white'
-                )}
-              >
-                <span className="hidden sm:inline">{config.label}</span>
-                <span className="sm:hidden">{config.shortLabel}</span>
-                {isComplete && <CheckCircle2 className="ml-1 h-3 w-3" />}
-              </TabsTrigger>
-            );
-          })}
-        </TabsList>
-
-        {STAGE_ORDER.map((stage) => (
-          <TabsContent key={stage} value={stage}>
-            <StageSection
-              stage={stage}
-              matches={matchesByStage[stage]}
-              allMatches={matches}
-              teams={teams}
-              groupPredictions={groupPredictions}
-              knockoutPredictions={knockoutPredictions}
-              onPredictionChange={onPredictionChange}
-              disabled={disabled}
-            />
-          </TabsContent>
-        ))}
-      </Tabs>
+      <StageSection
+        stage={stage}
+        matches={stageMatches}
+        allMatches={matches}
+        teams={teams}
+        groupPredictions={groupPredictions}
+        knockoutPredictions={knockoutPredictions}
+        onPredictionChange={onPredictionChange}
+        disabled={disabled}
+      />
     </div>
   );
 }

--- a/frontend/src/components/predictions/PredictionStepper.tsx
+++ b/frontend/src/components/predictions/PredictionStepper.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import * as React from 'react';
-import { Check, Lock } from 'lucide-react';
+import { Check, CornerDownRight, Lock } from 'lucide-react';
 
-import { TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 
 export type StepStatus = 'done' | 'current' | 'upcoming' | 'locked';
@@ -15,7 +15,12 @@ export interface StepperStep {
 }
 
 interface PredictionStepperProps {
-  steps: StepperStep[];
+  topSteps: StepperStep[];
+  topValue: string;
+  onTopChange: (value: string) => void;
+  subSteps?: StepperStep[];
+  subValue?: string;
+  onSubChange?: (value: string) => void;
   className?: string;
 }
 
@@ -33,73 +38,138 @@ const labelClasses: Record<StepStatus, string> = {
   locked: 'text-muted-foreground line-through',
 };
 
-export function PredictionStepper({ steps, className }: PredictionStepperProps) {
+interface StepperRowProps {
+  steps: StepperStep[];
+  value: string;
+  onValueChange: (value: string) => void;
+  size?: 'lg' | 'sm';
+  testIdPrefix?: string;
+}
+
+function StepperRow({
+  steps,
+  value,
+  onValueChange,
+  size = 'lg',
+  testIdPrefix = 'step-circle',
+}: StepperRowProps) {
+  const isSm = size === 'sm';
   return (
-    <TabsList
-      className={cn(
-        'mb-8 grid h-auto w-full gap-0 rounded-none bg-transparent p-0',
-        className
-      )}
-      style={{ gridTemplateColumns: `repeat(${steps.length}, minmax(0, 1fr))` }}
-    >
-      {steps.map((step, index) => {
-        const isFirst = index === 0;
-        const isLast = index === steps.length - 1;
-        const leftFilled = !isFirst && steps[index - 1].status === 'done';
-        const rightFilled = !isLast && step.status === 'done';
-        return (
-          <TabsTrigger
-            key={step.value}
-            value={step.value}
-            disabled={step.status === 'locked'}
-            data-status={step.status}
-            className="relative flex h-auto flex-col items-center gap-2 rounded-none bg-transparent px-2 py-1 shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-          >
-            {!isFirst && (
-              <span
-                aria-hidden
-                className={cn(
-                  'absolute top-4 left-0 h-0.5 w-1/2 -translate-y-1/2',
-                  leftFilled ? 'bg-green-500' : 'bg-muted'
-                )}
-              />
-            )}
-            {!isLast && (
-              <span
-                aria-hidden
-                className={cn(
-                  'absolute top-4 right-0 h-0.5 w-1/2 -translate-y-1/2',
-                  rightFilled ? 'bg-green-500' : 'bg-muted'
-                )}
-              />
-            )}
-            <span
-              data-testid={`step-circle-${step.value}`}
+    <Tabs value={value} onValueChange={onValueChange}>
+      <TabsList
+        className={cn(
+          'grid h-auto w-full gap-0 rounded-none bg-transparent p-0',
+          isSm && 'overflow-x-auto'
+        )}
+        style={{ gridTemplateColumns: `repeat(${steps.length}, minmax(0, 1fr))` }}
+      >
+        {steps.map((step, index) => {
+          const isFirst = index === 0;
+          const isLast = index === steps.length - 1;
+          const leftFilled = !isFirst && steps[index - 1].status === 'done';
+          const rightFilled = !isLast && step.status === 'done';
+          return (
+            <TabsTrigger
+              key={step.value}
+              value={step.value}
+              disabled={step.status === 'locked'}
+              data-status={step.status}
               className={cn(
-                'relative z-10 flex h-8 w-8 items-center justify-center rounded-full border-2 text-sm font-semibold transition-colors',
-                circleClasses[step.status]
+                'relative flex h-auto flex-col items-center gap-2 rounded-none bg-transparent shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none',
+                isSm ? 'px-1 py-1' : 'px-2 py-1'
               )}
             >
-              {step.status === 'done' ? (
-                <Check className="h-4 w-4" aria-hidden />
-              ) : step.status === 'locked' ? (
-                <Lock className="h-3.5 w-3.5" aria-hidden />
-              ) : (
-                index + 1
+              {!isFirst && (
+                <span
+                  aria-hidden
+                  className={cn(
+                    'absolute left-0 h-0.5 w-1/2 -translate-y-1/2',
+                    isSm ? 'top-3' : 'top-4',
+                    leftFilled ? 'bg-green-500' : 'bg-muted'
+                  )}
+                />
               )}
-            </span>
-            <span className={cn('text-xs sm:text-sm', labelClasses[step.status])}>
-              {step.label}
-            </span>
-            <span className="sr-only">
-              Step {index + 1} of {steps.length}
-              {step.status === 'done' && ' (complete)'}
-              {step.status === 'current' && ' (current)'}
-              {step.status === 'locked' && ' (locked)'}
-            </span>
-          </TabsTrigger>
-        );
-      })}
-    </TabsList>
+              {!isLast && (
+                <span
+                  aria-hidden
+                  className={cn(
+                    'absolute right-0 h-0.5 w-1/2 -translate-y-1/2',
+                    isSm ? 'top-3' : 'top-4',
+                    rightFilled ? 'bg-green-500' : 'bg-muted'
+                  )}
+                />
+              )}
+              <span
+                data-testid={`${testIdPrefix}-${step.value}`}
+                className={cn(
+                  'relative z-10 flex items-center justify-center rounded-full border-2 font-semibold transition-colors',
+                  isSm ? 'h-6 w-6 text-xs' : 'h-8 w-8 text-sm',
+                  circleClasses[step.status]
+                )}
+              >
+                {step.status === 'done' ? (
+                  <Check className={cn(isSm ? 'h-3 w-3' : 'h-4 w-4')} aria-hidden />
+                ) : step.status === 'locked' ? (
+                  <Lock className={cn(isSm ? 'h-3 w-3' : 'h-3.5 w-3.5')} aria-hidden />
+                ) : (
+                  index + 1
+                )}
+              </span>
+              <span className={cn(isSm ? 'text-[10px] sm:text-xs' : 'text-xs sm:text-sm', labelClasses[step.status])}>
+                {step.label}
+              </span>
+              <span className="sr-only">
+                Step {index + 1} of {steps.length}
+                {step.status === 'done' && ' (complete)'}
+                {step.status === 'current' && ' (current)'}
+                {step.status === 'locked' && ' (locked)'}
+              </span>
+            </TabsTrigger>
+          );
+        })}
+      </TabsList>
+    </Tabs>
+  );
+}
+
+export function PredictionStepper({
+  topSteps,
+  topValue,
+  onTopChange,
+  subSteps,
+  subValue,
+  onSubChange,
+  className,
+}: PredictionStepperProps) {
+  const showSub = subSteps && subValue !== undefined && onSubChange;
+
+  return (
+    <div className={cn('mb-8 space-y-3', className)}>
+      <StepperRow
+        steps={topSteps}
+        value={topValue}
+        onValueChange={onTopChange}
+        size="lg"
+        testIdPrefix="step-circle"
+      />
+      {showSub && (
+        <div
+          className="bg-muted/30 rounded-md border border-dashed px-3 py-2"
+          data-testid="prediction-substepper"
+        >
+          <div className="text-muted-foreground mb-1 flex items-center gap-1 text-xs">
+            <CornerDownRight className="h-3 w-3" aria-hidden />
+            <span>Knockout stages</span>
+          </div>
+          <StepperRow
+            steps={subSteps}
+            value={subValue}
+            onValueChange={onSubChange}
+            size="sm"
+            testIdPrefix="substep-circle"
+          />
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/predictions/__tests__/KnockoutBracket.test.tsx
+++ b/frontend/src/components/predictions/__tests__/KnockoutBracket.test.tsx
@@ -46,6 +46,7 @@ function renderBracket(
     groupPredictions: createEmptyGroupPredictions(),
     knockoutPredictions: createEmptyKnockoutPredictions(),
     onPredictionChange: jest.fn(),
+    stage: 'round_of_32',
     ...overrides,
   };
   render(<KnockoutBracket {...props} />);
@@ -59,14 +60,19 @@ describe('KnockoutBracket', () => {
       expect(screen.getByText('Knockout Bracket')).toBeInTheDocument();
     });
 
-    it('should render stage tabs', () => {
+    it('renders only the matches for the active stage', () => {
+      renderBracket({ stage: 'quarter_finals', groupPredictions: createCompleteGroupPredictions() });
+      // QF has 4 match cards (M25-M28); R32 has 16 (M1-M16). Only QF should render.
+      expect(screen.getByText('M25')).toBeInTheDocument();
+      expect(screen.queryByText('M1')).not.toBeInTheDocument();
+      expect(screen.queryByText('M17')).not.toBeInTheDocument();
+    });
+
+    it('shows the stage subtitle for the active stage', () => {
       renderBracket();
-      expect(screen.getAllByText(/Round of 32/i).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText(/Round of 16/i).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText(/Quarter-finals/i).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText(/Semi-finals/i).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText(/Final/i).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText(/Third Place/i).length).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.getByText(/Picks here decide which teams sit in your Round of 16 slots/i)
+      ).toBeInTheDocument();
     });
 
     it('should show helper text', () => {
@@ -99,25 +105,9 @@ describe('KnockoutBracket', () => {
 
     it('should show team names when group predictions are complete', () => {
       renderBracket({ groupPredictions: createCompleteGroupPredictions() });
+      // Group A first place advances to M1; Group D first place advances to M2.
+      expect(screen.getByText('Mexico')).toBeInTheDocument();
       expect(screen.getByText('United States')).toBeInTheDocument();
-      expect(screen.getByText('Colombia')).toBeInTheDocument();
-    });
-  });
-
-  describe('stage navigation', () => {
-    it('should switch between stages when tabs are clicked', async () => {
-      const user = userEvent.setup();
-      renderBracket({ groupPredictions: createCompleteGroupPredictions() });
-      const qfTab = screen.getByRole('tab', { name: /Quarter-finals/i });
-      await user.click(qfTab);
-      expect(qfTab).toHaveAttribute('data-state', 'active');
-    });
-
-    it('should explain R32 picks set R16 slots', () => {
-      renderBracket({ groupPredictions: createCompleteGroupPredictions() });
-      expect(
-        screen.getByText(/Picks here decide which teams sit in your Round of 16 slots/i)
-      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/predictions/__tests__/PredictionStepper.test.tsx
+++ b/frontend/src/components/predictions/__tests__/PredictionStepper.test.tsx
@@ -2,72 +2,98 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { PredictionStepper, type StepperStep } from '../PredictionStepper';
-import { Tabs } from '@/components/ui/tabs';
 
-function renderStepper(steps: StepperStep[], onValueChange = jest.fn(), value = 'one') {
+const baseTopSteps: StepperStep[] = [
+  { value: 'groups', label: 'Group Stage', status: 'current' },
+  { value: 'knockout', label: 'Knockout', status: 'upcoming' },
+  { value: 'tiebreaker', label: 'Tiebreaker', status: 'upcoming' },
+];
+
+const baseSubSteps: StepperStep[] = [
+  { value: 'round_of_32', label: 'R32', status: 'current' },
+  { value: 'round_of_16', label: 'R16', status: 'upcoming' },
+  { value: 'quarter_finals', label: 'QF', status: 'upcoming' },
+  { value: 'semi_finals', label: 'SF', status: 'upcoming' },
+  { value: 'final', label: 'Final', status: 'upcoming' },
+  { value: 'third_place', label: '3rd', status: 'upcoming' },
+];
+
+function renderStepper(props: Partial<React.ComponentProps<typeof PredictionStepper>> = {}) {
+  const onTopChange = props.onTopChange ?? jest.fn();
+  const onSubChange = props.onSubChange ?? jest.fn();
   return {
-    onValueChange,
+    onTopChange,
+    onSubChange,
     ...render(
-      <Tabs value={value} onValueChange={onValueChange}>
-        <PredictionStepper steps={steps} />
-      </Tabs>
+      <PredictionStepper
+        topSteps={props.topSteps ?? baseTopSteps}
+        topValue={props.topValue ?? 'groups'}
+        onTopChange={onTopChange}
+        subSteps={props.subSteps}
+        subValue={props.subValue}
+        onSubChange={props.onSubChange ? onSubChange : undefined}
+      />
     ),
   };
 }
 
-const baseSteps: StepperStep[] = [
-  { value: 'one', label: 'Group Stage', status: 'current' },
-  { value: 'two', label: 'Knockout', status: 'upcoming' },
-  { value: 'three', label: 'Tiebreaker', status: 'upcoming' },
-];
-
 describe('PredictionStepper', () => {
-  it('renders one trigger per step with the configured label', () => {
-    renderStepper(baseSteps);
+  it('renders one trigger per top step with the configured label', () => {
+    renderStepper();
     expect(screen.getByRole('tab', { name: /Group Stage/ })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Knockout/ })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Tiebreaker/ })).toBeInTheDocument();
   });
 
-  it('shows the step number for upcoming steps', () => {
-    renderStepper(baseSteps);
-    expect(screen.getByTestId('step-circle-two')).toHaveTextContent('2');
-    expect(screen.getByTestId('step-circle-three')).toHaveTextContent('3');
+  it('shows the step number for upcoming top steps', () => {
+    renderStepper();
+    expect(screen.getByTestId('step-circle-knockout')).toHaveTextContent('2');
+    expect(screen.getByTestId('step-circle-tiebreaker')).toHaveTextContent('3');
   });
 
-  it('shows a check icon for done steps', () => {
-    renderStepper([
-      { value: 'one', label: 'Group Stage', status: 'done' },
-      { value: 'two', label: 'Knockout', status: 'current' },
-      { value: 'three', label: 'Tiebreaker', status: 'upcoming' },
-    ]);
-    const doneCircle = screen.getByTestId('step-circle-one');
+  it('shows a check icon for done top steps', () => {
+    renderStepper({
+      topSteps: [
+        { value: 'groups', label: 'Group Stage', status: 'done' },
+        { value: 'knockout', label: 'Knockout', status: 'current' },
+        { value: 'tiebreaker', label: 'Tiebreaker', status: 'upcoming' },
+      ],
+      topValue: 'knockout',
+    });
+    const doneCircle = screen.getByTestId('step-circle-groups');
     expect(doneCircle).not.toHaveTextContent('1');
     expect(doneCircle.querySelector('svg')).toBeInTheDocument();
     expect(doneCircle).toHaveClass('bg-green-500');
   });
 
-  it('renders locked steps as disabled triggers', () => {
-    renderStepper([
-      { value: 'one', label: 'Group Stage', status: 'locked' },
-      { value: 'two', label: 'Knockout', status: 'locked' },
-      { value: 'three', label: 'Tiebreaker', status: 'locked' },
-    ]);
+  it('renders locked top steps as disabled triggers', () => {
+    renderStepper({
+      topSteps: [
+        { value: 'groups', label: 'Group Stage', status: 'locked' },
+        { value: 'knockout', label: 'Knockout', status: 'locked' },
+        { value: 'tiebreaker', label: 'Tiebreaker', status: 'locked' },
+      ],
+    });
     const tabs = screen.getAllByRole('tab');
     tabs.forEach((tab) => expect(tab).toBeDisabled());
-    const lockedCircle = screen.getByTestId('step-circle-one');
-    expect(lockedCircle.querySelector('svg')).toBeInTheDocument();
   });
 
-  it('calls onValueChange when a step is clicked', async () => {
+  it('calls onTopChange when a top step is clicked', async () => {
     const user = userEvent.setup();
-    const { onValueChange } = renderStepper(baseSteps);
+    const { onTopChange } = renderStepper();
     await user.click(screen.getByRole('tab', { name: /Knockout/ }));
-    expect(onValueChange).toHaveBeenCalledWith('two');
+    expect(onTopChange).toHaveBeenCalledWith('knockout');
   });
 
-  it('marks the active step with aria-selected', () => {
-    renderStepper(baseSteps, jest.fn(), 'two');
+  it('marks the active top step with aria-selected', () => {
+    renderStepper({
+      topValue: 'knockout',
+      topSteps: [
+        { value: 'groups', label: 'Group Stage', status: 'done' },
+        { value: 'knockout', label: 'Knockout', status: 'current' },
+        { value: 'tiebreaker', label: 'Tiebreaker', status: 'upcoming' },
+      ],
+    });
     expect(screen.getByRole('tab', { name: /Group Stage/ })).toHaveAttribute(
       'aria-selected',
       'false'
@@ -76,5 +102,41 @@ describe('PredictionStepper', () => {
       'aria-selected',
       'true'
     );
+  });
+
+  describe('hierarchical (sub row)', () => {
+    it('does not render the sub row when subSteps is omitted', () => {
+      renderStepper();
+      expect(screen.queryByTestId('prediction-substepper')).not.toBeInTheDocument();
+    });
+
+    it('renders the sub row when subSteps is provided', () => {
+      renderStepper({
+        topValue: 'knockout',
+        subSteps: baseSubSteps,
+        subValue: 'round_of_32',
+        onSubChange: jest.fn(),
+      });
+      expect(screen.getByTestId('prediction-substepper')).toBeInTheDocument();
+      // Six sub chips with the short labels.
+      expect(screen.getByRole('tab', { name: /R32/ })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /R16/ })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /QF/ })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /SF/ })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /3rd/ })).toBeInTheDocument();
+    });
+
+    it('calls onSubChange when a sub chip is clicked', async () => {
+      const onSubChange = jest.fn();
+      const user = userEvent.setup();
+      renderStepper({
+        topValue: 'knockout',
+        subSteps: baseSubSteps,
+        subValue: 'round_of_32',
+        onSubChange,
+      });
+      await user.click(screen.getByRole('tab', { name: /QF/ }));
+      expect(onSubChange).toHaveBeenCalledWith('quarter_finals');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Flattens the predictions form into a single 8-step linear wizard (Group Stage → R32 → R16 → QF → SF → Final → Third Place → Tiebreaker), with Previous/Next buttons always at the bottom of the current step.
- Top stepper renders hierarchically: three high-level chips (Group Stage / Knockout / Tiebreaker), with a 6-chip sub-row that appears under "Knockout" while the user is inside a knockout stage. Top "Knockout" chip jumps to the first incomplete knockout stage; sub chips jump directly. Next stays gated on per-stage completion.
- Existing draft persistence, scoring copy, and submission flow are untouched.

## Why
Users were getting stranded on inner knockout stages because the only visible CTA at the bottom of an inner stage was the outer "Continue to Tiebreaker" button — disabled until every knockout stage was filled, and not what they wanted. They had to scroll back up to the inner tab strip to advance from R32 → R16, etc. Third Place in particular felt orphaned because it sat after Final in the inner tab order. Flattening into one progressive flow removes the dead-end and keeps navigation in a predictable spot.

## Notable changes
- `KnockoutBracket` is now controlled via a `stage` prop and renders only that stage's matches. Internal stage tabs removed. `STAGE_CONFIG` / `STAGE_ORDER` exported.
- `PredictionStepper` rewritten with a hierarchical API (`topSteps` / `topValue` / `onTopChange` + optional `subSteps` / `subValue` / `onSubChange`). Sub row uses smaller chips and scrolls horizontally on narrow screens.
- `PredictionsPageContent` orchestrates the 8-step `Step` union with per-stage completion gating.
- `AdminUserBracket` gets a small inline stage selector since it relied on the now-removed internal tabs (admin UX is otherwise unchanged).

## Test plan
- [x] `cd frontend && npm test` — all 259 tests across 33 suites pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean for edited files
- [x] On `/predictions`: fill Group Stage, click Continue 7 times, verify each Continue button is named after the next step (R32 → R16 → QF → SF → Final → Third Place → Tiebreaker), and verify the final step shows "Review & submit" rather than "Continue to ..."
- [x] Verify the top "Knockout" chip from Groups jumps to the first incomplete knockout stage; sub chips jump to that stage directly
- [x] Verify Previous walks back through the same 8 steps
- [x] Sanity-check on a phone-width window: top row 3 chips fit, sub row scrolls horizontally without overflow