### PR TITLE
feat(leaderboard): Preview Bracket button per row

### DIFF
--- a/frontend/src/app/api/leaderboard/prediction/[id]/route.ts
+++ b/frontend/src/app/api/leaderboard/prediction/[id]/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+interface RpcRow {
+  prediction_id: string;
+  prediction_name: string;
+  username: string;
+  total_goals: number | null;
+  submitted_at: string | null;
+  groups: Array<{
+    group_id: string;
+    first_team_id: string | null;
+    second_team_id: string | null;
+    third_team_id: string | null;
+    fourth_team_id: string | null;
+  }> | null;
+  knockout: Array<{ match_id: string; winner_team_id: string | null }> | null;
+  advancers: Array<{ rank: number; team_id: string }> | null;
+}
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const { id } = await context.params;
+  const supabase = await getServerSupabase();
+
+  // Require auth. The RPC enforces it too (auth.uid() is not null), but
+  // failing fast here gives a cleaner 401 instead of an empty result.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data, error } = await supabase.rpc('get_public_prediction', {
+    p_prediction_id: id,
+  });
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const rows = (data ?? []) as RpcRow[];
+  const row = rows[0];
+  if (!row) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    id: row.prediction_id,
+    name: row.prediction_name,
+    username: row.username,
+    totalGoals: row.total_goals,
+    submittedAt: row.submitted_at,
+    // The RPC only ever returns paid + submitted predictions, so these are
+    // always true. Kept for shape-compat with BracketPreviewDialog.
+    isPaid: true,
+    paidAt: null,
+    groups: (row.groups ?? []).map((g) => ({
+      groupId: g.group_id,
+      first: g.first_team_id,
+      second: g.second_team_id,
+      third: g.third_team_id,
+      fourth: g.fourth_team_id,
+    })),
+    knockout: (row.knockout ?? []).map((k) => ({
+      matchId: k.match_id,
+      winner: k.winner_team_id,
+    })),
+    advancers: (row.advancers ?? []).map((a) => ({
+      rank: a.rank,
+      teamId: a.team_id,
+    })),
+  });
+}

