### PR TITLE
fix: prediction submit 400 and sign-out hang

### DIFF
--- a/frontend/src/components/layout/AuthMenu.tsx
+++ b/frontend/src/components/layout/AuthMenu.tsx
@@ -19,7 +19,16 @@ export function AuthMenu() {
   const handleSignOut = async () => {
     setIsSigningOut(true);
     try {
-      await signOut();
+      // If GoTrue's lock wedges, fall back to a hard reload to /login so the
+      // button never gets stuck in 'Signing out…' (see supabase/auth-js#762).
+      const timeout = new Promise<'timeout'>((resolve) =>
+        setTimeout(() => resolve('timeout'), 5000)
+      );
+      const result = await Promise.race([signOut().then(() => 'ok' as const), timeout]);
+      if (result === 'timeout') {
+        window.location.href = ROUTES.login;
+        return;
+      }
       toast.success('Signed out');
       router.push(ROUTES.home);
       router.refresh();

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -52,13 +52,17 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
   );
 
   React.useEffect(() => {
-    const { data: subscription } = supabase.auth.onAuthStateChange(async (_event, session) => {
+    // Never await Supabase calls inside this callback — auth-js holds an internal
+    // navigator.locks lock for the duration of the listener, and re-entering it
+    // can wedge a later signOut() (see supabase/auth-js#762).
+    const { data: subscription } = supabase.auth.onAuthStateChange((event, session) => {
       setUser(session?.user ?? null);
-      if (session?.user) {
-        await loadProfile(session.user.id);
-      } else {
+      if (!session?.user) {
         setProfile(null);
+        return;
       }
+      if (event === 'INITIAL_SESSION') return;
+      void loadProfile(session.user.id);
     });
     return () => subscription.subscription.unsubscribe();
   }, [supabase, loadProfile]);

--- a/supabase/migrations/0011_prediction_writes_grants.sql
+++ b/supabase/migrations/0011_prediction_writes_grants.sql
@@ -1,0 +1,11 @@
+-- 0007_grants.sql granted SELECT on the prediction tables but not the writes
+-- needed by submit_predictions (which is security invoker). Without these,
+-- POST /api/predictions surfaces as a 400 'request failed' because Postgres
+-- raises 'permission denied for table predictions' before RLS is consulted.
+-- RLS still scopes which rows a user can write.
+
+grant insert, update, delete on
+    public.predictions,
+    public.group_predictions,
+    public.knockout_predictions
+  to authenticated;


### PR DESCRIPTION
## Summary
Two production hotfixes:

- **POST /api/predictions returning 400 `request failed`.** `submit_predictions` is `security invoker`, but `0007_grants.sql` only granted `SELECT` on the prediction tables. Postgres was rejecting the insert with `permission denied for table predictions` before RLS was even consulted. Migration `0011` grants `INSERT/UPDATE/DELETE` to the `authenticated` role on `predictions`, `group_predictions`, `knockout_predictions`. RLS still enforces ownership and the lock-time check.
- **Sign-out button hanging on "Signing out…".** `AuthProvider` was awaiting `loadProfile` (a Supabase query) inside the `onAuthStateChange` callback. Re-entering the GoTrue `navigator.locks` lock from the listener can wedge a later `signOut()` — see [supabase/auth-js#762](https://github.com/supabase/auth-js/issues/762). Hard reload reinitializes the client, which matches the reported symptom. Fixed by not awaiting inside the listener and skipping the redundant `INITIAL_SESSION` reload (we already have `initialProfile` from the server). Also added a 5s timeout fallback in `AuthMenu` so the button can never get permanently stuck.

Migration `0011` was already applied to prod via `supabase db push --linked` and the predictions endpoint was verified returning 200.

## Test plan
- [x] `npm test` — 259 passing
- [x] `npm run typecheck` — clean
- [x] Replayed the failing curl in prod after migration push → HTTP 200 with predictionId
- [ ] After deploy: click Sign out repeatedly across reloads/tabs, verify it never hangs