### PR TITLE
fix(group-form): allow reordering picks via swap

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -575,11 +575,23 @@ export function PredictionsPageContent({
     teamId: string | null
   ) => {
     setGroupPredictions((prev) => {
-      const next = prev.map((group) =>
-        group.groupId === groupId
-          ? { ...group, positions: { ...group.positions, [position]: teamId } }
-          : group
-      );
+      const next = prev.map((group) => {
+        if (group.groupId !== groupId) return group;
+        const positions = { ...group.positions };
+        // Picking a team that's already in another slot swaps them: the
+        // displaced team takes the slot the user just freed up, so the user
+        // can reorder picks without first clearing their group.
+        if (teamId) {
+          const conflictPos = (Object.keys(positions) as PositionKey[]).find(
+            (p) => p !== position && positions[p] === teamId
+          );
+          if (conflictPos) {
+            positions[conflictPos] = positions[position] ?? null;
+          }
+        }
+        positions[position] = teamId;
+        return { ...group, positions };
+      });
       persistDraft({ groupPredictions: next });
       return next;
     });

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -72,13 +72,10 @@ function GroupCard({
     // `getAvailableTeams` logic keeps that consistent.
   }, [autoFillFourth, disabled, prediction.positions.fourth, onPositionChange]);
 
-  // Get available teams for a position (not selected in other positions)
-  const getAvailableTeams = (position: PositionKey): Team[] => {
-    const currentSelection = prediction.positions[position];
-    return group.teams.filter(
-      (team) => team.id === currentSelection || !selectedTeamIds.has(team.id)
-    );
-  };
+  // Every team in the group is selectable from every position's dropdown.
+  // Picking a team that's already in another slot swaps the two — handled by
+  // the parent's onPredictionChange (it detects the conflict and reassigns).
+  const availableTeams: Team[] = group.teams;
 
   return (
     <Card className={cn(isComplete && 'border-green-500/50 bg-green-500/5 dark:bg-green-500/10')}>
@@ -100,7 +97,6 @@ function GroupCard({
       </CardHeader>
       <CardContent className="space-y-3">
         {(Object.keys(POSITION_LABELS) as PositionKey[]).map((position) => {
-          const availableTeams = getAvailableTeams(position);
           const selectedValue = prediction.positions[position];
           const isAutoFilled = position === 'fourth' && autoFillFourth !== null;
 


### PR DESCRIPTION
When all 4 group slots are filled, the dropdown for any position only showed the current selection. Every other team was filtered out by 'not in selectedTeamIds', so the user couldn't reorder picks without first clearing the group. With the new 4th-place auto-fill, this got worse — clearing one of 1/2/3 didn't free the 4th, so users were effectively locked in.

**Fix:** every position's dropdown now lists all 4 teams. Picking a team already in another slot swaps the two: the displaced team takes the slot the user just freed up. Auto-fill of 4th still works because top-3 stays full post-swap.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test --runInBand` — 37 / 282 still green
- [x] `npx eslint src` clean
- [ ] After deploy: change 1st to a team currently in 2nd → 1st becomes that team, 2nd becomes the previous 1st, 3rd/4th unchanged