### PR TITLE
docs: never push directly to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ All by client IP. The first three protect against email enumeration / mailbox fl
 ## Git Commits
 
 - Do not include "Co-Authored-By" lines in commit messages.
+- **Never push directly to `main`.** All changes — including small follow-up fixes — must land on a feature branch and go through a pull request. Even one-line fixes during a session: branch, commit, push, open PR.
 
 
 ## SQL Statements


### PR DESCRIPTION
Adds a rule to CLAUDE.md under "Git Commits":

> Never push directly to `main`. All changes — including small follow-up fixes — must land on a feature branch and go through a pull request.

Triggered by two follow-up fixes pushed straight to main after merging #60 (`0e311e4` FK hint, `34445ab` 1:1 embed unwrap). Codifying this so it's the consistent default going forward.