--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -179,6 +179,7 @@ export function LeaderboardPageContent() {
               entries={entries}
               currentUsername={currentUsername}
               highlightedRank={highlightedRank}
+              enablePreview={!!user}
             />
           )}
         </CardContent>

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { TrendingDown, TrendingUp, Minus, Trophy } from 'lucide-react';
+import * as React from 'react';
+import { Eye, TrendingDown, TrendingUp, Minus, Trophy } from 'lucide-react';
 import {
   Table,
   TableBody,
@@ -10,6 +11,8 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
 import { cn } from '@/lib/utils';
 import type { LeaderboardEntry } from '@/types/tournament';
 
@@ -18,6 +21,13 @@ export interface LeaderboardTableProps {
   currentUsername?: string | null;
   highlightedRank?: number | null;
   className?: string;
+  /**
+   * When true, render a Preview button per row that opens the bracket
+   * preview dialog. Server-side, the dialog only resolves the bracket for
+   * paid + submitted predictions, so all leaderboard rows are eligible.
+   * The route requires auth; gate the column visually too.
+   */
+  enablePreview?: boolean;
 }
 
 function getRankBadge(rank: number): { color: string; label: string } | null {
@@ -63,79 +73,111 @@ export function LeaderboardTable({
   currentUsername,
   highlightedRank,
   className,
+  enablePreview = false,
 }: LeaderboardTableProps) {
-  return (
-    <Table className={className}>
-      <TableHeader>
-        <TableRow>
-          <TableHead className="w-20">Rank</TableHead>
-          <TableHead>Player</TableHead>
-          <TableHead className="text-right">Points</TableHead>
-          <TableHead className="w-24 text-right">Change</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {entries.map((entry, index) => {
-          const isCurrentUser =
-            currentUsername && entry.username.toLowerCase() === currentUsername.toLowerCase();
-          const isHighlighted = highlightedRank && entry.rank === highlightedRank;
-          const rankBadge = getRankBadge(entry.rank);
-          const isEvenRow = index % 2 === 0;
+  const [previewId, setPreviewId] = React.useState<string | null>(null);
 
-          return (
-            <TableRow
-              key={entry.predictionId}
-              id={`rank-${entry.rank}`}
-              className={cn(
-                isEvenRow && 'bg-muted/30',
-                isCurrentUser && 'bg-primary/10 hover:bg-primary/15',
-                isHighlighted && 'ring-primary ring-2 ring-inset'
-              )}
-            >
-              <TableCell className="font-medium">
-                {rankBadge ? (
-                  <Badge className={cn('gap-1', rankBadge.color)}>
-                    <Trophy className="h-3 w-3" />
-                    {rankBadge.label}
-                  </Badge>
-                ) : (
-                  <span className="text-muted-foreground">{entry.rank}</span>
+  const colCount = enablePreview ? 5 : 4;
+
+  return (
+    <>
+      <Table className={className}>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-20">Rank</TableHead>
+            <TableHead>Player</TableHead>
+            <TableHead className="text-right">Points</TableHead>
+            <TableHead className="w-24 text-right">Change</TableHead>
+            {enablePreview && <TableHead className="w-24 text-right">Bracket</TableHead>}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {entries.map((entry, index) => {
+            const isCurrentUser =
+              currentUsername && entry.username.toLowerCase() === currentUsername.toLowerCase();
+            const isHighlighted = highlightedRank && entry.rank === highlightedRank;
+            const rankBadge = getRankBadge(entry.rank);
+            const isEvenRow = index % 2 === 0;
+
+            return (
+              <TableRow
+                key={entry.predictionId}
+                id={`rank-${entry.rank}`}
+                className={cn(
+                  isEvenRow && 'bg-muted/30',
+                  isCurrentUser && 'bg-primary/10 hover:bg-primary/15',
+                  isHighlighted && 'ring-primary ring-2 ring-inset'
                 )}
-              </TableCell>
-              <TableCell>
-                <div className="flex flex-col">
-                  <span
-                    className={cn(
-                      'text-sm font-medium',
-                      isCurrentUser && 'text-primary font-semibold'
-                    )}
-                  >
-                    {entry.predictionName}
-                    {isCurrentUser && (
-                      <span className="text-muted-foreground ml-2 text-xs">(You)</span>
-                    )}
-                  </span>
-                  <span className="text-muted-foreground text-xs">{entry.username}</span>
-                </div>
-              </TableCell>
-              <TableCell className="text-right">
-                <span className="font-semibold">{entry.points}</span>
-                <span className="text-muted-foreground ml-1 text-xs">pts</span>
-              </TableCell>
-              <TableCell className="text-right">
-                <ChangeIndicator change={entry.change} />
+              >
+                <TableCell className="font-medium">
+                  {rankBadge ? (
+                    <Badge className={cn('gap-1', rankBadge.color)}>
+                      <Trophy className="h-3 w-3" />
+                      {rankBadge.label}
+                    </Badge>
+                  ) : (
+                    <span className="text-muted-foreground">{entry.rank}</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-col">
+                    <span
+                      className={cn(
+                        'text-sm font-medium',
+                        isCurrentUser && 'text-primary font-semibold'
+                      )}
+                    >
+                      {entry.predictionName}
+                      {isCurrentUser && (
+                        <span className="text-muted-foreground ml-2 text-xs">(You)</span>
+                      )}
+                    </span>
+                    <span className="text-muted-foreground text-xs">{entry.username}</span>
+                  </div>
+                </TableCell>
+                <TableCell className="text-right">
+                  <span className="font-semibold">{entry.points}</span>
+                  <span className="text-muted-foreground ml-1 text-xs">pts</span>
+                </TableCell>
+                <TableCell className="text-right">
+                  <ChangeIndicator change={entry.change} />
+                </TableCell>
+                {enablePreview && (
+                  <TableCell className="text-right">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setPreviewId(entry.predictionId)}
+                      aria-label={`Preview ${entry.predictionName}'s bracket`}
+                    >
+                      <Eye className="mr-1.5 h-4 w-4" />
+                      Preview
+                    </Button>
+                  </TableCell>
+                )}
+              </TableRow>
+            );
+          })}
+          {entries.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={colCount} className="text-muted-foreground h-24 text-center">
+                No entries found.
               </TableCell>
             </TableRow>
-          );
-        })}
-        {entries.length === 0 && (
-          <TableRow>
-            <TableCell colSpan={4} className="text-muted-foreground h-24 text-center">
-              No entries found.
-            </TableCell>
-          </TableRow>
-        )}
-      </TableBody>
-    </Table>
+          )}
+        </TableBody>
+      </Table>
+
+      {enablePreview && (
+        <BracketPreviewDialog
+          predictionId={previewId}
+          apiBasePath="/api/leaderboard/prediction"
+          onOpenChange={(open) => {
+            if (!open) setPreviewId(null);
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -13,7 +13,12 @@ import {
 } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BracketView } from '@/components/predictions/BracketView';
-import type { Group, KnockoutMatch, Team } from '@/types/tournament';
+import type {
+  Group,
+  KnockoutMatch,
+  R32BracketAssignment,
+  Team,
+} from '@/types/tournament';
 
 interface PredictionDetail {
   id: string;
@@ -76,6 +81,13 @@ export function BracketPreviewDialog({
     queryFn: () => fetchJSON('/api/groups'),
   });
 
+  const bracketQuery = useQuery<{ assignments: R32BracketAssignment[] }>({
+    queryKey: ['r32-bracket'],
+    enabled: open,
+    queryFn: () => fetchJSON('/api/r32-bracket'),
+  });
+  const bracketAssignments = bracketQuery.data?.assignments ?? [];
+
   const ready =
     predictionQuery.data && matchesQuery.data && teamsQuery.data && groupsQuery.data;
 
@@ -132,6 +144,7 @@ export function BracketPreviewDialog({
               matchId: k.matchId,
               winnerId: k.winner,
             }))}
+            bracketAssignments={bracketAssignments}
           />
         )}
       </DialogContent>

--- a/supabase/migrations/0029_public_prediction_preview.sql
+++ b/supabase/migrations/0029_public_prediction_preview.sql
@@ -1,0 +1,83 @@
+-- Public bracket preview for paid + submitted leaderboard entries.
+--
+-- The `predictions` SELECT policy is "own_or_admin", so a normal user
+-- can't read another user's bracket directly. The leaderboard already
+-- exposes who's playing and their points, and the product wants
+-- authenticated users to be able to preview each other's paid brackets.
+-- Drafts and unpaid predictions remain private.
+--
+-- This RPC is SECURITY DEFINER so it bypasses RLS, and applies the same
+-- eligibility filter the leaderboard already uses:
+--   * the caller is authenticated
+--   * the prediction is submitted
+--   * the prediction has a tournament_payments row with
+--     paid_at <= tournament.lock_time
+-- Anything else returns no rows (the route maps that to 404).
+
+create or replace function public.get_public_prediction(p_prediction_id uuid)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    total_goals int,
+    submitted_at timestamptz,
+    groups jsonb,
+    knockout jsonb,
+    advancers jsonb
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with elig as (
+        select p.id, p.user_id, p.tournament_id, p.prediction_name, p.total_goals, p.submitted_at
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        join public.tournaments t on t.id = p.tournament_id
+        where p.id = p_prediction_id
+          and auth.uid() is not null
+          and p.submitted_at is not null
+          and tp.paid_at <= t.lock_time
+    )
+    select
+        e.id as prediction_id,
+        e.prediction_name::text,
+        pr.username::text as username,
+        e.total_goals,
+        e.submitted_at,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'group_id', gp.group_id,
+                'first_team_id', gp.first_team_id,
+                'second_team_id', gp.second_team_id,
+                'third_team_id', gp.third_team_id,
+                'fourth_team_id', gp.fourth_team_id
+            ) order by gp.group_id)
+            from public.group_predictions gp
+            where gp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as groups,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'match_id', kp.match_id,
+                'winner_team_id', kp.winner_team_id
+            ) order by kp.match_id)
+            from public.knockout_predictions kp
+            where kp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as knockout,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'rank', ap.rank,
+                'team_id', ap.team_id
+            ) order by ap.rank)
+            from public.advancer_predictions ap
+            where ap.prediction_id = e.id),
+            '[]'::jsonb
+        ) as advancers
+    from elig e
+    join public.profiles pr on pr.id = e.user_id;
+$$;
+
+grant execute on function public.get_public_prediction(uuid) to authenticated;


