### PR TITLE
feat(admin): clear/deselect affordance on results forms

### DIFF
--- a/frontend/src/app/admin/advancers/AdvancersForm.tsx
+++ b/frontend/src/app/admin/advancers/AdvancersForm.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, Lock, Unlock } from 'lucide-react';
+import { CheckCircle2, Lock, Unlock, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
@@ -122,6 +122,24 @@ export function AdvancersForm() {
     }
   };
 
+  const clearSlot = async (slotIndex: number) => {
+    if (!tournamentId) return;
+    try {
+      const res = await fetch('/api/admin/third-place-advancers', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tournamentId, slotIndex }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(String(body.error ?? 'Failed'));
+      }
+      await queryClient.invalidateQueries({ queryKey: ['admin-advancers'] });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed');
+    }
+  };
+
   const togglePhaseTwo = async (unlock: boolean) => {
     if (!tournamentId) return;
     setBusy(true);
@@ -198,34 +216,48 @@ export function AdvancersForm() {
                   </p>
                 </CardHeader>
                 <CardContent>
-                  <Select
-                    value={pick?.groupLetter ?? ''}
-                    onValueChange={(v) => setSlot(slot.slotIndex, v)}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Pick a group" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {slot.allowedLetters.map((letter) => {
-                        const team = thirdByGroup.get(letter);
-                        return (
-                          <SelectItem key={letter} value={letter}>
-                            {team ? (
-                              <span className="flex items-center gap-2">
-                                <TeamFlag code={team.code} />
-                                <span className="text-muted-foreground font-mono text-xs">
-                                  {letter}
+                  <div className="flex items-center gap-1">
+                    <Select
+                      value={pick?.groupLetter ?? ''}
+                      onValueChange={(v) => setSlot(slot.slotIndex, v)}
+                    >
+                      <SelectTrigger className="flex-1">
+                        <SelectValue placeholder="Pick a group" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {slot.allowedLetters.map((letter) => {
+                          const team = thirdByGroup.get(letter);
+                          return (
+                            <SelectItem key={letter} value={letter}>
+                              {team ? (
+                                <span className="flex items-center gap-2">
+                                  <TeamFlag code={team.code} />
+                                  <span className="text-muted-foreground font-mono text-xs">
+                                    {letter}
+                                  </span>
+                                  <span>{team.name}</span>
                                 </span>
-                                <span>{team.name}</span>
-                              </span>
-                            ) : (
-                              <>Group {letter}</>
-                            )}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                              ) : (
+                                <>Group {letter}</>
+                              )}
+                            </SelectItem>
+                          );
+                        })}
+                      </SelectContent>
+                    </Select>
+                    {pick ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-9 w-9 shrink-0"
+                        aria-label={`Clear slot ${slot.slotIndex + 1}`}
+                        onClick={() => clearSlot(slot.slotIndex)}
+                      >
+                        <X className="h-4 w-4" aria-hidden />
+                      </Button>
+                    ) : null}
+                  </div>
                 </CardContent>
               </Card>
             );

--- a/frontend/src/app/admin/advancers/AdvancersForm.tsx
+++ b/frontend/src/app/admin/advancers/AdvancersForm.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, Lock, Unlock, X } from 'lucide-react';
+import { CheckCircle2, Lock, Unlock } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
@@ -26,6 +26,9 @@ interface AdvancersResponse {
   tournamentId: string;
   advancers: Array<{ slotIndex: number; groupLetter: string }>;
 }
