### PR TITLE
feat: lock-status banner + read-only bracket preview overlay

### DIFF
--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Plus, Trash2 } from 'lucide-react';
+import { Eye, Plus, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -21,6 +21,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
 
 interface AdminPrediction {
   id: string;
@@ -149,6 +150,7 @@ export function AdminUserBracket({ userId }: { userId: string }) {
   const queryClient = useQueryClient();
   const [pendingDelete, setPendingDelete] = React.useState<AdminPrediction | null>(null);
   const [isDeleting, setIsDeleting] = React.useState(false);
+  const [previewId, setPreviewId] = React.useState<string | null>(null);
 
   const query = useQuery<AdminPredictionsResponse>({
     queryKey: ['admin-user-predictions', userId],
@@ -240,6 +242,15 @@ export function AdminUserBracket({ userId }: { userId: string }) {
                     </Link>
                   </Button>
                   <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPreviewId(p.id)}
+                    title="Preview bracket"
+                  >
+                    <Eye className="h-4 w-4" />
+                    <span className="sr-only">Preview</span>
+                  </Button>
+                  <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => setPendingDelete(p)}
@@ -285,6 +296,14 @@ export function AdminUserBracket({ userId }: { userId: string }) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <BracketPreviewDialog
+        predictionId={previewId}
+        apiBasePath={`/api/admin/users/${userId}/predictions`}
+        onOpenChange={(open) => {
+          if (!open) setPreviewId(null);
+        }}
+      />
     </PageLayout>
   );
 }

--- a/frontend/src/app/api/tournament/route.ts
+++ b/frontend/src/app/api/tournament/route.ts
@@ -3,18 +3,29 @@ import { getServerSupabase } from '@/lib/supabase/server';
 
 export async function GET() {
   const supabase = await getServerSupabase();
-  const { data, error } = await supabase
-    .from('tournaments')
-    .select('id, slug, name, status, lock_time, total_entries, champion_total_goals')
-    .eq('is_active', true)
-    .maybeSingle();
+  const [tournamentRes, serverTimeRes] = await Promise.all([
+    supabase
+      .from('tournaments')
+      .select('id, slug, name, status, lock_time, total_entries, champion_total_goals')
+      .eq('is_active', true)
+      .maybeSingle(),
+    supabase.rpc('select_now'),
+  ]);
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+  if (tournamentRes.error) {
+    return NextResponse.json({ error: tournamentRes.error.message }, { status: 500 });
   }
-  if (!data) {
+  if (!tournamentRes.data) {
     return NextResponse.json({ error: 'No active tournament' }, { status: 404 });
   }
+
+  const data = tournamentRes.data;
+  // serverTime defaults to the request's wall clock if the RPC ever fails;
+  // the client treats this as zero skew (degraded but not broken).
+  const serverTime =
+    typeof serverTimeRes.data === 'string'
+      ? new Date(serverTimeRes.data).toISOString()
+      : new Date().toISOString();
 
   return NextResponse.json({
     id: data.id,
@@ -24,5 +35,6 @@ export async function GET() {
     lockTime: data.lock_time,
     totalEntries: data.total_entries,
     championTotalGoals: data.champion_total_goals,
+    serverTime,
   });
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -39,7 +39,7 @@ export default async function RootLayout({
   if (user) {
     const { data } = await supabase
       .from('profiles')
-      .select('id, username, display_name, avatar_url, is_admin')
+      .select('id, username, display_name, avatar_url, is_admin, is_super_admin')
       .eq('id', user.id)
       .maybeSingle();
     profile = data
@@ -49,6 +49,7 @@ export default async function RootLayout({
           displayName: data.display_name,
           avatarUrl: data.avatar_url,
           isAdmin: data.is_admin,
+          isSuperAdmin: data.is_super_admin,
         }
       : null;
   }

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, Clock, FileEdit, Plus, Trash2 } from 'lucide-react';
+import { CheckCircle2, Clock, Eye, FileEdit, Plus, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -24,6 +24,8 @@ import {
   NEW_PREDICTION_SENTINEL,
   clearDraftForPrediction,
 } from '@/hooks/useDraftPersistence';
+import { useTournamentLock } from '@/hooks/useTournamentLock';
+import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
 import { PREDICTION_CAP, ROUTES } from '@/lib/constants';
 
 interface ApiPrediction {
@@ -54,22 +56,26 @@ function formatTime(value: string | null) {
 
 export function PredictionsListPage() {
   const queryClient = useQueryClient();
-  const { user } = useAuthContext();
+  const { user, profile } = useAuthContext();
   const [pendingDelete, setPendingDelete] = React.useState<ApiPrediction | null>(null);
   const [isDeleting, setIsDeleting] = React.useState(false);
+  const [previewId, setPreviewId] = React.useState<string | null>(null);
 
   const query = useQuery<ApiResponse>({
     queryKey: ['predictions'],
     queryFn: () => fetchJSON('/api/predictions'),
   });
 
+  // Skew-adjusted lock state — robust to client clock manipulation. The
+  // server-side RPC enforces the actual write boundary; this is purely UX.
+  const { isLocked } = useTournamentLock();
+  const isSuperAdmin = profile?.isSuperAdmin === true;
+
   const predictions = query.data?.predictions ?? [];
   const cap = query.data?.cap ?? PREDICTION_CAP;
-  const lockTime = query.data?.tournament.lockTime
-    ? new Date(query.data.tournament.lockTime)
-    : null;
-  const isLocked = lockTime ? new Date() >= lockTime : false;
   const atCap = predictions.length >= cap;
+  // Super admins can keep adding past lock; everyone else can't.
+  const canCreate = !atCap && (!isLocked || isSuperAdmin);
 
   const handleDelete = async () => {
     if (!pendingDelete) return;
@@ -104,16 +110,14 @@ export function PredictionsListPage() {
             Create up to {cap} brackets. Each paid bracket is ranked separately on the leaderboard.
           </p>
         </div>
-        <Button asChild disabled={atCap || isLocked} size="lg">
+        <Button asChild disabled={!canCreate} size="lg">
           <Link
             href={
-              atCap || isLocked
-                ? '#'
-                : `${ROUTES.predictions}/${NEW_PREDICTION_SENTINEL}`
+              canCreate ? `${ROUTES.predictions}/${NEW_PREDICTION_SENTINEL}` : '#'
             }
-            aria-disabled={atCap || isLocked}
+            aria-disabled={!canCreate}
             title={
-              isLocked
+              isLocked && !isSuperAdmin
                 ? 'Predictions are locked'
                 : atCap
                   ? `You've reached the cap of ${cap}`
@@ -178,18 +182,27 @@ export function PredictionsListPage() {
                 <div className="flex items-center gap-2">
                   <Button asChild variant="outline" size="sm">
                     <Link href={`${ROUTES.predictions}/${encodeURIComponent(p.id)}`}>
-                      {isLocked ? 'View' : 'Edit'}
+                      {isLocked && !isSuperAdmin ? 'View' : 'Edit'}
                     </Link>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPreviewId(p.id)}
+                    title="Preview bracket"
+                  >
+                    <Eye className="h-4 w-4" />
+                    <span className="sr-only">Preview</span>
                   </Button>
                   <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => setPendingDelete(p)}
-                    disabled={isLocked || p.isPaid}
+                    disabled={(isLocked && !isSuperAdmin) || p.isPaid}
                     title={
                       p.isPaid
                         ? 'Ask an admin to mark unpaid before deleting'
-                        : isLocked
+                        : isLocked && !isSuperAdmin
                           ? 'Predictions are locked'
                           : 'Delete'
                     }
@@ -232,6 +245,14 @@ export function PredictionsListPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <BracketPreviewDialog
+        predictionId={previewId}
+        apiBasePath="/api/predictions"
+        onOpenChange={(open) => {
+          if (!open) setPreviewId(null);
+        }}
+      />
     </PageLayout>
   );
 }

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -20,6 +20,7 @@ import { FieldError } from '@/components/ui/field-error';
 import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthContext } from '@/providers/AuthProvider';
+import { useTournamentLock } from '@/hooks/useTournamentLock';
 import {
   NEW_PREDICTION_SENTINEL,
   clearDraftForPrediction,
@@ -239,7 +240,15 @@ export function PredictionsPageContent({
 }: PredictionsPageContentProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { user } = useAuthContext();
+  const { user, profile } = useAuthContext();
+  const { isLocked } = useTournamentLock();
+  // When a super admin is editing their *own* predictions past lock, the
+  // regular submit_predictions RPC will reject. Route through the admin RPC
+  // (scoped to their own user id) which permits super admins past lock.
+  const effectiveApiBasePath =
+    apiBasePath === '/api/predictions' && profile?.isSuperAdmin && isLocked && user?.id
+      ? `/api/admin/users/${user.id}/predictions`
+      : apiBasePath;
 
   const tournamentQuery = useQuery<{
     id: string;
@@ -289,7 +298,6 @@ export function PredictionsPageContent({
   const matches = matchesQuery.data;
   const tournament = tournamentQuery.data;
   const lockTime = tournament ? new Date(tournament.lockTime) : null;
-  const isLocked = lockTime ? new Date() >= lockTime : false;
 
   const draftPredictionId = predictionId ?? NEW_PREDICTION_SENTINEL;
   const { loadDraft, saveDraft, clearDraft, lastSavedAt } = useDraftPersistence<DraftData>(
@@ -631,8 +639,8 @@ export function PredictionsPageContent({
 
       const url =
         mode === 'edit' && predictionId
-          ? `${apiBasePath}/${encodeURIComponent(predictionId)}`
-          : apiBasePath;
+          ? `${effectiveApiBasePath}/${encodeURIComponent(predictionId)}`
+          : effectiveApiBasePath;
       const method = mode === 'edit' ? 'PATCH' : 'POST';
 
       const res = await fetch(url, {

--- a/frontend/src/components/layout/LockStatusBanner.tsx
+++ b/frontend/src/components/layout/LockStatusBanner.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import * as React from 'react';
+import { AlertCircle, Lock, Unlock, X } from 'lucide-react';
+
+import { useTournamentLock } from '@/hooks/useTournamentLock';
+import { useAuth } from '@/hooks/useAuth';
+import { cn } from '@/lib/utils';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return '0m';
+  const totalSec = Math.floor(ms / 1000);
+  const days = Math.floor(totalSec / 86400);
+  const hours = Math.floor((totalSec % 86400) / 3600);
+  const minutes = Math.floor((totalSec % 3600) / 60);
+  const seconds = totalSec % 60;
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
+function dismissKey(tournamentId: string, locked: boolean): string {
+  return `wc2026:banner-dismissed:${tournamentId}:${locked ? 'locked' : 'open'}`;
+}
+
+export function LockStatusBanner() {
+  const { tournamentId, lockTime, isLoading, isLocked, remainingMs, clockSuspect } =
+    useTournamentLock();
+  const { profile } = useAuth();
+  const [dismissed, setDismissed] = React.useState(false);
+
+  // Re-evaluate dismissal state when the tournament or locked-flag change so
+  // a state transition re-shows the banner.
+  React.useEffect(() => {
+    if (!tournamentId || typeof window === 'undefined') {
+      setDismissed(false);
+      return;
+    }
+    try {
+      const flag = window.sessionStorage.getItem(dismissKey(tournamentId, isLocked));
+      setDismissed(flag === '1');
+    } catch {
+      setDismissed(false);
+    }
+  }, [tournamentId, isLocked]);
+
+  const handleDismiss = React.useCallback(() => {
+    if (!tournamentId || typeof window === 'undefined') return;
+    try {
+      window.sessionStorage.setItem(dismissKey(tournamentId, isLocked), '1');
+    } catch {
+      // best-effort
+    }
+    setDismissed(true);
+  }, [tournamentId, isLocked]);
+
+  if (isLoading || !lockTime || dismissed) return null;
+
+  const urgent = !isLocked && remainingMs <= ONE_DAY_MS;
+  const isSuperAdmin = profile?.isSuperAdmin === true;
+
+  const tone = isLocked ? 'locked' : urgent ? 'urgent' : 'open';
+  const toneClasses = {
+    open: 'bg-green-600 text-white',
+    urgent: 'bg-amber-600 text-white',
+    locked: 'bg-red-600 text-white',
+  } as const;
+
+  const Icon = isLocked ? Lock : Unlock;
+
+  return (
+    <div
+      role="status"
+      className={cn('w-full border-b border-black/10 shadow-sm', toneClasses[tone])}
+    >
+      <div className="mx-auto flex max-w-7xl items-start justify-between gap-3 px-4 py-2 text-sm sm:px-6 lg:px-8">
+        <div className="flex flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+          <Icon className="h-4 w-4 shrink-0" aria-hidden />
+          <span className="font-medium">
+            {isLocked ? 'Predictions are locked. Tournament is underway.' : null}
+            {!isLocked ? `Predictions lock in ${formatRemaining(remainingMs)}.` : null}
+          </span>
+          {isLocked && isSuperAdmin && (
+            <span className="rounded-md bg-white/15 px-2 py-0.5 text-xs font-medium">
+              Super admin: edits still open
+            </span>
+          )}
+          {clockSuspect && (
+            <span className="inline-flex items-center gap-1 rounded-md bg-white/15 px-2 py-0.5 text-xs">
+              <AlertCircle className="h-3 w-3" aria-hidden />
+              Your device clock looks off — countdown shown is server time.
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss notification"
+          className="-mr-1 inline-flex h-6 w-6 items-center justify-center rounded transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/PageLayout.tsx
+++ b/frontend/src/components/layout/PageLayout.tsx
@@ -2,6 +2,7 @@
 
 import { Header } from './Header';
 import { Footer } from './Footer';
+import { LockStatusBanner } from './LockStatusBanner';
 
 interface PageLayoutProps {
   children: React.ReactNode;
@@ -10,6 +11,7 @@ interface PageLayoutProps {
 export function PageLayout({ children }: PageLayoutProps) {
   return (
     <div className="flex min-h-screen flex-col">
+      <LockStatusBanner />
       <Header />
       <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">{children}</main>
       <Footer />

--- a/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
+
+import { LockStatusBanner } from '../LockStatusBanner';
+
+const mockProfile = { isSuperAdmin: false };
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'u1' }, profile: mockProfile }),
+}));
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  window.sessionStorage.clear();
+  mockProfile.isSuperAdmin = false;
+});
+
+function wrap(children: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function mockTournament({
+  lockOffsetMs,
+  serverOffsetMs = 0,
+}: {
+  lockOffsetMs: number;
+  serverOffsetMs?: number;
+}) {
+  const lockTime = new Date(Date.now() + lockOffsetMs).toISOString();
+  const serverTime = new Date(Date.now() + serverOffsetMs).toISOString();
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      id: 't1',
+      slug: 'wc',
+      name: 'WC',
+      status: 'upcoming',
+      lockTime,
+      totalEntries: 0,
+      serverTime,
+    }),
+  }) as unknown as typeof fetch;
+}
+
+describe('LockStatusBanner', () => {
+  it('renders nothing while tournament data is loading', () => {
+    global.fetch = jest.fn().mockImplementation(() => new Promise(() => {})) as unknown as typeof fetch;
+    const { container } = render(wrap(<LockStatusBanner />));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders an open countdown when far from lock', async () => {
+    mockTournament({ lockOffsetMs: 7 * 24 * 60 * 60 * 1000 });
+    render(wrap(<LockStatusBanner />));
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    expect(screen.getByRole('status')).toHaveTextContent(/Predictions lock in/);
+    expect(screen.getByRole('status').className).toContain('bg-green-600');
+  });
+
+  it('renders the urgent (amber) state inside the final 24 hours', async () => {
+    mockTournament({ lockOffsetMs: 60_000 });
+    render(wrap(<LockStatusBanner />));
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    expect(screen.getByRole('status').className).toContain('bg-amber-600');
+  });
+
+  it('renders the locked state when lock is in the past', async () => {
+    mockTournament({ lockOffsetMs: -60_000 });
+    render(wrap(<LockStatusBanner />));
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    expect(screen.getByRole('status')).toHaveTextContent(/locked/i);
+    expect(screen.getByRole('status').className).toContain('bg-red-600');
+  });
+
+  it('shows the super-admin chip when locked + super admin', async () => {
+    mockProfile.isSuperAdmin = true;
+    mockTournament({ lockOffsetMs: -60_000 });
+    render(wrap(<LockStatusBanner />));
+    await waitFor(() =>
+      expect(screen.getByText(/Super admin: edits still open/i)).toBeInTheDocument()
+    );
+  });
+
+  it('shows the clock-skew caption when the device clock is off > 5 minutes', async () => {
+    mockTournament({ lockOffsetMs: 86_400_000, serverOffsetMs: 10 * 60 * 1000 });
+    render(wrap(<LockStatusBanner />));
+    await waitFor(() =>
+      expect(screen.getByText(/device clock looks off/i)).toBeInTheDocument()
+    );
+  });
+
+  it('persists dismiss in sessionStorage', async () => {
+    mockTournament({ lockOffsetMs: 86_400_000 });
+    const user = userEvent.setup();
+    const { unmount } = render(wrap(<LockStatusBanner />));
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    // Mounting again with the same tournament + same locked-flag stays dismissed.
+    unmount();
+    render(wrap(<LockStatusBanner />));
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/layout/__tests__/PageLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/PageLayout.test.tsx
@@ -1,4 +1,11 @@
 import { render, screen } from '@testing-library/react';
+
+// LockStatusBanner is exercised in its own test; mock it here so this layout
+// test stays a unit test and doesn't pull in QueryClient/useAuth wiring.
+jest.mock('../LockStatusBanner', () => ({
+  LockStatusBanner: () => null,
+}));
+
 import { PageLayout } from '../PageLayout';
 
 describe('PageLayout', () => {

--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { BracketView } from '@/components/predictions/BracketView';
+import type { Group, KnockoutMatch, Team } from '@/types/tournament';
+
+interface PredictionDetail {
+  id: string;
+  name: string;
+  totalGoals: number | null;
+  submittedAt: string | null;
+  isPaid: boolean;
+  paidAt: string | null;
+  groups: Array<{
+    groupId: string;
+    first: string | null;
+    second: string | null;
+    third: string | null;
+    fourth: string | null;
+  }>;
+  knockout: Array<{ matchId: string; winner: string | null }>;
+}
+
+export interface BracketPreviewDialogProps {
+  predictionId: string | null;
+  /** e.g. '/api/predictions' or `/api/admin/users/${userId}/predictions`. */
+  apiBasePath: string;
+  onOpenChange: (open: boolean) => void;
+}
+
+async function fetchJSON<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
+  return res.json();
+}
+
+export function BracketPreviewDialog({
+  predictionId,
+  apiBasePath,
+  onOpenChange,
+}: BracketPreviewDialogProps) {
+  const open = predictionId !== null;
+
+  const predictionQuery = useQuery<PredictionDetail>({
+    queryKey: ['prediction', apiBasePath, predictionId],
+    enabled: open && !!predictionId,
+    queryFn: () => fetchJSON(`${apiBasePath}/${encodeURIComponent(predictionId!)}`),
+  });
+
+  const matchesQuery = useQuery<KnockoutMatch[]>({
+    queryKey: ['knockout-matches'],
+    enabled: open,
+    queryFn: () => fetchJSON('/api/knockout-matches'),
+  });
+
+  const teamsQuery = useQuery<Team[]>({
+    queryKey: ['teams'],
+    enabled: open,
+    queryFn: () => fetchJSON('/api/teams'),
+  });
+
+  const groupsQuery = useQuery<Group[]>({
+    queryKey: ['groups'],
+    enabled: open,
+    queryFn: () => fetchJSON('/api/groups'),
+  });
+
+  const ready =
+    predictionQuery.data && matchesQuery.data && teamsQuery.data && groupsQuery.data;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-5xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex flex-wrap items-center gap-2">
+            {predictionQuery.data?.name ?? 'Bracket'}
+            {predictionQuery.data && (
+              <>
+                <Badge variant={predictionQuery.data.submittedAt ? 'secondary' : 'outline'}>
+                  {predictionQuery.data.submittedAt ? 'Submitted' : 'Draft'}
+                </Badge>
+                <Badge variant={predictionQuery.data.isPaid ? 'default' : 'outline'}>
+                  {predictionQuery.data.isPaid ? 'Paid' : 'Unpaid'}
+                </Badge>
+              </>
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            Read-only preview of the bracket as predicted. Empty slots show as TBD.
+          </DialogDescription>
+        </DialogHeader>
+
+        {predictionQuery.isError && (
+          <p className="text-destructive text-sm" role="alert">
+            Couldn&apos;t load this prediction.
+          </p>
+        )}
+
+        {!ready && !predictionQuery.isError && (
+          <div className="space-y-3">
+            <Skeleton className="h-32 w-full" />
+            <Skeleton className="h-32 w-full" />
+            <Skeleton className="h-32 w-full" />
+          </div>
+        )}
+
+        {ready && (
+          <BracketView
+            matches={matchesQuery.data!}
+            teams={teamsQuery.data!}
+            groupPredictions={(predictionQuery.data!.groups ?? []).map((g) => ({
+              groupId: g.groupId,
+              positions: {
+                first: g.first,
+                second: g.second,
+                third: g.third,
+                fourth: g.fourth,
+              },
+            }))}
+            knockoutPredictions={(predictionQuery.data!.knockout ?? []).map((k) => ({
+              matchId: k.matchId,
+              winnerId: k.winner,
+            }))}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/predictions/BracketView.tsx
+++ b/frontend/src/components/predictions/BracketView.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import * as React from 'react';
+import { Trophy } from 'lucide-react';
+
+import { TeamFlag } from '@/components/shared/TeamFlag';
+import { resolveTeamSource } from '@/lib/knockoutResolver';
+import { cn } from '@/lib/utils';
+import type {
+  GroupPrediction,
+  KnockoutMatch,
+  KnockoutMatchPrediction,
+  KnockoutStage,
+  Team,
+} from '@/types/tournament';
+
+interface BracketViewProps {
+  matches: KnockoutMatch[];
+  teams: Team[];
+  groupPredictions: GroupPrediction[];
+  knockoutPredictions: KnockoutMatchPrediction[];
+}
+
+const COLUMN_STAGES: Array<{ stage: KnockoutStage; label: string }> = [
+  { stage: 'round_of_32', label: 'Round of 32' },
+  { stage: 'round_of_16', label: 'Round of 16' },
+  { stage: 'quarter_finals', label: 'Quarter-finals' },
+  { stage: 'semi_finals', label: 'Semi-finals' },
+  { stage: 'final', label: 'Final' },
+];
+
+interface MatchSlot {
+  teamId: string | null;
+  isWinner: boolean;
+}
+
+function teamLabel(teamId: string | null, teams: Team[]): { code: string; name: string } | null {
+  if (!teamId) return null;
+  const team = teams.find((t) => t.id === teamId);
+  if (!team) return null;
+  return { code: team.code, name: team.name };
+}
+
+function MatchNode({
+  match,
+  matches,
+  teams,
+  groupPredictions,
+  knockoutPredictions,
+}: {
+  match: KnockoutMatch;
+  matches: KnockoutMatch[];
+  teams: Team[];
+  groupPredictions: GroupPrediction[];
+  knockoutPredictions: KnockoutMatchPrediction[];
+}) {
+  const team1Id = resolveTeamSource(match.team1Source, matches, groupPredictions, knockoutPredictions);
+  const team2Id = resolveTeamSource(match.team2Source, matches, groupPredictions, knockoutPredictions);
+  const winnerId =
+    knockoutPredictions.find((p) => p.matchId === match.id)?.winnerId ?? null;
+
+  const slots: Array<MatchSlot> = [
+    { teamId: team1Id, isWinner: !!winnerId && winnerId === team1Id },
+    { teamId: team2Id, isWinner: !!winnerId && winnerId === team2Id },
+  ];
+
+  return (
+    <div
+      className="bg-card border-border w-full rounded-md border text-xs shadow-sm"
+      data-testid={`bracket-match-${match.id}`}
+    >
+      <div className="text-muted-foreground border-b px-2 py-1 text-[10px] font-medium uppercase tracking-wide">
+        {match.id}
+      </div>
+      {slots.map((slot, idx) => {
+        const label = teamLabel(slot.teamId, teams);
+        return (
+          <div
+            key={idx}
+            className={cn(
+              'flex items-center gap-2 px-2 py-1.5',
+              slot.isWinner && 'bg-primary/10 font-semibold text-primary',
+              idx === 0 && 'border-b'
+            )}
+          >
+            {label ? (
+              <>
+                <TeamFlag code={label.code} />
+                <span className="truncate">{label.name}</span>
+                {slot.isWinner && (
+                  <Trophy className="text-primary ml-auto h-3.5 w-3.5 shrink-0" aria-hidden />
+                )}
+              </>
+            ) : (
+              <span className="text-muted-foreground italic">TBD</span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function BracketView({
+  matches,
+  teams,
+  groupPredictions,
+  knockoutPredictions,
+}: BracketViewProps) {
+  const matchesByStage = React.useMemo(() => {
+    const grouped: Record<KnockoutStage, KnockoutMatch[]> = {
+      round_of_32: [],
+      round_of_16: [],
+      quarter_finals: [],
+      semi_finals: [],
+      third_place: [],
+      final: [],
+    };
+    matches.forEach((m) => grouped[m.stage].push(m));
+    Object.keys(grouped).forEach((stage) => {
+      grouped[stage as KnockoutStage].sort((a, b) => {
+        const aNum = Number(a.id.replace('M', ''));
+        const bNum = Number(b.id.replace('M', ''));
+        return aNum - bNum;
+      });
+    });
+    return grouped;
+  }, [matches]);
+
+  const thirdPlace = matchesByStage.third_place[0] ?? null;
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
+        {COLUMN_STAGES.map(({ stage, label }) => {
+          const stageMatches = matchesByStage[stage] ?? [];
+          if (stageMatches.length === 0) return null;
+          return (
+            <div key={stage} className="space-y-2">
+              <h3 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+                {label}
+              </h3>
+              <div className="space-y-2">
+                {stageMatches.map((m) => (
+                  <MatchNode
+                    key={m.id}
+                    match={m}
+                    matches={matches}
+                    teams={teams}
+                    groupPredictions={groupPredictions}
+                    knockoutPredictions={knockoutPredictions}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {thirdPlace && (
+        <div className="space-y-2">
+          <h3 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+            Third-place play-off
+          </h3>
+          <div className="max-w-xs">
+            <MatchNode
+              match={thirdPlace}
+              matches={matches}
+              teams={teams}
+              groupPredictions={groupPredictions}
+              knockoutPredictions={knockoutPredictions}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { TeamFlag } from '@/components/shared/TeamFlag';
+import { resolveTeamSource } from '@/lib/knockoutResolver';
 import { cn } from '@/lib/utils';
 import type {
   GroupPrediction,
@@ -84,67 +85,8 @@ interface KnockoutBracketProps {
   stage: KnockoutStage;
 }
 
-// Helper to resolve a team source to team ID or null
-function resolveTeamSource(
-  source: string,
-  matches: KnockoutMatch[],
-  groupPredictions: GroupPrediction[],
-  knockoutPredictions: KnockoutMatchPrediction[]
-): string | null {
-  // Group position source (e.g., "1A" = 1st place in Group A, "2B" = 2nd place in Group B)
-  const groupMatch = source.match(/^([123])([A-L])$/);
-  if (groupMatch) {
-    const [, position, groupId] = groupMatch;
-    const groupPrediction = groupPredictions.find((p) => p.groupId === groupId);
-    if (!groupPrediction) return null;
-
-    switch (position) {
-      case '1':
-        return groupPrediction.positions.first;
-      case '2':
-        return groupPrediction.positions.second;
-      case '3':
-        return groupPrediction.positions.third;
-      default:
-        return null;
-    }
-  }
-
-  // Match winner source (e.g., "M1" = winner of match M1)
-  const matchWinnerMatch = source.match(/^M(\d+)$/);
-  if (matchWinnerMatch) {
-    const matchPrediction = knockoutPredictions.find((p) => p.matchId === source);
-    return matchPrediction?.winnerId ?? null;
-  }
-
-  // Match loser source (e.g., "L-M29" = loser of match M29)
-  const matchLoserMatch = source.match(/^L-M(\d+)$/);
-  if (matchLoserMatch) {
-    const matchId = `M${matchLoserMatch[1]}`;
-    const matchPrediction = knockoutPredictions.find((p) => p.matchId === matchId);
-    const match = matches.find((m) => m.id === matchId);
-    if (!matchPrediction?.winnerId || !match) return null;
-
-    const team1Id = resolveTeamSource(
-      match.team1Source,
-      matches,
-      groupPredictions,
-      knockoutPredictions
-    );
-    const team2Id = resolveTeamSource(
-      match.team2Source,
-      matches,
-      groupPredictions,
-      knockoutPredictions
-    );
-
-    if (matchPrediction.winnerId === team1Id) return team2Id;
-    if (matchPrediction.winnerId === team2Id) return team1Id;
-    return null;
-  }
-
-  return null;
-}
+// resolveTeamSource lives in @/lib/knockoutResolver so both this editor and
+// the read-only BracketView can share it.
 
 function getTeamDisplay(
   teamId: string | null,

--- a/frontend/src/components/predictions/__tests__/BracketView.test.tsx
+++ b/frontend/src/components/predictions/__tests__/BracketView.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, within } from '@testing-library/react';
+
+import { BracketView } from '../BracketView';
+import { fixtureKnockoutMatches, fixtureTeams } from '@/test-utils/fixtures';
+
+describe('BracketView', () => {
+  it('renders all 32 match nodes plus the third-place play-off', () => {
+    render(
+      <BracketView
+        matches={fixtureKnockoutMatches}
+        teams={fixtureTeams}
+        groupPredictions={[]}
+        knockoutPredictions={[]}
+      />
+    );
+
+    // 32 match nodes total (M1..M32, with M31 being third place).
+    for (let i = 1; i <= 32; i++) {
+      expect(screen.getByTestId(`bracket-match-M${i}`)).toBeInTheDocument();
+    }
+    expect(screen.getByText(/Third-place play-off/i)).toBeInTheDocument();
+  });
+
+  it('renders TBD when picks are missing', () => {
+    render(
+      <BracketView
+        matches={fixtureKnockoutMatches}
+        teams={fixtureTeams}
+        groupPredictions={[]}
+        knockoutPredictions={[]}
+      />
+    );
+    const m1 = screen.getByTestId('bracket-match-M1');
+    expect(within(m1).getAllByText('TBD').length).toBeGreaterThan(0);
+  });
+
+  it('shows the winning team highlighted with a trophy', () => {
+    const groupPredictions = [
+      {
+        groupId: 'A',
+        positions: { first: 'mex', second: 'kor', third: 'rsa', fourth: 'cze' },
+      },
+      {
+        groupId: 'B',
+        positions: { first: 'sui', second: 'qat', third: 'bih', fourth: 'can' },
+      },
+    ];
+    const knockoutPredictions = [{ matchId: 'M1', winnerId: 'mex' }];
+
+    render(
+      <BracketView
+        matches={fixtureKnockoutMatches}
+        teams={fixtureTeams}
+        groupPredictions={groupPredictions}
+        knockoutPredictions={knockoutPredictions}
+      />
+    );
+
+    const m1 = screen.getByTestId('bracket-match-M1');
+    expect(within(m1).getByText('Mexico')).toBeInTheDocument();
+    expect(within(m1).getByText('Qatar')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/__tests__/useTournamentLock.test.ts
+++ b/frontend/src/hooks/__tests__/useTournamentLock.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
+
+import { useTournamentLock } from '../useTournamentLock';
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  global.fetch = realFetch;
+  jest.useRealTimers();
+});
+
+describe('useTournamentLock', () => {
+  it('reports unlocked with a positive remaining ms when lock is in the future', async () => {
+    const lockTime = new Date(Date.now() + 60_000).toISOString();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 't1',
+        slug: 'wc',
+        name: 'WC',
+        status: 'upcoming',
+        lockTime,
+        totalEntries: 0,
+        serverTime: new Date().toISOString(),
+      }),
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useTournamentLock(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.tournamentId).toBe('t1'));
+    expect(result.current.isLocked).toBe(false);
+    expect(result.current.remainingMs).toBeGreaterThan(0);
+    expect(result.current.clockSuspect).toBe(false);
+  });
+
+  it('reports locked when server time is past lockTime even if local clock disagrees', async () => {
+    const lockTime = new Date('2026-01-01T00:00:00Z').toISOString();
+    // Pretend the server clock is one hour past the lock; local clock thinks it's
+    // way before. The hook should still report locked.
+    const serverTime = new Date('2026-01-01T01:00:00Z').toISOString();
+
+    // Force Date.now() to return something well before lockTime.
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-06-01T00:00:00Z'));
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 't1',
+        slug: 'wc',
+        name: 'WC',
+        status: 'group_stage',
+        lockTime,
+        totalEntries: 0,
+        serverTime,
+      }),
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useTournamentLock(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.tournamentId).toBe('t1'));
+    expect(result.current.isLocked).toBe(true);
+    expect(result.current.remainingMs).toBe(0);
+    // Skew is ~7 months → definitely suspect.
+    expect(result.current.clockSuspect).toBe(true);
+  });
+
+  it('flags clockSuspect when |skew| > 5 minutes', async () => {
+    const lockTime = new Date(Date.now() + 86_400_000).toISOString();
+    const serverTime = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 't1',
+        slug: 'wc',
+        name: 'WC',
+        status: 'upcoming',
+        lockTime,
+        totalEntries: 0,
+        serverTime,
+      }),
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useTournamentLock(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.clockSuspect).toBe(true));
+  });
+
+  it('ticks the countdown', async () => {
+    const lockTime = new Date(Date.now() + 5_000).toISOString();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 't1',
+        slug: 'wc',
+        name: 'WC',
+        status: 'upcoming',
+        lockTime,
+        totalEntries: 0,
+        serverTime: new Date().toISOString(),
+      }),
+    }) as unknown as typeof fetch;
+
+    jest.useFakeTimers();
+    const { result } = renderHook(() => useTournamentLock(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.tournamentId).toBe('t1'));
+
+    const initial = result.current.remainingMs;
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.remainingMs).toBeLessThanOrEqual(initial);
+  });
+});

--- a/frontend/src/hooks/useTournamentLock.ts
+++ b/frontend/src/hooks/useTournamentLock.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+interface TournamentResponse {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+  lockTime: string;
+  totalEntries: number;
+  serverTime: string;
+}
+
+export interface TournamentLockState {
+  tournamentId: string | null;
+  lockTime: Date | null;
+  isLoading: boolean;
+  /** Server-time minus client-time, in ms. 0 if data not loaded. */
+  skewMs: number;
+  /** True iff `Date.now() + skewMs >= lockTime`. */
+  isLocked: boolean;
+  /** Milliseconds remaining until lock (clamped at 0). */
+  remainingMs: number;
+  /** True if |skewMs| > 5 minutes — surface a hint to the user. */
+  clockSuspect: boolean;
+}
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+export function useTournamentLock(): TournamentLockState {
+  const query = useQuery<TournamentResponse>({
+    queryKey: ['tournament'],
+    queryFn: async () => {
+      const res = await fetch('/api/tournament');
+      if (!res.ok) throw new Error('Failed to fetch tournament');
+      return res.json();
+    },
+  });
+
+  const data = query.data;
+
+  // Compute skew once per data arrival; don't recompute on every render.
+  const skewMs = React.useMemo(() => {
+    if (!data?.serverTime) return 0;
+    return new Date(data.serverTime).getTime() - Date.now();
+  }, [data?.serverTime]);
+
+  const lockTime = React.useMemo(
+    () => (data?.lockTime ? new Date(data.lockTime) : null),
+    [data?.lockTime]
+  );
+
+  // Tick once per second so the countdown updates.
+  const [tick, setTick] = React.useState(0);
+  React.useEffect(() => {
+    if (!lockTime) return;
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [lockTime]);
+
+  const remainingMs = React.useMemo(() => {
+    if (!lockTime) return 0;
+    return Math.max(0, lockTime.getTime() - (Date.now() + skewMs));
+    // tick included so this re-evaluates each second
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lockTime, skewMs, tick]);
+
+  const isLocked = remainingMs === 0 && !!lockTime;
+  const clockSuspect = Math.abs(skewMs) > FIVE_MINUTES_MS;
+
+  return {
+    tournamentId: data?.id ?? null,
+    lockTime,
+    isLoading: query.isLoading,
+    skewMs,
+    isLocked,
+    remainingMs,
+    clockSuspect,
+  };
+}

--- a/frontend/src/lib/__tests__/knockoutResolver.test.ts
+++ b/frontend/src/lib/__tests__/knockoutResolver.test.ts
@@ -1,0 +1,73 @@
+import { resolveTeamSource } from '../knockoutResolver';
+import type {
+  GroupPrediction,
+  KnockoutMatch,
+  KnockoutMatchPrediction,
+} from '@/types/tournament';
+
+const groupPredictions: GroupPrediction[] = [
+  {
+    groupId: 'A',
+    positions: { first: 'mex', second: 'kor', third: 'rsa', fourth: 'cze' },
+  },
+  {
+    groupId: 'B',
+    positions: { first: 'sui', second: 'qat', third: 'bih', fourth: 'can' },
+  },
+];
+
+const matches: KnockoutMatch[] = [
+  { id: 'M1', stage: 'round_of_32', team1Source: '1A', team2Source: '2B', pointValue: 2 },
+  { id: 'M2', stage: 'round_of_32', team1Source: '1B', team2Source: '2A', pointValue: 2 },
+  { id: 'M17', stage: 'round_of_16', team1Source: 'M1', team2Source: 'M2', pointValue: 4 },
+  { id: 'M29', stage: 'semi_finals', team1Source: 'M25', team2Source: 'M26', pointValue: 15 },
+  { id: 'M31', stage: 'third_place', team1Source: 'L-M29', team2Source: 'L-M30', pointValue: 10 },
+];
+
+describe('resolveTeamSource', () => {
+  it('resolves group-position references', () => {
+    expect(resolveTeamSource('1A', matches, groupPredictions, [])).toBe('mex');
+    expect(resolveTeamSource('2B', matches, groupPredictions, [])).toBe('qat');
+    expect(resolveTeamSource('3A', matches, groupPredictions, [])).toBe('rsa');
+  });
+
+  it('returns null for an unknown group', () => {
+    expect(resolveTeamSource('1Z', matches, groupPredictions, [])).toBeNull();
+  });
+
+  it('resolves match-winner references', () => {
+    const knockoutPredictions: KnockoutMatchPrediction[] = [
+      { matchId: 'M1', winnerId: 'mex' },
+    ];
+    expect(resolveTeamSource('M1', matches, groupPredictions, knockoutPredictions)).toBe('mex');
+  });
+
+  it('returns null when the predicted winner is missing', () => {
+    expect(resolveTeamSource('M1', matches, groupPredictions, [])).toBeNull();
+  });
+
+  it('resolves match-loser references via the contestants', () => {
+    // M1 contestants: 1A (mex), 2B (qat). Predicted winner: mex → loser: qat.
+    const knockoutPredictions: KnockoutMatchPrediction[] = [
+      { matchId: 'M1', winnerId: 'mex' },
+    ];
+    // Build a fake third-place match that consumes L-M1 just to exercise the path.
+    const localMatches: KnockoutMatch[] = [
+      ...matches,
+      {
+        id: 'M99',
+        stage: 'third_place',
+        team1Source: 'L-M1',
+        team2Source: 'L-M1',
+        pointValue: 10,
+      },
+    ];
+    expect(resolveTeamSource('L-M1', localMatches, groupPredictions, knockoutPredictions)).toBe(
+      'qat'
+    );
+  });
+
+  it('returns null for an unrecognised source', () => {
+    expect(resolveTeamSource('garbage', matches, groupPredictions, [])).toBeNull();
+  });
+});

--- a/frontend/src/lib/knockoutResolver.ts
+++ b/frontend/src/lib/knockoutResolver.ts
@@ -1,0 +1,70 @@
+import type {
+  GroupPrediction,
+  KnockoutMatch,
+  KnockoutMatchPrediction,
+} from '@/types/tournament';
+
+/**
+ * Resolves a `team1_source` / `team2_source` reference (e.g. `"1A"`, `"M5"`,
+ * `"L-M29"`) to the predicted team id, given a user's group + knockout picks.
+ * Returns null when the picks for the source aren't filled in yet.
+ */
+export function resolveTeamSource(
+  source: string,
+  matches: KnockoutMatch[],
+  groupPredictions: GroupPrediction[],
+  knockoutPredictions: KnockoutMatchPrediction[]
+): string | null {
+  // Group position source: '1A' = 1st in Group A, '2B' = 2nd in Group B, etc.
+  const groupMatch = source.match(/^([123])([A-L])$/);
+  if (groupMatch) {
+    const [, position, groupId] = groupMatch;
+    const groupPrediction = groupPredictions.find((p) => p.groupId === groupId);
+    if (!groupPrediction) return null;
+    switch (position) {
+      case '1':
+        return groupPrediction.positions.first;
+      case '2':
+        return groupPrediction.positions.second;
+      case '3':
+        return groupPrediction.positions.third;
+      default:
+        return null;
+    }
+  }
+
+  // Match winner source: 'M1' = the predicted winner of M1.
+  if (/^M\d+$/.test(source)) {
+    const matchPrediction = knockoutPredictions.find((p) => p.matchId === source);
+    return matchPrediction?.winnerId ?? null;
+  }
+
+  // Match loser source: 'L-M29' = the loser of M29 (the team that lost in the
+  // user's prediction). Recurse to figure out who the two contestants were.
+  const loserMatch = source.match(/^L-M(\d+)$/);
+  if (loserMatch) {
+    const matchId = `M${loserMatch[1]}`;
+    const matchPrediction = knockoutPredictions.find((p) => p.matchId === matchId);
+    const match = matches.find((m) => m.id === matchId);
+    if (!matchPrediction?.winnerId || !match) return null;
+
+    const team1Id = resolveTeamSource(
+      match.team1Source,
+      matches,
+      groupPredictions,
+      knockoutPredictions
+    );
+    const team2Id = resolveTeamSource(
+      match.team2Source,
+      matches,
+      groupPredictions,
+      knockoutPredictions
+    );
+
+    if (matchPrediction.winnerId === team1Id) return team2Id;
+    if (matchPrediction.winnerId === team2Id) return team1Id;
+    return null;
+  }
+
+  return null;
+}

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -33,7 +33,7 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
     async (userId: string) => {
       const { data } = await supabase
         .from('profiles')
-        .select('id, username, display_name, avatar_url, is_admin')
+        .select('id, username, display_name, avatar_url, is_admin, is_super_admin')
         .eq('id', userId)
         .maybeSingle();
       if (!data) {
@@ -46,6 +46,7 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
         displayName: data.display_name,
         avatarUrl: data.avatar_url,
         isAdmin: data.is_admin,
+        isSuperAdmin: data.is_super_admin,
       });
     },
     [supabase]

--- a/frontend/src/providers/__tests__/AuthProvider.test.tsx
+++ b/frontend/src/providers/__tests__/AuthProvider.test.tsx
@@ -48,6 +48,7 @@ describe('AuthProvider', () => {
           displayName: null,
           avatarUrl: null,
           isAdmin: false,
+          isSuperAdmin: false,
         }}
       >
         <Consumer />

--- a/frontend/src/types/tournament.ts
+++ b/frontend/src/types/tournament.ts
@@ -113,4 +113,5 @@ export interface Profile {
   displayName: string | null;
   avatarUrl: string | null;
   isAdmin: boolean;
+  isSuperAdmin: boolean;
 }

--- a/supabase/migrations/0018_super_admin_lock_bypass.sql
+++ b/supabase/migrations/0018_super_admin_lock_bypass.sql
@@ -1,0 +1,164 @@
+-- Super admin gate for post-lock writes.
+--
+-- Adds is_super_admin() helper and replaces admin_submit_predictions to
+-- require super admin AFTER the tournament lock_time. Regular admins can
+-- still mark payments paid/unpaid past lock (admin_set_prediction_payment
+-- is unaffected) but can no longer create or edit predictions past lock.
+--
+-- Also adds select_now() so the frontend can fetch the server's current
+-- time and compute clock skew, making the lock countdown UI resistant to
+-- device clock manipulation. (The real security boundary remains
+-- is_before_lock(tid), which uses Postgres now() — this just keeps the UI
+-- honest.)
+
+create or replace function public.is_super_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select coalesce((select is_super_admin from public.profiles where id = auth.uid()), false);
+$$;
+
+create or replace function public.select_now()
+returns timestamptz
+language sql
+stable
+as $$
+    select now();
+$$;
+
+grant execute on function public.select_now() to anon, authenticated;
+
+-- ========== admin_submit_predictions: restrict post-lock to super admin ==========
+-- Body identical to 0017 except for the added is_super_admin gate after the
+-- existing is_admin() check.
+
+create or replace function public.admin_submit_predictions(p_user_id uuid, payload jsonb)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid := (payload->>'tournament_id')::uuid;
+    v_prediction_id uuid := nullif(payload->>'prediction_id', '')::uuid;
+    v_prediction_name text := nullif(trim(payload->>'prediction_name'), '');
+    v_total_goals int := nullif(payload->>'total_goals', '')::int;
+    v_mark_submitted boolean := coalesce((payload->>'submit')::boolean, true);
+    v_existing_count int;
+    v_group jsonb;
+    v_match jsonb;
+    v_group_id text;
+    v_team_ids text[];
+    v_mismatched_team text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_user_id is null or v_tournament_id is null then
+        raise exception 'user_id and tournament_id are required' using errcode = 'P0001';
+    end if;
+    -- Past lock, only super admins may write predictions.
+    if not public.is_super_admin() and not public.is_before_lock(v_tournament_id) then
+        raise exception 'predictions are locked' using errcode = 'P0001';
+    end if;
+
+    if v_prediction_id is null then
+        if v_prediction_name is null then
+            raise exception 'prediction name required' using errcode = 'P0001';
+        end if;
+
+        perform pg_advisory_xact_lock(hashtext(p_user_id::text || ':' || v_tournament_id::text));
+
+        select count(*) into v_existing_count
+          from public.predictions
+         where user_id = p_user_id and tournament_id = v_tournament_id;
+        if v_existing_count >= 5 then
+            raise exception 'prediction limit reached' using errcode = 'P0001';
+        end if;
+
+        begin
+            insert into public.predictions (user_id, tournament_id, prediction_name, total_goals, submitted_at)
+            values (
+                p_user_id,
+                v_tournament_id,
+                v_prediction_name,
+                v_total_goals,
+                case when v_mark_submitted then now() else null end
+            )
+            returning id into v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    else
+        perform 1 from public.predictions
+            where id = v_prediction_id and user_id = p_user_id and tournament_id = v_tournament_id;
+        if not found then
+            raise exception 'prediction not found' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.predictions
+               set prediction_name = coalesce(v_prediction_name, prediction_name),
+                   total_goals = v_total_goals,
+                   submitted_at = case when v_mark_submitted then now() else submitted_at end
+             where id = v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    delete from public.group_predictions where prediction_id = v_prediction_id;
+    delete from public.knockout_predictions where prediction_id = v_prediction_id;
+
+    for v_group in select * from jsonb_array_elements(coalesce(payload->'groups', '[]'::jsonb))
+    loop
+        v_group_id := v_group->>'group_id';
+        v_team_ids := array_remove(array[
+            nullif(v_group->>'first', ''),
+            nullif(v_group->>'second', ''),
+            nullif(v_group->>'third', ''),
+            nullif(v_group->>'fourth', '')
+        ], null);
+
+        select t.id into v_mismatched_team
+          from public.teams t
+         where t.id = any(v_team_ids) and t.group_id is distinct from v_group_id
+         limit 1;
+
+        if v_mismatched_team is not null then
+            raise exception 'team % does not belong to group %', v_mismatched_team, v_group_id
+                using errcode = 'P0001';
+        end if;
+
+        insert into public.group_predictions (
+            prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id
+        ) values (
+            v_prediction_id,
+            v_group_id,
+            nullif(v_group->>'first', ''),
+            nullif(v_group->>'second', ''),
+            nullif(v_group->>'third', ''),
+            nullif(v_group->>'fourth', '')
+        );
+    end loop;
+
+    for v_match in select * from jsonb_array_elements(coalesce(payload->'knockout', '[]'::jsonb))
+    loop
+        insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+        values (
+            v_prediction_id,
+            v_match->>'match_id',
+            nullif(v_match->>'winner', '')
+        );
+    end loop;
+
+    return v_prediction_id;
+end;
+$$;
+
+grant execute on function public.admin_submit_predictions(uuid, jsonb) to authenticated;


### PR DESCRIPTION
## Summary

Two UI/UX adds requested:

### 1. Lock-status banner (every page)
- **Green** when predictions are open with a live countdown.
- **Amber** inside the final 24 hours (visual urgency, same lock state).
- **Red** when locked, with a *"Super admin: edits still open"* chip for super admins.
- **Close (X)** button; dismissal persists per session in \`sessionStorage\`, keyed on \`(tournament, locked-flag)\` so a state transition re-shows the banner.
- Surfaces a *"your device clock looks off — countdown shown is server time"* caption when client/server clock skew exceeds 5 minutes.

The countdown is anchored to the server's \`now()\`, fetched via a new \`select_now()\` RPC and exposed by \`/api/tournament\` as \`serverTime\`. The new \`useTournamentLock()\` hook computes a one-time skew and ticks the countdown each second. Banner mounts in \`PageLayout\` above the existing sticky Header.

### 2. Bracket preview overlay
- Wikipedia-style 5-column knockout tree: R32 → R16 → QF → SF → Final, with the **third-place play-off** broken out below.
- Predicted winner per match highlighted with a trophy icon.
- Empty slots render **TBD** for in-progress drafts.
- New **Preview** button on each prediction card (\`/predictions\`) and on each row in \`/admin/users/[id]\`. The dialog accepts an \`apiBasePath\` so it serves both contexts.
- \`resolveTeamSource()\` extracted to \`@/lib/knockoutResolver\` and shared between the editor and the reader (DRY).

### Security model
The actual lock boundary is the database — \`is_before_lock(tid)\` uses Postgres \`now()\`, so spoofing the device clock can't get past it. The banner and the UI are pure UX. **Past lock, only super admins may write predictions** — migration 0018 adds \`is_super_admin()\` and updates \`admin_submit_predictions\` to require it past lock. Regular admins keep payment-toggle access but lose post-lock prediction writes. The user-side wizard automatically routes a super admin's submit through the admin RPC so they can edit their own predictions past lock.

\`Profile.isSuperAdmin\` is hydrated end-to-end (server layout + client AuthProvider).

## Migration
- \`supabase/migrations/0018_super_admin_lock_bypass.sql\` — additive.
  - Adds \`public.is_super_admin()\`.
  - Adds \`public.select_now()\` (granted to anon + authenticated).
  - \`create or replace\` of \`admin_submit_predictions\` with one extra check: past lock, requires \`is_super_admin()\`.

Smoke-verified locally: a regular admin past lock gets \`'predictions are locked'\`; a super admin succeeds.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 36 suites / 271 tests pass (4 new suites: \`knockoutResolver\`, \`useTournamentLock\`, \`LockStatusBanner\`, \`BracketView\`)
- [x] \`npx eslint src\` — clean
- [x] Local DB smoke: regular admin past lock blocked, super admin past lock succeeds
- [ ] After deploy: visit any page, see green banner with countdown
- [ ] Set tournament \`lock_time\` 1 minute in the past via Studio → banner flips red, "New prediction" button hides for regular users, super admin still sees it
- [ ] Click Preview on a prediction card → bracket dialog opens with 32 nodes + third-place row
- [ ] Same on \`/admin/users/[id]\`

## Rollout
Single merge → CF auto-deploy → \`supabase db push --linked\` for migration 0018. Migration is purely additive (one new helper, one new RPC, one tightened RPC body) — safe to apply at any point relative to the deploy.

## Risks
- **Banner z-index** — banner now scrolls naturally above the sticky Header instead of fighting it. If you prefer it sticky too, that's a small follow-up.
- **Bracket layout on narrow screens** — desktop-first 5-column grid; collapses to single-column stack below md. Acceptable for v1.
- **Skew warning copy** is conservative; it's purely informational, doesn't block actions.