### PR TITLE
chore(banner): center text and reword open-state copy

### DIFF
--- a/frontend/src/components/layout/LockStatusBanner.tsx
+++ b/frontend/src/components/layout/LockStatusBanner.tsx
@@ -76,12 +76,13 @@ export function LockStatusBanner() {
       role="status"
       className={cn('w-full border-b border-black/10 shadow-sm', toneClasses[tone])}
     >
-      <div className="mx-auto flex max-w-7xl items-start justify-between gap-3 px-4 py-2 text-sm sm:px-6 lg:px-8">
-        <div className="flex flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+      <div className="mx-auto flex max-w-7xl items-start justify-center gap-3 px-4 py-2 text-sm sm:px-6 lg:px-8">
+        <div className="flex flex-1 flex-wrap items-center justify-center gap-x-3 gap-y-1 text-center">
           <Icon className="h-4 w-4 shrink-0" aria-hidden />
           <span className="font-medium">
-            {isLocked ? 'Predictions are locked. Tournament is underway.' : null}
-            {!isLocked ? `Predictions lock in ${formatRemaining(remainingMs)}.` : null}
+            {isLocked
+              ? 'Predictions are locked. Tournament is underway.'
+              : `You have ${formatRemaining(remainingMs)} left to choose your picks before the tournament starts! Don't miss out!`}
           </span>
           {isLocked && isSuperAdmin && (
             <span className="rounded-md bg-white/15 px-2 py-0.5 text-xs font-medium">

--- a/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
@@ -61,7 +61,7 @@ describe('LockStatusBanner', () => {
     mockTournament({ lockOffsetMs: 7 * 24 * 60 * 60 * 1000 });
     render(wrap(<LockStatusBanner />));
     await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
-    expect(screen.getByRole('status')).toHaveTextContent(/Predictions lock in/);
+    expect(screen.getByRole('status')).toHaveTextContent(/left to choose your picks/i);
     expect(screen.getByRole('status').className).toContain('bg-green-600');
   });
 


### PR DESCRIPTION
Centers the banner content and updates the unlocked copy to:

> You have {time} left to choose your picks before the tournament starts! Don't miss out!

Locked-state copy unchanged. Test updated to match the new wording.