### PR TITLE
refactor(admin): reuse GroupStageForm for results; fold Advancers into Results tabs

### DIFF
--- a/frontend/src/app/admin/advancers/AdvancersForm.tsx
+++ b/frontend/src/app/admin/advancers/AdvancersForm.tsx
@@ -5,8 +5,6 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { CheckCircle2, Lock, Unlock } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { PageLayout } from '@/components/layout/PageLayout';
-import { AdminNav } from '@/components/admin/AdminNav';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -121,10 +119,7 @@ export function AdvancersForm() {
   };
 
   return (
-    <PageLayout>
-      <h1 className="mb-2 text-3xl font-bold">Admin</h1>
-      <AdminNav />
-
+    <div>
       <div className="mb-6">
         <h2 className="text-xl font-semibold">Best-3rd advancers</h2>
         <p className="text-muted-foreground text-sm">
@@ -230,6 +225,6 @@ export function AdvancersForm() {
           </div>
         </CardContent>
       </Card>
-    </PageLayout>
+    </div>
   );
 }

--- a/frontend/src/app/admin/advancers/AdvancersForm.tsx
+++ b/frontend/src/app/admin/advancers/AdvancersForm.tsx
@@ -18,7 +18,9 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
+import { TeamFlag } from '@/components/shared/TeamFlag';
 import { BUNDLE_SLOTS } from '@/lib/constants';
