### PR TITLE
fix: admin write grants on tournament + result tables

### DIFF
--- a/supabase/migrations/0019_admin_write_grants.sql
+++ b/supabase/migrations/0019_admin_write_grants.sql
@@ -1,0 +1,12 @@
+-- Same class of fix as 0011 (which granted writes on prediction tables) for
+-- the admin-write reference tables. Supabase Cloud doesn't extend default
+-- INSERT/UPDATE/DELETE privileges to tables created via migrations; without
+-- explicit grants, PostgREST returns 403 'permission denied for table X'
+-- before RLS is consulted. RLS already restricts writes to is_admin() so
+-- this only widens the privilege bit, not the security model.
+
+grant insert, update, delete on
+    public.tournaments,
+    public.group_standings,
+    public.knockout_results
+  to authenticated;


### PR DESCRIPTION
Same class of bug as PR #58 (which granted writes on prediction tables): admin updates to `tournaments`, `group_standings`, and `knockout_results` returned `permission denied for table X` from PostgREST before RLS was consulted, because Supabase Cloud doesn't extend default INSERT/UPDATE/DELETE privileges to tables created via migrations.

Reproduced on prod by hitting PATCH /api/admin/tournament:
```
{ "error": "permission denied for table tournaments" }
```

RLS already restricts writes on these tables to `is_admin()`. Migration 0019 just flips the table-level privilege bit Postgres checks before RLS is invoked.