### PR TITLE
chore(supabase): preserve local super-admin account across db reset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
-> **Version:** 3.0.0
-> **Last Updated:** 2026-04-30
+> **Version:** 3.1.0
+> **Last Updated:** 2026-05-09
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -154,6 +154,7 @@ Admin-controlled v1: an admin (`profiles.is_admin = true`) submits final group s
 - **Don't trust the client**: any new mutation must validate at the RPC boundary, not in the route handler.
 - **Never import `lib/supabase/admin.ts` from a client component** — service-role key would leak.
 - **Cloudflare Workers runtime**: `npm run preview` builds with OpenNext and runs locally on the Worker runtime. If you add a Node-only dep, expect to need `compatibility_flags = ["nodejs_compat"]` in `wrangler.toml` (already set) or to find an edge-friendly alternative.
+- **Local dev accounts must survive `supabase db reset`.** `supabase db reset` wipes `auth.users` along with everything else and reruns migrations + `seed.sql`. Any account you want preserved across resets must be re-seeded from `supabase/seed.sql` (local-only, never runs against prod). To add one: insert into `auth.users` (with `extensions.crypt(password, extensions.gen_salt('bf'))`) + `auth.identities`, both with stable UUIDs guarded by `on conflict do nothing`. The `handle_new_user` trigger creates the profile from `raw_user_meta_data.username`. To set `is_admin` / `is_super_admin`, temporarily `disable trigger profiles_block_super_admin_change` on `public.profiles`, update, re-enable — `set session_replication_role = 'replica'` won't work in seed because seed runs as the non-superuser `postgres` role.
 
 ## Production rate limits (Cloudflare WAF)
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -93,3 +93,61 @@ insert into public.knockout_matches (id, stage, team1_source, team2_source, poin
 
 insert into public.tournaments (slug, name, status, lock_time, is_active)
 values ('wc2026', 'FIFA World Cup 2026', 'upcoming', now() + interval '30 days', true);
+
+-- =============================================================================
+-- Local-only dev accounts
+-- =============================================================================
+-- Re-seeded on every `supabase db reset` so local super-admin access doesn't
+-- get wiped. seed.sql is local-only — never runs against production.
+-- Add new accounts by following the same pattern (auth.users + auth.identities
+-- + a post-trigger profile flag flip). All inserts are idempotent on the
+-- stable UUID, so re-running the seed is safe.
+--
+-- Account: leedium@me.com / localdev123 (super admin, username `user_4f1fc348`)
+-- =============================================================================
+
+insert into auth.users (
+    instance_id, id, aud, role, email,
+    encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data,
+    created_at, updated_at,
+    confirmation_token, recovery_token, email_change_token_new, email_change
+) values (
+    '00000000-0000-0000-0000-000000000000',
+    '0b42c609-f4e3-493e-bb06-162aa57318e7',
+    'authenticated', 'authenticated',
+    'leedium@me.com',
+    extensions.crypt('localdev123', extensions.gen_salt('bf')),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"username":"user_4f1fc348"}'::jsonb,
+    now(), now(),
+    '', '', '', ''
+)
+on conflict (id) do nothing;
+
+insert into auth.identities (
+    id, user_id, identity_data, provider, provider_id,
+    last_sign_in_at, created_at, updated_at
+) values (
+    extensions.gen_random_uuid(),
+    '0b42c609-f4e3-493e-bb06-162aa57318e7',
+    '{"sub":"0b42c609-f4e3-493e-bb06-162aa57318e7","email":"leedium@me.com"}'::jsonb,
+    'email',
+    '0b42c609-f4e3-493e-bb06-162aa57318e7',
+    now(), now(), now()
+)
+on conflict (provider, provider_id) do nothing;
+
+-- handle_new_user trigger created the profile row above with the username
+-- from raw_user_meta_data. Now flip is_admin/is_super_admin — we have to
+-- temporarily disable prevent_super_admin_change (which always blocks
+-- is_super_admin transitions from app context) to do it.
+alter table public.profiles disable trigger profiles_block_super_admin_change;
+
+update public.profiles
+   set is_admin = true,
+       is_super_admin = true
+ where id = '0b42c609-f4e3-493e-bb06-162aa57318e7';
+
+alter table public.profiles enable trigger profiles_block_super_admin_change;


### PR DESCRIPTION
## Summary
- `supabase/seed.sql` now re-creates `leedium@me.com` (super admin, username `user_4f1fc348`) on every `supabase db reset`. Login: `leedium@me.com` / `localdev123`. Inserts are idempotent (`on conflict do nothing` on stable UUID `0b42c609-…`).
- Flow: insert into `auth.users` + `auth.identities` → `handle_new_user` trigger creates the profile from `raw_user_meta_data.username` → temporarily disable `profiles_block_super_admin_change` → flip `is_admin` / `is_super_admin` → re-enable trigger. `session_replication_role = 'replica'` won't work in seed because seed runs as the non-superuser `postgres` role; `disable trigger` works because `public.profiles` is owned by `postgres`.
- CLAUDE.md gets a new rule under "Workflow Notes" so any future local-only accounts follow the same pattern instead of getting wiped on every reset.

## Test plan
- [ ] Verified the seed snippet runs cleanly on the live local DB (idempotent re-run as the `postgres` role: 5/5 statements succeeded).
- [ ] After this lands, run `supabase db reset` — confirm:
  - `select id, username, is_admin, is_super_admin from public.profiles where username = 'user_4f1fc348';` returns `t / t`.
  - Sign-in at `/login` with `leedium@me.com` / `localdev123` works.
  - `/admin` is reachable; super-admin past-lock writes (`admin_submit_predictions`) are honored.
- [ ] No prod impact: `seed.sql` is local-only and never runs against the linked Supabase project.