+import type { Team } from '@/types/tournament';
 
 interface AdvancersResponse {
   tournamentId: string;
@@ -30,6 +32,11 @@ interface TournamentResponse {
   knockoutUnlocked: boolean;
   knockoutLockTime: string | null;
   phase: 'phase1' | 'phase1_locked' | 'phase2_open' | 'phase2_locked';
+}
+
+interface GroupStandingRow {
+  group_id: string;
+  third_team_id: string | null;
 }
 
 async function fetchJSON<T>(url: string): Promise<T> {
@@ -68,6 +75,34 @@ export function AdvancersForm() {
   const completedCount = advancers.length;
   const allEight = completedCount === 8;
   const knockoutUnlocked = tournamentQuery.data?.knockoutUnlocked ?? false;
+
+  // Look up the actual 3rd-place team per group from admin-entered standings
+  // so the group-letter dropdowns can preview the country if it's known.
+  const standingsQuery = useQuery<GroupStandingRow[]>({
+    queryKey: ['admin-group-standings', tournamentId],
+    queryFn: () => fetchJSON(`/api/admin/group-standings?tournamentId=${tournamentId}`),
+    enabled: !!tournamentId,
+  });
+  const teamsQuery = useQuery<Team[]>({
+    queryKey: ['teams'],
+    queryFn: () => fetchJSON('/api/teams'),
+  });
+
+  const teamById = React.useMemo(() => {
+    const map = new Map<string, Team>();
+    for (const t of teamsQuery.data ?? []) map.set(t.id, t);
+    return map;
+  }, [teamsQuery.data]);
+
+  const thirdByGroup = React.useMemo(() => {
+    const map = new Map<string, Team>();
+    for (const row of standingsQuery.data ?? []) {
+      if (!row.third_team_id) continue;
+      const team = teamById.get(row.third_team_id);
+      if (team) map.set(row.group_id, team);
+    }
+    return map;
+  }, [standingsQuery.data, teamById]);
 
   const setSlot = async (slotIndex: number, groupLetter: string) => {
     if (!tournamentId) return;
@@ -171,11 +206,24 @@ export function AdvancersForm() {
                       <SelectValue placeholder="Pick a group" />
                     </SelectTrigger>
                     <SelectContent>
-                      {slot.allowedLetters.map((letter) => (
-                        <SelectItem key={letter} value={letter}>
-                          Group {letter}
-                        </SelectItem>
-                      ))}
+                      {slot.allowedLetters.map((letter) => {
+                        const team = thirdByGroup.get(letter);
+                        return (
+                          <SelectItem key={letter} value={letter}>
+                            {team ? (
+                              <span className="flex items-center gap-2">
+                                <TeamFlag code={team.code} />
+                                <span className="text-muted-foreground font-mono text-xs">
+                                  {letter}
+                                </span>
+                                <span>{team.name}</span>
+                              </span>
+                            ) : (
+                              <>Group {letter}</>
+                            )}
+                          </SelectItem>
+                        );
+                      })}
                     </SelectContent>
                   </Select>
                 </CardContent>

--- a/frontend/src/app/admin/advancers/page.tsx
+++ b/frontend/src/app/admin/advancers/page.tsx
@@ -1,11 +1,5 @@
-import type { Metadata } from 'next';
-
-import { AdvancersForm } from './AdvancersForm';
-
-export const metadata: Metadata = {
-  title: 'Best-3rd advancers | Admin',
-};
+import { redirect } from 'next/navigation';
 
 export default function AdvancersPage() {
-  return <AdvancersForm />;
+  redirect('/admin/results');
 }

--- a/frontend/src/app/admin/results/AdminResults.tsx
+++ b/frontend/src/app/admin/results/AdminResults.tsx
@@ -6,6 +6,7 @@ import { AdminNav } from '@/components/admin/AdminNav';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { GroupStandingsEditor } from './GroupStandingsEditor';
 import { KnockoutResultsEditor } from './KnockoutResultsEditor';
+import { AdvancersForm } from '../advancers/AdvancersForm';
 import type { Group, KnockoutMatch, Team } from '@/types/tournament';
 
 interface TournamentInfo {
@@ -49,6 +50,7 @@ export function AdminResults() {
         <Tabs defaultValue="groups">
           <TabsList className="mb-6">
             <TabsTrigger value="groups">Group Standings</TabsTrigger>
+            <TabsTrigger value="advancers">Advancers</TabsTrigger>
             <TabsTrigger value="knockout">Knockout Results</TabsTrigger>
           </TabsList>
           <TabsContent value="groups">
@@ -56,6 +58,9 @@ export function AdminResults() {
               tournamentId={tournament.data!.id}
               groups={groups.data!}
             />
+          </TabsContent>
+          <TabsContent value="advancers">
+            <AdvancersForm />
           </TabsContent>
           <TabsContent value="knockout">
             <KnockoutResultsEditor

--- a/frontend/src/app/admin/results/GroupStandingsEditor.tsx
+++ b/frontend/src/app/admin/results/GroupStandingsEditor.tsx
@@ -3,17 +3,15 @@
 import * as React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
-import type { Group } from '@/types/tournament';
+  GroupStageForm,
+  type GroupPositionKey,
+} from '@/components/predictions/GroupStageForm';
+import { applyGroupPositionChange } from '@/lib/groupSwap';
+import type { Group, GroupPrediction } from '@/types/tournament';
 
 interface GroupStandingRow {
   group_id: string;
@@ -24,15 +22,21 @@ interface GroupStandingRow {
   submitted_at: string;
 }
 
-const POSITIONS = [
-  { key: 'first', label: '1st' },
-  { key: 'second', label: '2nd' },
-  { key: 'third', label: '3rd' },
-  { key: 'fourth', label: '4th' },
-] as const;
+function emptyPredictions(groups: Group[]): GroupPrediction[] {
+  return groups.map((g) => ({
+    groupId: g.id,
+    positions: { first: null, second: null, third: null, fourth: null },
+  }));
+}
 
-type Slots = { first: string; second: string; third: string; fourth: string };
-const EMPTY: Slots = { first: '', second: '', third: '', fourth: '' };
+function rowToPositions(row: GroupStandingRow) {
+  return {
+    first: row.first_team_id,
+    second: row.second_team_id,
+    third: row.third_team_id,
+    fourth: row.fourth_team_id,
+  };
+}
 
 export function GroupStandingsEditor({
   tournamentId,
@@ -60,27 +64,34 @@ export function GroupStandingsEditor({
     return map;
   }, [standings.data]);
 
-  const [picks, setPicks] = React.useState<Record<string, Slots>>({});
+  const [predictions, setPredictions] = React.useState<GroupPrediction[]>(() =>
+    emptyPredictions(groups)
+  );
   const [savingId, setSavingId] = React.useState<string | null>(null);
 
+  // Hydrate predictions from server-submitted rows whenever they change.
   React.useEffect(() => {
-    const next: Record<string, Slots> = {};
-    for (const g of groups) {
-      const row = submittedById.get(g.id);
-      next[g.id] = row
-        ? {
-            first: row.first_team_id,
-            second: row.second_team_id,
-            third: row.third_team_id,
-            fourth: row.fourth_team_id,
-          }
-        : EMPTY;
-    }
-    setPicks(next);
+    setPredictions(
+      groups.map((g) => {
+        const row = submittedById.get(g.id);
+        return row
+          ? { groupId: g.id, positions: rowToPositions(row) }
+          : { groupId: g.id, positions: { first: null, second: null, third: null, fourth: null } };
+      })
+    );
   }, [groups, submittedById]);
 
+  const handlePositionChange = (
+    groupId: string,
+    position: GroupPositionKey,
+    teamId: string | null
+  ) => {
+    setPredictions((prev) => applyGroupPositionChange(prev, groupId, position, teamId));
+  };
+
   const handleSave = async (groupId: string) => {
-    const slots = picks[groupId];
+    const group = predictions.find((p) => p.groupId === groupId);
+    const slots = group?.positions;
     if (!slots || !slots.first || !slots.second || !slots.third || !slots.fourth) {
       toast.error('All four positions are required');
       return;
@@ -90,7 +101,14 @@ export function GroupStandingsEditor({
       const res = await fetch('/api/admin/group-standings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ tournamentId, groupId, ...slots }),
+        body: JSON.stringify({
+          tournamentId,
+          groupId,
+          first: slots.first,
+          second: slots.second,
+          third: slots.third,
+          fourth: slots.fourth,
+        }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
@@ -107,56 +125,35 @@ export function GroupStandingsEditor({
   };
 
   return (
-    <div className="grid gap-4 md:grid-cols-2">
-      {groups.map((g) => {
-        const slots = picks[g.id] ?? EMPTY;
-        const submitted = submittedById.has(g.id);
-        const usedIds = new Set(Object.values(slots).filter(Boolean));
+    <GroupStageForm
+      groups={groups}
+      predictions={predictions}
+      onPredictionChange={handlePositionChange}
+      variant="admin"
+      extraPerCard={(groupId) => {
+        const submitted = submittedById.has(groupId);
+        const group = predictions.find((p) => p.groupId === groupId);
+        const slots = group?.positions;
+        const allFilled =
+          !!slots && !!slots.first && !!slots.second && !!slots.third && !!slots.fourth;
         return (
-          <Card key={g.id}>
-            <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-base">Group {g.id}</CardTitle>
-              {submitted ? <Badge>submitted</Badge> : <Badge variant="outline">pending</Badge>}
-            </CardHeader>
-            <CardContent className="space-y-3">
-              {POSITIONS.map((p) => (
-                <div key={p.key} className="flex items-center gap-3">
-                  <span className="text-muted-foreground w-10 text-sm">{p.label}</span>
-                  <Select
-                    value={slots[p.key]}
-                    onValueChange={(v) =>
-                      setPicks((prev) => ({ ...prev, [g.id]: { ...prev[g.id], [p.key]: v } }))
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select team" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {g.teams.map((t) => (
-                        <SelectItem
-                          key={t.id}
-                          value={t.id}
-                          disabled={usedIds.has(t.id) && slots[p.key] !== t.id}
-                        >
-                          {t.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              ))}
-              <Button
-                size="sm"
-                onClick={() => handleSave(g.id)}
-                disabled={savingId === g.id}
-                className="w-full"
-              >
-                {savingId === g.id ? 'Saving…' : submitted ? 'Update' : 'Save'}
-              </Button>
-            </CardContent>
-          </Card>
+          <div className="flex items-center gap-2">
+            {submitted ? (
+              <Badge>submitted</Badge>
+            ) : (
+              <Badge variant="outline">pending</Badge>
+            )}
+            <Button
+              size="sm"
+              className="ml-auto"
+              onClick={() => handleSave(groupId)}
+              disabled={savingId === groupId || !allFilled}
+            >
+              {savingId === groupId ? 'Saving…' : submitted ? 'Update' : 'Save'}
+            </Button>
+          </div>
         );
-      })}
-    </div>
+      }}
+    />
   );
 }

--- a/frontend/src/app/admin/results/GroupStandingsEditor.tsx
+++ b/frontend/src/app/admin/results/GroupStandingsEditor.tsx
@@ -46,16 +46,16 @@ export function GroupStandingsEditor({
   groups: Group[];
 }) {
   const queryClient = useQueryClient();
+  // No `initialData` here — pairing it with the global `staleTime: 60s`
+  // makes React Query treat the empty seed as fresh and skip the mount
+  // fetch, so saved standings never appear until a manual invalidation.
   const standings = useQuery<GroupStandingRow[]>({
     queryKey: ['group-standings', tournamentId],
     queryFn: async () => {
-      const res = await fetch(`/api/admin/group-standings?tournamentId=${tournamentId}`).catch(
-        () => null
-      );
-      if (res && res.ok) return res.json();
-      return [];
+      const res = await fetch(`/api/admin/group-standings?tournamentId=${tournamentId}`);
+      if (!res.ok) throw new Error((await res.json())?.error ?? 'Failed to load standings');
+      return res.json();
     },
-    initialData: [],
   });
 
   const submittedById = React.useMemo(() => {

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -39,6 +39,7 @@ import type {
   TournamentInfo,
 } from '@/types/tournament';
 import { BUNDLE_SLOTS } from '@/lib/constants';
+import { applyGroupPositionChange } from '@/lib/groupSwap';
 import { BestThirdBundleForm } from '@/components/predictions/BestThirdBundleForm';
 
 type PositionKey = 'first' | 'second' | 'third' | 'fourth';
@@ -575,23 +576,9 @@ export function PredictionsPageContent({
     teamId: string | null
   ) => {
     setGroupPredictions((prev) => {
-      const next = prev.map((group) => {
-        if (group.groupId !== groupId) return group;
-        const positions = { ...group.positions };
-        // Picking a team that's already in another slot swaps them: the
-        // displaced team takes the slot the user just freed up, so the user
-        // can reorder picks without first clearing their group.
-        if (teamId) {
-          const conflictPos = (Object.keys(positions) as PositionKey[]).find(
-            (p) => p !== position && positions[p] === teamId
-          );
-          if (conflictPos) {
-            positions[conflictPos] = positions[position] ?? null;
-          }
-        }
-        positions[position] = teamId;
-        return { ...group, positions };
-      });
+      // Conflict-swap semantics live in @/lib/groupSwap so admin code can
+      // reuse the same behavior.
+      const next = applyGroupPositionChange(prev, groupId, position, teamId);
       persistDraft({ groupPredictions: next });
       return next;
     });

--- a/frontend/src/components/admin/AdminNav.tsx
+++ b/frontend/src/components/admin/AdminNav.tsx
@@ -9,7 +9,6 @@ const links = [
   { label: 'Results', href: '/admin/results' },
   { label: 'Users', href: '/admin/users' },
   { label: 'Tournament', href: '/admin/tournament' },
-  { label: 'Advancers', href: '/admin/advancers' },
 ];
 
 export function AdminNav() {

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -24,14 +24,29 @@ const POSITION_LABELS = {
   fourth: '4th',
 } as const;
 
-type PositionKey = keyof typeof POSITION_LABELS;
+export type GroupPositionKey = keyof typeof POSITION_LABELS;
 
 interface GroupStageFormProps {
   groups: Group[];
   predictions: GroupPrediction[];
-  onPredictionChange: (groupId: string, position: PositionKey, teamId: string | null) => void;
+  onPredictionChange: (
+    groupId: string,
+    position: GroupPositionKey,
+    teamId: string | null
+  ) => void;
   disabled?: boolean;
+  /**
+   * Variant: 'predict' (default) is the user-side wizard with scoring tips.
+   * 'admin' hides the scoring tips and renames the heading; admins also
+   * typically pass `extraPerCard` to inject a Save button + submitted badge.
+   */
+  variant?: 'predict' | 'admin';
+  /** Optional render-prop appended inside each group card (e.g., a Save row). */
+  extraPerCard?: (groupId: string) => React.ReactNode;
 }
+
+// Local alias for the existing internal usage.
+type PositionKey = GroupPositionKey;
 
 // Single group card component
 function GroupCard({
@@ -39,11 +54,13 @@ function GroupCard({
   prediction,
   onPositionChange,
   disabled,
+  extra,
 }: {
   group: Group;
   prediction: GroupPrediction;
   onPositionChange: (position: PositionKey, teamId: string | null) => void;
   disabled?: boolean;
+  extra?: React.ReactNode;
 }) {
   // Get selected team IDs for this group
   const selectedTeamIds = new Set(
@@ -131,6 +148,7 @@ function GroupCard({
             </div>
           );
         })}
+        {extra ? <div className="border-t pt-3">{extra}</div> : null}
       </CardContent>
     </Card>
   );
@@ -141,7 +159,11 @@ export function GroupStageForm({
   predictions,
   onPredictionChange,
   disabled = false,
+  variant = 'predict',
+  extraPerCard,
 }: GroupStageFormProps) {
+  const isAdmin = variant === 'admin';
+
   // Calculate completion stats
   const completedGroups = predictions.filter((p) => {
     const filledPositions = Object.values(p.positions).filter((v) => v !== null).length;
@@ -150,47 +172,46 @@ export function GroupStageForm({
 
   return (
     <div className="space-y-6">
-      {/* Summary */}
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold">Group Stage Predictions</h3>
+        <h3 className="text-lg font-semibold">
+          {isAdmin ? 'Group Standings' : 'Group Stage Predictions'}
+        </h3>
         <Badge variant={completedGroups === 12 ? 'default' : 'secondary'}>
-          {completedGroups} / 12 groups complete
+          {completedGroups} / 12 groups {isAdmin ? 'filled in' : 'complete'}
         </Badge>
       </div>
 
-      {/* How is this scored? — collapsible, opens by default the first time. */}
-      <details
-        className="group bg-muted/40 rounded-md border px-4 py-3 open:pb-4"
-        open
-      >
-        <summary className="cursor-pointer list-none text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
-          <span className="inline-flex items-center gap-1.5">
-            <span className="text-muted-foreground transition-transform group-open:rotate-90">▶</span>
-            How is this scored?
-          </span>
-        </summary>
-        <div className="text-muted-foreground mt-3 space-y-2 text-sm">
-          <p>
-            Predict the final standings for each group: who finishes 1st, 2nd, 3rd, and 4th. Each
-            team can only be selected once per group.
-          </p>
-          <p>
-            <strong>Scoring uses only the top two finishers.</strong> 3rd and 4th picks aren&apos;t
-            scored, but your 3rd-place picks for groups A–H seed your Round of 32 bracket.
-          </p>
-          <p>
-            <strong>Per group:</strong> +6 for both top-two correct in exact order · +4 if both
-            correct but swapped · +3 for one correct in the right slot · +2 for one correct in the
-            wrong slot · 0 otherwise.
-          </p>
-          <p>
-            <strong>Group I (&ldquo;Group of Death&rdquo;)</strong> pays a +8 bonus instead of +6
-            when both top-two finishers are predicted in exact order.
-          </p>
-        </div>
-      </details>
+      {!isAdmin && (
+        <details className="group bg-muted/40 rounded-md border px-4 py-3 open:pb-4" open>
+          <summary className="cursor-pointer list-none text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="text-muted-foreground transition-transform group-open:rotate-90">▶</span>
+              How is this scored?
+            </span>
+          </summary>
+          <div className="text-muted-foreground mt-3 space-y-2 text-sm">
+            <p>
+              Predict the final standings for each group: who finishes 1st, 2nd, 3rd, and 4th. Each
+              team can only be selected once per group.
+            </p>
+            <p>
+              <strong>Scoring uses only the top two finishers.</strong> 3rd and 4th picks
+              aren&apos;t scored, but your 3rd-place picks for groups A–H seed your Round of 32
+              bracket.
+            </p>
+            <p>
+              <strong>Per group:</strong> +6 for both top-two correct in exact order · +4 if both
+              correct but swapped · +3 for one correct in the right slot · +2 for one correct in
+              the wrong slot · 0 otherwise.
+            </p>
+            <p>
+              <strong>Group I (&ldquo;Group of Death&rdquo;)</strong> pays a +8 bonus instead of +6
+              when both top-two finishers are predicted in exact order.
+            </p>
+          </div>
+        </details>
+      )}
 
-      {/* Groups Grid */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {groups.map((group) => {
           const prediction = predictions.find((p) => p.groupId === group.id);
@@ -205,6 +226,7 @@ export function GroupStageForm({
                 onPredictionChange(group.id, position, teamId)
               }
               disabled={disabled}
+              extra={extraPerCard?.(group.id)}
             />
           );
         })}

--- a/frontend/src/lib/groupSwap.ts
+++ b/frontend/src/lib/groupSwap.ts
@@ -1,0 +1,30 @@
+import type { GroupPrediction } from '@/types/tournament';
+import type { GroupPositionKey } from '@/components/predictions/GroupStageForm';
+
+/**
+ * Apply a single group-position change with conflict-swap semantics:
+ * if `teamId` is already in another slot of the same group, that slot
+ * inherits whatever was previously in `position`. Returns a new
+ * `GroupPrediction[]` (does not mutate input).
+ */
+export function applyGroupPositionChange(
+  predictions: GroupPrediction[],
+  groupId: string,
+  position: GroupPositionKey,
+  teamId: string | null
+): GroupPrediction[] {
+  return predictions.map((group) => {
+    if (group.groupId !== groupId) return group;
+    const positions = { ...group.positions };
+    if (teamId) {
+      const conflictPos = (Object.keys(positions) as GroupPositionKey[]).find(
+        (p) => p !== position && positions[p] === teamId
+      );
+      if (conflictPos) {
+        positions[conflictPos] = positions[position] ?? null;
+      }
+    }
+    positions[position] = teamId;
+    return { ...group, positions };
+  });
+}


### PR DESCRIPTION
## Summary
- Reuse the user-side `GroupStageForm` for the Admin → Results group-standings entry. The component now accepts `variant: 'predict' | 'admin'` and an `extraPerCard(groupId)` render-prop so the admin can inject per-group Save buttons + submitted/pending badges. The previous bespoke `GroupStandingsEditor` UI is replaced by a thin wrapper that hydrates from `/api/admin/group-standings` and POSTs per group.
- Extract the conflict-swap logic from `PredictionsPageContent.handleGroupPredictionChange` into a shared `lib/groupSwap.ts` helper so both wizards behave identically (pick a team that's already slotted → it swaps with the position you're editing). Avoids drift the next time someone tweaks one site and forgets the other.
- Reorganize the admin nav: **Advancers** moves under the **Results** tabs (Group Standings → Advancers → Knockout Results — matches the chronological flow of the tournament). Top-level "Advancers" link is removed from `AdminNav`, and `/admin/advancers` now redirects to `/admin/results` so existing bookmarks still work.

## Test plan
- [ ] `npm run typecheck` ✅
- [ ] `npm test` ✅ (282 passing)
- [ ] `npx eslint src` ✅
- [ ] Manual: `/admin/results` → Group Standings tab — pick top 3 in Group A, 4th auto-fills; "Save" enables and persists; reload shows submitted badge + values hydrated.
- [ ] Manual: switch to **Advancers** tab — same UI as old `/admin/advancers`, all 8 bundle slot cards + Phase 2 toggle.
- [ ] Manual: visit `/admin/advancers` → redirected to `/admin/results`.
- [ ] Manual: top-level admin nav no longer shows "Advancers" link.