+
+// Sentinel for the admin-only "(none)" SelectItem (Radix forbids empty values).
+const CLEAR_VALUE = '__CLEAR__';
 
 interface TournamentResponse {
   id: string;
@@ -216,48 +219,45 @@ export function AdvancersForm() {
                   </p>
                 </CardHeader>
                 <CardContent>
-                  <div className="flex items-center gap-1">
-                    <Select
-                      value={pick?.groupLetter ?? ''}
-                      onValueChange={(v) => setSlot(slot.slotIndex, v)}
-                    >
-                      <SelectTrigger className="flex-1">
-                        <SelectValue placeholder="Pick a group" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {slot.allowedLetters.map((letter) => {
-                          const team = thirdByGroup.get(letter);
-                          return (
-                            <SelectItem key={letter} value={letter}>
-                              {team ? (
-                                <span className="flex items-center gap-2">
-                                  <TeamFlag code={team.code} />
-                                  <span className="text-muted-foreground font-mono text-xs">
-                                    {letter}
-                                  </span>
-                                  <span>{team.name}</span>
+                  <Select
+                    value={pick?.groupLetter ?? ''}
+                    onValueChange={(v) => {
+                      if (v === CLEAR_VALUE) {
+                        void clearSlot(slot.slotIndex);
+                        return;
+                      }
+                      void setSlot(slot.slotIndex, v);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Pick a group" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {pick ? (
+                        <SelectItem value={CLEAR_VALUE}>
+                          <span className="text-muted-foreground">(none)</span>
+                        </SelectItem>
+                      ) : null}
+                      {slot.allowedLetters.map((letter) => {
+                        const team = thirdByGroup.get(letter);
+                        return (
+                          <SelectItem key={letter} value={letter}>
+                            {team ? (
+                              <span className="flex items-center gap-2">
+                                <TeamFlag code={team.code} />
+                                <span className="text-muted-foreground font-mono text-xs">
+                                  {letter}
                                 </span>
-                              ) : (
-                                <>Group {letter}</>
-                              )}
-                            </SelectItem>
-                          );
-                        })}
-                      </SelectContent>
-                    </Select>
-                    {pick ? (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-9 w-9 shrink-0"
-                        aria-label={`Clear slot ${slot.slotIndex + 1}`}
-                        onClick={() => clearSlot(slot.slotIndex)}
-                      >
-                        <X className="h-4 w-4" aria-hidden />
-                      </Button>
-                    ) : null}
-                  </div>
+                                <span>{team.name}</span>
+                              </span>
+                            ) : (
+                              <>Group {letter}</>
+                            )}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
                 </CardContent>
               </Card>
             );

--- a/frontend/src/app/admin/results/GroupStandingsEditor.tsx
+++ b/frontend/src/app/admin/results/GroupStandingsEditor.tsx
@@ -86,7 +86,42 @@ export function GroupStandingsEditor({
     position: GroupPositionKey,
     teamId: string | null
   ) => {
+    if (teamId === null) {
+      // Admin picked the "(none)" entry — revert the whole group standing.
+      // No-op for groups that were never saved.
+      if (submittedById.has(groupId)) {
+        void clearGroup(groupId);
+      } else {
+        setPredictions((prev) =>
+          prev.map((p) =>
+            p.groupId === groupId
+              ? { groupId, positions: { first: null, second: null, third: null, fourth: null } }
+              : p
+          )
+        );
+      }
+      return;
+    }
     setPredictions((prev) => applyGroupPositionChange(prev, groupId, position, teamId));
+  };
+
+  const clearGroup = async (groupId: string) => {
+    try {
+      const res = await fetch('/api/admin/group-standings', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tournamentId, groupId }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? 'Failed to clear');
+      }
+      toast.success(`Group ${groupId} cleared`);
+      await queryClient.invalidateQueries({ queryKey: ['group-standings', tournamentId] });
+      await queryClient.invalidateQueries({ queryKey: ['leaderboard', 1] });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to clear');
+    }
   };
 
   const handleSave = async (groupId: string) => {

--- a/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
+++ b/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { X } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -159,40 +160,84 @@ export function KnockoutResultsEditor({
                       </div>
                     </div>
                     <div className="grid gap-2 sm:grid-cols-3">
-                      <Select
-                        value={p.winner}
-                        onValueChange={(v) =>
-                          setPicks((prev) => ({ ...prev, [m.id]: { ...prev[m.id], winner: v } }))
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Winner" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {teams.map((t) => (
-                            <SelectItem key={t.id} value={t.id}>
-                              {t.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Select
-                        value={p.loser}
-                        onValueChange={(v) =>
-                          setPicks((prev) => ({ ...prev, [m.id]: { ...prev[m.id], loser: v } }))
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Loser" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {teams.map((t) => (
-                            <SelectItem key={t.id} value={t.id}>
-                              {t.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <div className="flex items-center gap-1">
+                        <Select
+                          value={p.winner}
+                          onValueChange={(v) =>
+                            setPicks((prev) => ({
+                              ...prev,
+                              [m.id]: { ...prev[m.id], winner: v },
+                            }))
+                          }
+                        >
+                          <SelectTrigger className="flex-1">
+                            <SelectValue placeholder="Winner" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {teams.map((t) => (
+                              <SelectItem key={t.id} value={t.id}>
+                                {t.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        {p.winner ? (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-9 w-9 shrink-0"
+                            aria-label="Clear winner"
+                            onClick={() =>
+                              setPicks((prev) => ({
+                                ...prev,
+                                [m.id]: { ...prev[m.id], winner: '' },
+                              }))
+                            }
+                          >
+                            <X className="h-4 w-4" aria-hidden />
+                          </Button>
+                        ) : null}
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <Select
+                          value={p.loser}
+                          onValueChange={(v) =>
+                            setPicks((prev) => ({
+                              ...prev,
+                              [m.id]: { ...prev[m.id], loser: v },
+                            }))
+                          }
+                        >
+                          <SelectTrigger className="flex-1">
+                            <SelectValue placeholder="Loser" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {teams.map((t) => (
+                              <SelectItem key={t.id} value={t.id}>
+                                {t.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        {p.loser ? (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-9 w-9 shrink-0"
+                            aria-label="Clear loser"
+                            onClick={() =>
+                              setPicks((prev) => ({
+                                ...prev,
+                                [m.id]: { ...prev[m.id], loser: '' },
+                              }))
+                            }
+                          >
+                            <X className="h-4 w-4" aria-hidden />
+                          </Button>
+                        ) : null}
+                      </div>
                       <Input
                         placeholder="Goals"
                         type="number"

--- a/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
+++ b/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { X } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -39,6 +38,10 @@ interface MatchPicks {
   totalGoals: string;
 }
 const EMPTY: MatchPicks = { winner: '', loser: '', totalGoals: '' };
+
+// Sentinel for the admin-only "(none)" SelectItem. Radix forbids empty-string
+// item values, so we intercept this in onValueChange and fire a DELETE.
+const CLEAR_VALUE = '__CLEAR__';
 
 export function KnockoutResultsEditor({
   tournamentId,
@@ -86,6 +89,27 @@ export function KnockoutResultsEditor({
     }
     setPicks(next);
   }, [matches, submittedById]);
+
+  const handleClear = async (matchId: string) => {
+    setPicks((prev) => ({ ...prev, [matchId]: EMPTY }));
+    if (!submittedById.has(matchId)) return;
+    try {
+      const res = await fetch('/api/admin/knockout-results', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tournamentId, matchId }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? 'Failed to clear');
+      }
+      toast.success(`Match ${matchId} cleared`);
+      await queryClient.invalidateQueries({ queryKey: ['knockout-results', tournamentId] });
+      await queryClient.invalidateQueries({ queryKey: ['leaderboard', 1] });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to clear');
+    }
+  };
 
   const handleSave = async (matchId: string) => {
     const p = picks[matchId];
@@ -160,84 +184,64 @@ export function KnockoutResultsEditor({
                       </div>
                     </div>
                     <div className="grid gap-2 sm:grid-cols-3">
-                      <div className="flex items-center gap-1">
-                        <Select
-                          value={p.winner}
-                          onValueChange={(v) =>
-                            setPicks((prev) => ({
-                              ...prev,
-                              [m.id]: { ...prev[m.id], winner: v },
-                            }))
+                      <Select
+                        value={p.winner}
+                        onValueChange={(v) => {
+                          if (v === CLEAR_VALUE) {
+                            void handleClear(m.id);
+                            return;
                           }
-                        >
-                          <SelectTrigger className="flex-1">
-                            <SelectValue placeholder="Winner" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {teams.map((t) => (
-                              <SelectItem key={t.id} value={t.id}>
-                                {t.name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        {p.winner ? (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            className="h-9 w-9 shrink-0"
-                            aria-label="Clear winner"
-                            onClick={() =>
-                              setPicks((prev) => ({
-                                ...prev,
-                                [m.id]: { ...prev[m.id], winner: '' },
-                              }))
-                            }
-                          >
-                            <X className="h-4 w-4" aria-hidden />
-                          </Button>
-                        ) : null}
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <Select
-                          value={p.loser}
-                          onValueChange={(v) =>
-                            setPicks((prev) => ({
-                              ...prev,
-                              [m.id]: { ...prev[m.id], loser: v },
-                            }))
+                          setPicks((prev) => ({
+                            ...prev,
+                            [m.id]: { ...prev[m.id], winner: v },
+                          }));
+                        }}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Winner" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {p.winner ? (
+                            <SelectItem value={CLEAR_VALUE}>
+                              <span className="text-muted-foreground">(none)</span>
+                            </SelectItem>
+                          ) : null}
+                          {teams.map((t) => (
+                            <SelectItem key={t.id} value={t.id}>
+                              {t.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={p.loser}
+                        onValueChange={(v) => {
+                          if (v === CLEAR_VALUE) {
+                            void handleClear(m.id);
+                            return;
                           }
-                        >
-                          <SelectTrigger className="flex-1">
-                            <SelectValue placeholder="Loser" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {teams.map((t) => (
-                              <SelectItem key={t.id} value={t.id}>
-                                {t.name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        {p.loser ? (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            className="h-9 w-9 shrink-0"
-                            aria-label="Clear loser"
-                            onClick={() =>
-                              setPicks((prev) => ({
-                                ...prev,
-                                [m.id]: { ...prev[m.id], loser: '' },
-                              }))
-                            }
-                          >
-                            <X className="h-4 w-4" aria-hidden />
-                          </Button>
-                        ) : null}
-                      </div>
+                          setPicks((prev) => ({
+                            ...prev,
+                            [m.id]: { ...prev[m.id], loser: v },
+                          }));
+                        }}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Loser" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {p.loser ? (
+                            <SelectItem value={CLEAR_VALUE}>
+                              <span className="text-muted-foreground">(none)</span>
+                            </SelectItem>
+                          ) : null}
+                          {teams.map((t) => (
+                            <SelectItem key={t.id} value={t.id}>
+                              {t.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                       <Input
                         placeholder="Goals"
                         type="number"

--- a/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
+++ b/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
@@ -5,7 +5,6 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -14,13 +13,34 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import type { KnockoutMatch, Team } from '@/types/tournament';
+import { TeamFlag } from '@/components/shared/TeamFlag';
+import { resolveTeamSource } from '@/lib/knockoutResolver';
+import type {
+  BundlePrediction,
+  GroupPrediction,
+  KnockoutMatch,
+  KnockoutMatchPrediction,
+  Team,
+} from '@/types/tournament';
 
 interface KnockoutResultRow {
   match_id: string;
   winner_team_id: string;
   loser_team_id: string;
   total_goals: number | null;
+}
+
+interface GroupStandingRow {
+  group_id: string;
+  first_team_id: string | null;
+  second_team_id: string | null;
+  third_team_id: string | null;
+  fourth_team_id: string | null;
+}
+
+interface AdvancersResponse {
+  tournamentId: string;
+  advancers: Array<{ slotIndex: number; groupLetter: string }>;
 }
 
 const STAGE_LABELS: Record<KnockoutMatch['stage'], string> = {
@@ -32,15 +52,7 @@ const STAGE_LABELS: Record<KnockoutMatch['stage'], string> = {
   final: 'Final',
 };
 
-interface MatchPicks {
-  winner: string;
-  loser: string;
-  totalGoals: string;
-}
-const EMPTY: MatchPicks = { winner: '', loser: '', totalGoals: '' };
-
-// Sentinel for the admin-only "(none)" SelectItem. Radix forbids empty-string
-// item values, so we intercept this in onValueChange and fire a DELETE.
+// Sentinel for the admin-only "(none)" SelectItem (Radix forbids empty values).
 const CLEAR_VALUE = '__CLEAR__';
 
 export function KnockoutResultsEditor({
@@ -66,32 +78,105 @@ export function KnockoutResultsEditor({
     initialData: [],
   });
 
+  const standings = useQuery<GroupStandingRow[]>({
+    queryKey: ['group-standings', tournamentId],
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/group-standings?tournamentId=${tournamentId}`).catch(
+        () => null
+      );
+      if (res && res.ok) return res.json();
+      return [];
+    },
+    initialData: [],
+  });
+
+  const advancers = useQuery<AdvancersResponse>({
+    queryKey: ['admin-advancers'],
+    queryFn: async () => {
+      const res = await fetch('/api/admin/third-place-advancers').catch(() => null);
+      if (res && res.ok) return res.json();
+      return { tournamentId, advancers: [] };
+    },
+  });
+
   const submittedById = React.useMemo(() => {
     const map = new Map<string, KnockoutResultRow>();
     for (const r of results.data ?? []) map.set(r.match_id, r);
     return map;
   }, [results.data]);
 
-  const [picks, setPicks] = React.useState<Record<string, MatchPicks>>({});
+  // Adapt server rows to the shapes resolveTeamSource expects.
+  const groupPredictions: GroupPrediction[] = React.useMemo(
+    () =>
+      (standings.data ?? []).map((row) => ({
+        groupId: row.group_id,
+        positions: {
+          first: row.first_team_id,
+          second: row.second_team_id,
+          third: row.third_team_id,
+          fourth: row.fourth_team_id,
+        },
+      })),
+    [standings.data]
+  );
+
+  const knockoutPredictions: KnockoutMatchPrediction[] = React.useMemo(
+    () =>
+      (results.data ?? []).map((r) => ({
+        matchId: r.match_id,
+        winnerId: r.winner_team_id,
+      })),
+    [results.data]
+  );
+
+  const bundlePredictions: BundlePrediction[] = React.useMemo(
+    () => advancers.data?.advancers ?? [],
+    [advancers.data]
+  );
+
+  const teamById = React.useMemo(() => {
+    const map = new Map<string, Team>();
+    for (const t of teams) map.set(t.id, t);
+    return map;
+  }, [teams]);
+
+  // For each match, resolve the two teams that will actually play.
+  const resolvedPairs = React.useMemo(() => {
+    const map = new Map<string, { team1Id: string | null; team2Id: string | null }>();
+    for (const m of matches) {
+      map.set(m.id, {
+        team1Id: resolveTeamSource(
+          m.team1Source,
+          matches,
+          groupPredictions,
+          knockoutPredictions,
+          bundlePredictions
+        ),
+        team2Id: resolveTeamSource(
+          m.team2Source,
+          matches,
+          groupPredictions,
+          knockoutPredictions,
+          bundlePredictions
+        ),
+      });
+    }
+    return map;
+  }, [matches, groupPredictions, knockoutPredictions, bundlePredictions]);
+
+  const [picks, setPicks] = React.useState<Record<string, string>>({});
   const [savingId, setSavingId] = React.useState<string | null>(null);
 
   React.useEffect(() => {
-    const next: Record<string, MatchPicks> = {};
+    const next: Record<string, string> = {};
     for (const m of matches) {
-      const r = submittedById.get(m.id);
-      next[m.id] = r
-        ? {
-            winner: r.winner_team_id,
-            loser: r.loser_team_id,
-            totalGoals: r.total_goals != null ? String(r.total_goals) : '',
-          }
-        : EMPTY;
+      next[m.id] = submittedById.get(m.id)?.winner_team_id ?? '';
     }
     setPicks(next);
   }, [matches, submittedById]);
 
   const handleClear = async (matchId: string) => {
-    setPicks((prev) => ({ ...prev, [matchId]: EMPTY }));
+    setPicks((prev) => ({ ...prev, [matchId]: '' }));
     if (!submittedById.has(matchId)) return;
     try {
       const res = await fetch('/api/admin/knockout-results', {
@@ -112,12 +197,14 @@ export function KnockoutResultsEditor({
   };
 
   const handleSave = async (matchId: string) => {
-    const p = picks[matchId];
-    if (!p || !p.winner || !p.loser) {
-      toast.error('Winner and loser are required');
+    const winner = picks[matchId];
+    const pair = resolvedPairs.get(matchId);
+    if (!winner || !pair?.team1Id || !pair?.team2Id) {
+      toast.error('Pick a winner first');
       return;
     }
-    if (p.winner === p.loser) {
+    const loser = pair.team1Id === winner ? pair.team2Id : pair.team1Id;
+    if (winner === loser) {
       toast.error('Winner and loser must differ');
       return;
     }
@@ -129,9 +216,9 @@ export function KnockoutResultsEditor({
         body: JSON.stringify({
           tournamentId,
           matchId,
-          winnerTeamId: p.winner,
-          loserTeamId: p.loser,
-          totalGoals: p.totalGoals ? Number(p.totalGoals) : null,
+          winnerTeamId: winner,
+          loserTeamId: loser,
+          totalGoals: null,
         }),
       });
       if (!res.ok) {
@@ -165,8 +252,13 @@ export function KnockoutResultsEditor({
           <h3 className="mb-3 text-lg font-semibold">{STAGE_LABELS[stage]}</h3>
           <div className="grid gap-3 md:grid-cols-2">
             {stageMatches.map((m) => {
-              const p = picks[m.id] ?? EMPTY;
+              const winner = picks[m.id] ?? '';
               const submitted = submittedById.has(m.id);
+              const pair = resolvedPairs.get(m.id);
+              const team1 = pair?.team1Id ? teamById.get(pair.team1Id) : undefined;
+              const team2 = pair?.team2Id ? teamById.get(pair.team2Id) : undefined;
+              const bothResolved = !!team1 && !!team2;
+
               return (
                 <Card key={m.id}>
                   <CardContent className="space-y-2 p-4">
@@ -183,82 +275,51 @@ export function KnockoutResultsEditor({
                         )}
                       </div>
                     </div>
-                    <div className="grid gap-2 sm:grid-cols-3">
+                    {bothResolved ? (
                       <Select
-                        value={p.winner}
+                        value={winner}
                         onValueChange={(v) => {
                           if (v === CLEAR_VALUE) {
                             void handleClear(m.id);
                             return;
                           }
-                          setPicks((prev) => ({
-                            ...prev,
-                            [m.id]: { ...prev[m.id], winner: v },
-                          }));
+                          setPicks((prev) => ({ ...prev, [m.id]: v }));
                         }}
                       >
                         <SelectTrigger>
-                          <SelectValue placeholder="Winner" />
+                          <SelectValue placeholder="Pick winner" />
                         </SelectTrigger>
                         <SelectContent>
-                          {p.winner ? (
+                          {winner ? (
                             <SelectItem value={CLEAR_VALUE}>
                               <span className="text-muted-foreground">(none)</span>
                             </SelectItem>
                           ) : null}
-                          {teams.map((t) => (
-                            <SelectItem key={t.id} value={t.id}>
-                              {t.name}
-                            </SelectItem>
-                          ))}
+                          {[team1, team2].map((t) =>
+                            t ? (
+                              <SelectItem key={t.id} value={t.id}>
+                                <span className="flex items-center gap-2">
+                                  <TeamFlag code={t.code} />
+                                  <span className="text-muted-foreground font-mono text-xs">
+                                    {t.code}
+                                  </span>
+                                  <span>{t.name}</span>
+                                </span>
+                              </SelectItem>
+                            ) : null
+                          )}
                         </SelectContent>
                       </Select>
-                      <Select
-                        value={p.loser}
-                        onValueChange={(v) => {
-                          if (v === CLEAR_VALUE) {
-                            void handleClear(m.id);
-                            return;
-                          }
-                          setPicks((prev) => ({
-                            ...prev,
-                            [m.id]: { ...prev[m.id], loser: v },
-                          }));
-                        }}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Loser" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {p.loser ? (
-                            <SelectItem value={CLEAR_VALUE}>
-                              <span className="text-muted-foreground">(none)</span>
-                            </SelectItem>
-                          ) : null}
-                          {teams.map((t) => (
-                            <SelectItem key={t.id} value={t.id}>
-                              {t.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Input
-                        placeholder="Goals"
-                        type="number"
-                        value={p.totalGoals}
-                        onChange={(e) =>
-                          setPicks((prev) => ({
-                            ...prev,
-                            [m.id]: { ...prev[m.id], totalGoals: e.target.value },
-                          }))
-                        }
-                      />
-                    </div>
+                    ) : (
+                      <p className="text-muted-foreground bg-muted/40 rounded-md border px-3 py-2 text-xs">
+                        TBD — set the earlier results that feed this match first.
+                      </p>
+                    )}
                     <Button
                       size="sm"
                       className="w-full"
                       onClick={() => handleSave(m.id)}
-                      disabled={savingId === m.id}
+                      disabled={savingId === m.id || !winner || !bothResolved}
                     >
                       {savingId === m.id ? 'Saving…' : submitted ? 'Update' : 'Save'}
                     </Button>

--- a/frontend/src/app/api/admin/group-standings/route.ts
+++ b/frontend/src/app/api/admin/group-standings/route.ts
@@ -11,6 +11,11 @@ interface Body {
   fourth?: string;
 }
 
+interface DeleteBody {
+  tournamentId?: string;
+  groupId?: string;
+}
+
 export async function GET(request: NextRequest) {
   const ctx = await requireAdmin();
   if (isAdminGateError(ctx)) return ctx.response;
@@ -52,6 +57,27 @@ export async function POST(request: NextRequest) {
     p_second: body.second,
     p_third: body.third,
     p_fourth: body.fourth,
+  });
+
+  if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json().catch(() => ({}))) as DeleteBody;
+  if (!body.tournamentId || !body.groupId) {
+    return NextResponse.json(
+      { error: 'tournamentId and groupId are required' },
+      { status: 400 }
+    );
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_clear_group_standing', {
+    p_tournament_id: body.tournamentId,
+    p_group_id: body.groupId,
   });
 
   if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 400 });

--- a/frontend/src/app/api/admin/knockout-results/route.ts
+++ b/frontend/src/app/api/admin/knockout-results/route.ts
@@ -10,6 +10,11 @@ interface Body {
   totalGoals?: number | null;
 }
 
+interface DeleteBody {
+  tournamentId?: string;
+  matchId?: string;
+}
+
 export async function GET(request: NextRequest) {
   const ctx = await requireAdmin();
   if (isAdminGateError(ctx)) return ctx.response;
@@ -47,6 +52,27 @@ export async function POST(request: NextRequest) {
     p_winner_team_id: body.winnerTeamId,
     p_loser_team_id: body.loserTeamId,
     p_total_goals: body.totalGoals ?? null,
+  });
+
+  if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json().catch(() => ({}))) as DeleteBody;
+  if (!body.tournamentId || !body.matchId) {
+    return NextResponse.json(
+      { error: 'tournamentId and matchId are required' },
+      { status: 400 }
+    );
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_clear_knockout_result', {
+    p_tournament_id: body.tournamentId,
+    p_match_id: body.matchId,
   });
 
   if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 400 });

--- a/frontend/src/app/api/admin/third-place-advancers/route.ts
+++ b/frontend/src/app/api/admin/third-place-advancers/route.ts
@@ -8,6 +8,11 @@ interface PatchBody {
   groupLetter?: string;
 }
 
+interface DeleteBody {
+  tournamentId?: string;
+  slotIndex?: number;
+}
+
 export async function GET() {
   const ctx = await requireAdmin();
   if (isAdminGateError(ctx)) return ctx.response;
@@ -60,6 +65,28 @@ export async function PATCH(request: NextRequest) {
     const msg = error.message ?? '';
     const status = msg.includes('unknown bundle slot') ? 404 : 400;
     return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+  return NextResponse.json({ success: true });
+}
+
+export async function DELETE(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json().catch(() => ({}))) as DeleteBody;
+  if (!body.tournamentId) {
+    return NextResponse.json({ error: 'tournamentId is required' }, { status: 400 });
+  }
+  if (typeof body.slotIndex !== 'number' || body.slotIndex < 0 || body.slotIndex > 7) {
+    return NextResponse.json({ error: 'slotIndex must be 0-7' }, { status: 400 });
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_clear_third_place_advancer', {
+    p_tournament_id: body.tournamentId,
+    p_slot_index: body.slotIndex,
+  });
+  if (error) {
+    return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
   }
   return NextResponse.json({ success: true });
 }

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -450,8 +450,21 @@ export function PredictionsPageContent({
   const isBracketComplete =
     totalKnockoutMatches > 0 && completedKnockoutMatches === totalKnockoutMatches;
   const isTiebreakerComplete = totalGoals !== null;
-  const isPredictionsComplete =
-    isGroupsComplete && isBundlesComplete && isBracketComplete && isTiebreakerComplete;
+
+  // Which fields the current submit can actually accept depends on phase. The
+  // server-side RPC (submit_predictions in 0022) raises 'phase 1 only fields
+  // allowed' if a phase-1 payload includes knockout or total_goals, and
+  // 'phase 1 ended; group + bundle picks are frozen' on the inverse — so the
+  // wizard has to gate completeness on the same partition. Routes that go
+  // through admin_submit_predictions (super admin editing themselves in non-
+  // phase-1 phases, or any admin editing a user) bypass the guard and need
+  // everything filled to count as complete.
+  const usesAdminRoute = effectiveApiBasePath.startsWith('/api/admin/');
+  const isPredictionsComplete = usesAdminRoute
+    ? isGroupsComplete && isBundlesComplete && isBracketComplete && isTiebreakerComplete
+    : phase === 'phase2_open'
+      ? isBracketComplete && isTiebreakerComplete
+      : isGroupsComplete && isBundlesComplete;
 
   const trimmedName = predictionName.trim();
   const nameError =
@@ -671,26 +684,37 @@ export function PredictionsPageContent({
     if (markSubmitted) setIsSubmitting(true);
     else setIsSavingProgress(true);
     try {
+      // Phase-aware payload. The RPC rejects mismatched fields (see the
+      // matching gate around isPredictionsComplete above). Admin route
+      // (admin_submit_predictions) has no phase guards, so send everything.
+      const sendPhase1Fields = usesAdminRoute || phase === 'phase1';
+      const sendPhase2Fields = usesAdminRoute || phase === 'phase2_open';
       const body = {
         tournamentId: tournament.id,
         predictionName: trimmedName,
-        totalGoals,
+        totalGoals: sendPhase2Fields ? totalGoals : null,
         submit: markSubmitted,
-        groups: groupPredictions.map((g) => ({
-          groupId: g.groupId,
-          first: g.positions.first,
-          second: g.positions.second,
-          third: g.positions.third,
-          fourth: g.positions.fourth,
-        })),
-        knockout: knockoutPredictions.map((k) => ({
-          matchId: k.matchId,
-          winner: k.winnerId,
-        })),
-        bundles: bundlePredictions.map((b) => ({
-          slotIndex: b.slotIndex,
-          groupLetter: b.groupLetter,
-        })),
+        groups: sendPhase1Fields
+          ? groupPredictions.map((g) => ({
+              groupId: g.groupId,
+              first: g.positions.first,
+              second: g.positions.second,
+              third: g.positions.third,
+              fourth: g.positions.fourth,
+            }))
+          : [],
+        knockout: sendPhase2Fields
+          ? knockoutPredictions.map((k) => ({
+              matchId: k.matchId,
+              winner: k.winnerId,
+            }))
+          : [],
+        bundles: sendPhase1Fields
+          ? bundlePredictions.map((b) => ({
+              slotIndex: b.slotIndex,
+              groupLetter: b.groupLetter,
+            }))
+          : [],
       };
 
       const url =

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import * as React from 'react';
-import { CheckCircle2, Circle, X } from 'lucide-react';
+import { CheckCircle2, Circle } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Select,
@@ -16,6 +15,11 @@ import {
 import { TeamFlag } from '@/components/shared/TeamFlag';
 import { cn } from '@/lib/utils';
 import type { Group, GroupPrediction, Team } from '@/types/tournament';
+
+// Sentinel value for the admin-only "(none)" SelectItem. Radix Select forbids
+// empty-string item values, so we route this through onValueChange and translate
+// it back to null when calling onPositionChange.
+const CLEAR_VALUE = '__CLEAR__';
 
 // Position labels for display
 const POSITION_LABELS = {
@@ -127,7 +131,9 @@ function GroupCard({
               </span>
               <Select
                 value={selectedValue ?? ''}
-                onValueChange={(value) => onPositionChange(position, value || null)}
+                onValueChange={(value) =>
+                  onPositionChange(position, value === CLEAR_VALUE ? null : value || null)
+                }
                 disabled={disabled || isAutoFilled}
               >
                 <SelectTrigger
@@ -137,6 +143,11 @@ function GroupCard({
                   <SelectValue placeholder="Select team" />
                 </SelectTrigger>
                 <SelectContent>
+                  {showClear && !isAutoFilled && selectedValue ? (
+                    <SelectItem value={CLEAR_VALUE}>
+                      <span className="text-muted-foreground">(none)</span>
+                    </SelectItem>
+                  ) : null}
                   {availableTeams.map((team) => (
                     <SelectItem key={team.id} value={team.id}>
                       <span className="flex items-center gap-2">
@@ -148,18 +159,6 @@ function GroupCard({
                   ))}
                 </SelectContent>
               </Select>
-              {showClear && !disabled && !isAutoFilled && selectedValue ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-9 w-9 shrink-0"
-                  aria-label={`Clear ${POSITION_LABELS[position]} place`}
-                  onClick={() => onPositionChange(position, null)}
-                >
-                  <X className="h-4 w-4" aria-hidden />
-                </Button>
-              ) : null}
             </div>
           );
         })}

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import * as React from 'react';
-import { CheckCircle2, Circle } from 'lucide-react';
+import { CheckCircle2, Circle, X } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Select,
@@ -55,12 +56,14 @@ function GroupCard({
   onPositionChange,
   disabled,
   extra,
+  showClear,
 }: {
   group: Group;
   prediction: GroupPrediction;
   onPositionChange: (position: PositionKey, teamId: string | null) => void;
   disabled?: boolean;
   extra?: React.ReactNode;
+  showClear?: boolean;
 }) {
   // Get selected team IDs for this group
   const selectedTeamIds = new Set(
@@ -145,6 +148,18 @@ function GroupCard({
                   ))}
                 </SelectContent>
               </Select>
+              {showClear && !disabled && !isAutoFilled && selectedValue ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 shrink-0"
+                  aria-label={`Clear ${POSITION_LABELS[position]} place`}
+                  onClick={() => onPositionChange(position, null)}
+                >
+                  <X className="h-4 w-4" aria-hidden />
+                </Button>
+              ) : null}
             </div>
           );
         })}
@@ -227,6 +242,7 @@ export function GroupStageForm({
               }
               disabled={disabled}
               extra={extraPerCard?.(group.id)}
+              showClear={isAdmin}
             />
           );
         })}

--- a/supabase/migrations/0023_admin_clear_third_place_advancer.sql
+++ b/supabase/migrations/0023_admin_clear_third_place_advancer.sql
@@ -1,0 +1,26 @@
+-- Admin "clear" path for R32 best-third advancer slots.
+--
+-- Mirrors admin_set_third_place_advancer (0022) but deletes the row instead of
+-- upserting, so an admin can revert a slot back to the unsubmitted state.
+
+create or replace function public.admin_clear_third_place_advancer(
+    p_tournament_id uuid,
+    p_slot_index int
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    delete from public.tournament_third_place_advancers
+     where tournament_id = p_tournament_id
+       and slot_index = p_slot_index;
+end;
+$$;
+
+revoke all on function public.admin_clear_third_place_advancer(uuid, int) from public;
+grant execute on function public.admin_clear_third_place_advancer(uuid, int) to authenticated;

--- a/supabase/migrations/0024_admin_clear_results.sql
+++ b/supabase/migrations/0024_admin_clear_results.sql
@@ -1,0 +1,50 @@
+-- Admin "clear" paths for group standings + knockout results.
+--
+-- Mirrors admin_set_group_standing / admin_set_knockout_result (0005) but
+-- DELETEs the row instead of upserting. Lets admins revert a saved result
+-- back to the unsubmitted state directly from the form's Select (the empty
+-- "(none)" entry fires this RPC).
+
+create or replace function public.admin_clear_group_standing(
+    p_tournament_id uuid,
+    p_group_id text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    delete from public.group_standings
+     where tournament_id = p_tournament_id
+       and group_id = p_group_id;
+end;
+$$;
+
+revoke all on function public.admin_clear_group_standing(uuid, text) from public;
+grant execute on function public.admin_clear_group_standing(uuid, text) to authenticated;
+
+create or replace function public.admin_clear_knockout_result(
+    p_tournament_id uuid,
+    p_match_id text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    delete from public.knockout_results
+     where tournament_id = p_tournament_id
+       and match_id = p_match_id;
+end;
+$$;
+
+revoke all on function public.admin_clear_knockout_result(uuid, text) from public;
+grant execute on function public.admin_clear_knockout_result(uuid, text) to authenticated;


### PR DESCRIPTION
## Summary
- Adds a small **X** clear button next to each team/group `Select` in the three admin results editors so admins can revert a slot back to the empty placeholder if a wrong pick was made.
- `GroupStageForm` gets the clear per position only when `variant='admin'`, the slot has a value, the form isn't disabled, and the slot isn't auto-filled (the leftover 4th place is derived from top-3 — clearing those clears it implicitly).
- `KnockoutResultsEditor` gets matching clears next to winner + loser; Save already requires both fields so cleared state simply disables Save until refilled.
- `AdvancersForm` persists on change with no Save buffer, so a UI-only clear isn't enough — adds a new `admin_clear_third_place_advancer(tournament_id, slot_index)` RPC (0023 migration) and a `DELETE` method on `/api/admin/third-place-advancers` that the clear button invokes.
- User-side prediction flows are untouched (`variant='predict'` doesn't render the clear button).

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — 37 suites / 282 tests pass
- [x] `eslint` clean on changed files
- [ ] `supabase db reset` to apply 0023; sign in as admin
  - [ ] **Group Standings:** pick 1/2/3, watch 4 auto-fill, click clear on 2nd → 2nd empties and 4th un-auto-fills; refill → Save works
  - [ ] **Knockout Results:** save winner+loser+goals; clear winner → Save disables; refill → Save persists
  - [ ] **Advancers:** set a slot's group letter; click clear → row deletes from `tournament_third_place_advancers`; pick again → row re-creates
- [ ] Sign in as non-admin → `/predictions/new` group form has no clear buttons (variant gate works)