### PR DESCRIPTION
## Summary

Adds a per-row **Preview** button on the leaderboard that opens the same `BracketPreviewDialog` already used on the predictions page. Authenticated members can inspect each other's **paid** brackets; drafts and unpaid predictions stay private.

## DB

New `SECURITY DEFINER` RPC `get_public_prediction(p_prediction_id)` returning groups/knockout/advancers as JSONB, but only when:

- `auth.uid() is not null` (must be signed in)
- the prediction is submitted
- `tournament_payments.paid_at <= tournament.lock_time` (same eligibility criterion the leaderboard already uses)

Anything else returns no rows — the route maps that to 404.

## Frontend

- New `/api/leaderboard/prediction/[id]` route that calls the RPC and reshapes for `BracketPreviewDialog`.
- `BracketPreviewDialog` now also fetches `r32_bracket_assignments` so 3rd-place R32 slots resolve to the admin-assigned advancers in phase 2.
- `LeaderboardTable` gains an `enablePreview` prop; the leaderboard page sets it to `!!user` so the column only renders for signed-in members.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 279/279 passing
- [x] `npx eslint src` — clean
- [x] `supabase db reset` — all 29 migrations apply cleanly
- [ ] Signed-in user: leaderboard shows a Preview button per row; clicking opens the bracket dialog with the predicted picks.
- [ ] Signed-out visitor: Preview column hidden.
- [ ] Try to hit `/api/leaderboard/prediction/<some-unpaid-prediction-id>` while signed in — should 404.
- [ ] Hit it while signed out — should 401.

## Deployment notes

Migration 0029 must be pushed to prod (`supabase db push`) **before** the frontend deploy reaches production, or the new route will 500 on missing RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)