### PR TITLE
feat(group-form): auto-fill 4th from leftover team

### DIFF
--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -53,6 +53,25 @@ function GroupCard({
   // Check if group is complete (all 4 positions filled)
   const isComplete = selectedTeamIds.size === 4;
 
+  // When 1, 2, 3 are all picked, the 4th is forced to the one leftover team —
+  // the user can't pick it (or anything else) for that slot.
+  const { first, second, third } = prediction.positions;
+  const top3AllFilled = !!(first && second && third);
+  const top3Ids = new Set<string>([first, second, third].filter((v): v is string => !!v));
+  const autoFillFourth = top3AllFilled
+    ? (group.teams.find((t) => !top3Ids.has(t.id)) ?? null)
+    : null;
+
+  React.useEffect(() => {
+    if (disabled) return;
+    if (autoFillFourth && prediction.positions.fourth !== autoFillFourth.id) {
+      onPositionChange('fourth', autoFillFourth.id);
+    }
+    // We deliberately don't auto-clear `fourth` when top-3 is incomplete —
+    // the user may have started by picking the 4th first; the existing
+    // `getAvailableTeams` logic keeps that consistent.
+  }, [autoFillFourth, disabled, prediction.positions.fourth, onPositionChange]);
+
   // Get available teams for a position (not selected in other positions)
   const getAvailableTeams = (position: PositionKey): Team[] => {
     const currentSelection = prediction.positions[position];
@@ -83,6 +102,7 @@ function GroupCard({
         {(Object.keys(POSITION_LABELS) as PositionKey[]).map((position) => {
           const availableTeams = getAvailableTeams(position);
           const selectedValue = prediction.positions[position];
+          const isAutoFilled = position === 'fourth' && autoFillFourth !== null;
 
           return (
             <div key={position} className="flex items-center gap-3">
@@ -92,9 +112,12 @@ function GroupCard({
               <Select
                 value={selectedValue ?? ''}
                 onValueChange={(value) => onPositionChange(position, value || null)}
-                disabled={disabled}
+                disabled={disabled || isAutoFilled}
               >
-                <SelectTrigger className="flex-1">
+                <SelectTrigger
+                  className="flex-1"
+                  title={isAutoFilled ? 'Auto-filled from your top 3 picks' : undefined}
+                >
                   <SelectValue placeholder="Select team" />
                 </SelectTrigger>
                 <SelectContent>

--- a/frontend/src/components/predictions/__tests__/GroupStageForm.test.tsx
+++ b/frontend/src/components/predictions/__tests__/GroupStageForm.test.tsx
@@ -312,4 +312,89 @@ describe('GroupStageForm', () => {
       expect(screen.getByText('Mexico')).toBeInTheDocument();
     });
   });
+
+  describe('auto-fill 4th place', () => {
+    it('auto-fires onPredictionChange for the 4th when 1, 2, 3 are filled', () => {
+      const mockOnChange = jest.fn();
+      const predictions = createEmptyPredictions();
+      // Group A teams: mex, kor, rsa, cze. Picking 1/2/3 leaves cze for 4th.
+      predictions[0] = {
+        groupId: 'A',
+        positions: { first: 'mex', second: 'kor', third: 'rsa', fourth: null },
+      };
+
+      render(
+        <GroupStageForm
+          groups={fixtureGroups}
+          predictions={predictions}
+          onPredictionChange={mockOnChange}
+        />
+      );
+
+      expect(mockOnChange).toHaveBeenCalledWith('A', 'fourth', 'cze');
+    });
+
+    it('does not re-fire onPredictionChange when 4 already matches the leftover', () => {
+      const mockOnChange = jest.fn();
+      const predictions = createEmptyPredictions();
+      predictions[0] = {
+        groupId: 'A',
+        positions: { first: 'mex', second: 'kor', third: 'rsa', fourth: 'cze' },
+      };
+
+      render(
+        <GroupStageForm
+          groups={fixtureGroups}
+          predictions={predictions}
+          onPredictionChange={mockOnChange}
+        />
+      );
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it('disables the 4th-place select when auto-filled', () => {
+      const mockOnChange = jest.fn();
+      const predictions = createEmptyPredictions();
+      predictions[0] = {
+        groupId: 'A',
+        positions: { first: 'mex', second: 'kor', third: 'rsa', fourth: 'cze' },
+      };
+
+      render(
+        <GroupStageForm
+          groups={fixtureGroups}
+          predictions={predictions}
+          onPredictionChange={mockOnChange}
+        />
+      );
+
+      const selects = screen.getAllByRole('combobox');
+      // Group A is the first card in the grid → first 4 selects belong to it.
+      const groupAFourth = selects[3];
+      expect(groupAFourth).toBeDisabled();
+    });
+
+    it('leaves the 4th select enabled when top-3 is incomplete', () => {
+      const mockOnChange = jest.fn();
+      const predictions = createEmptyPredictions();
+      predictions[0] = {
+        groupId: 'A',
+        positions: { first: 'mex', second: 'kor', third: null, fourth: null },
+      };
+
+      render(
+        <GroupStageForm
+          groups={fixtureGroups}
+          predictions={predictions}
+          onPredictionChange={mockOnChange}
+        />
+      );
+
+      const selects = screen.getAllByRole('combobox');
+      const groupAFourth = selects[3];
+      expect(groupAFourth).toBeEnabled();
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
When 1, 2, 3 are picked the 4th is the only remaining team — no choice to make. Auto-set it and disable the field so the user can't accidentally change it.

Idempotent (won't re-fire if the 4th already matches the leftover) and reverts to manual editing if the user clears any of 1/2/3.

Part 1 of 3 toward the FIFA-2026 multi-phase prediction redesign (see plan). UI-only, no DB changes.

## Test plan
- [x] 4 new test cases in GroupStageForm covering auto-fire, idempotency, disable state, and the 'top-3 incomplete' path.
- [x] All 36 suites / 275 tests pass; eslint src clean.