### PR TITLE
fix(predictions): payment banner shows 'not paid' for paid predictions

### DIFF
--- a/frontend/src/app/admin/users/[id]/predictions/[predictionId]/page.tsx
+++ b/frontend/src/app/admin/users/[id]/predictions/[predictionId]/page.tsx
@@ -22,7 +22,7 @@ export default async function AdminEditPredictionPage({
   const { data: prediction } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, total_goals, submitted_at, tournament_payments(paid_at)'
+      'id, prediction_name, total_goals, submitted_at, tournament_payments!prediction_id(paid_at)'
     )
     .eq('id', predictionId)
     .eq('user_id', id)
@@ -45,11 +45,20 @@ export default async function AdminEditPredictionPage({
       .eq('prediction_id', predictionId),
   ]);
 
+  // PostgREST returns a single object (not an array) when the embedded
+  // relation has a unique FK target — `tournament_payments.prediction_id`
+  // is UNIQUE, so it's 1:1. Handle both shapes to be safe.
+  type Payment = { paid_at: string | null };
   type Pred = typeof prediction & {
-    tournament_payments: Array<{ paid_at: string | null }> | null;
+    tournament_payments: Payment | Payment[] | null;
   };
   const p = prediction as Pred;
-  const payment = p.tournament_payments?.[0] ?? null;
+  const rawPayment = p.tournament_payments;
+  const payment: Payment | null = !rawPayment
+    ? null
+    : Array.isArray(rawPayment)
+      ? (rawPayment[0] ?? null)
+      : rawPayment;
 
   const initial: InitialPrediction = {
     id: p.id,

--- a/frontend/src/app/predictions/[id]/page.tsx
+++ b/frontend/src/app/predictions/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function EditPredictionPage({ params }: PageProps) {
   const { data: prediction } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, total_goals, submitted_at, tournament_payments(paid_at)'
+      'id, prediction_name, total_goals, submitted_at, tournament_payments!prediction_id(paid_at)'
     )
     .eq('id', id)
     .eq('user_id', user.id)
@@ -47,11 +47,20 @@ export default async function EditPredictionPage({ params }: PageProps) {
       .eq('prediction_id', id),
   ]);
 
+  // PostgREST returns a single object (not an array) when the embedded
+  // relation has a unique FK target — `tournament_payments.prediction_id`
+  // is UNIQUE, so it's 1:1. Handle both shapes to be safe.
+  type Payment = { paid_at: string | null };
   type Pred = typeof prediction & {
-    tournament_payments: Array<{ paid_at: string | null }> | null;
+    tournament_payments: Payment | Payment[] | null;
   };
   const p = prediction as Pred;
-  const payment = p.tournament_payments?.[0] ?? null;
+  const rawPayment = p.tournament_payments;
+  const payment: Payment | null = !rawPayment
+    ? null
+    : Array.isArray(rawPayment)
+      ? (rawPayment[0] ?? null)
+      : rawPayment;
 
   const initial: InitialPrediction = {
     id: p.id,


### PR DESCRIPTION
## Summary

The edit-prediction pages were always rendering the "Payment not recorded by lock time" banner — even for predictions an admin has marked as paid.

**Root cause**: `tournament_payments.prediction_id` has a `UNIQUE` constraint, so PostgREST returns the embedded payment row as a **single object**, not an array. Both server pages selected `tournament_payments(paid_at)` and cast the result to `Array<...>`, then read `[0]` — which on a plain object is `undefined`. `payment` collapsed to `null` → `isPaid=false`.

The API routes (`/api/predictions`, `/api/predictions/[id]`, the admin variants) already use the explicit hint `tournament_payments!prediction_id(...)` and handle both shapes — that's why the predictions list correctly shows the paid badge while the editor doesn't. This PR aligns the two server pages with the same pattern.

## Files

- `frontend/src/app/predictions/[id]/page.tsx`
- `frontend/src/app/admin/users/[id]/predictions/[predictionId]/page.tsx`

## Test plan

- [x] `npm run typecheck` — clean
- [ ] Edit a paid prediction in the wizard — banner should now read "Payment received" (or "Payment recorded after lock time" if paid late), never "Payment not recorded by lock time"
- [ ] Edit an unpaid prediction — banner behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)