### PR TITLE
fix(admin): unselect + cross-slot dedupe on advancers page

### DIFF
--- a/frontend/src/app/admin/advancers/AdvancersForm.tsx
+++ b/frontend/src/app/admin/advancers/AdvancersForm.tsx
@@ -292,6 +292,14 @@ export function AdvancersForm() {
           {thirdPlaceSlots.map(({ matchId, slot, sourceLabel }) => {
             const current = assignments.find((a) => a.matchId === matchId && a.slot === slot);
             const currentTeam = current ? teamById.get(current.teamId) : null;
+            // Teams already assigned to a different slot — disable them so
+            // the admin can't accidentally double-assign and hit the
+            // `unique (tournament_id, team_id)` constraint error.
+            const assignedElsewhere = new Set(
+              assignments
+                .filter((a) => !(a.matchId === matchId && a.slot === slot))
+                .map((a) => a.teamId)
+            );
 
             return (
               <Card
@@ -342,14 +350,24 @@ export function AdvancersForm() {
                       {advancers.map((a) => {
                         const team = teamById.get(a.teamId);
                         if (!team) return null;
+                        const usedElsewhere = assignedElsewhere.has(team.id);
                         return (
-                          <SelectItem key={a.rank} value={team.id}>
+                          <SelectItem
+                            key={a.rank}
+                            value={team.id}
+                            disabled={usedElsewhere}
+                          >
                             <span className="flex items-center gap-2">
                               <TeamFlag code={team.code} />
                               <span className="text-muted-foreground font-mono text-xs">
                                 #{a.rank}
                               </span>
                               <span>{team.name}</span>
+                              {usedElsewhere && (
+                                <span className="text-muted-foreground ml-1 text-xs italic">
+                                  (assigned elsewhere)
+                                </span>
+                              )}
                             </span>
                           </SelectItem>
                         );

--- a/frontend/src/components/predictions/AdvancersForm.tsx
+++ b/frontend/src/components/predictions/AdvancersForm.tsx
@@ -36,6 +36,10 @@ export interface AdvancersFormProps {
 
 const RANKS = Array.from({ length: ADVANCER_COUNT }, (_, i) => i + 1);
 
+// Sentinel for the "(none)" entry so admins/users can clear a rank.
+// Radix Select forbids empty string values, so a non-empty marker is needed.
+const CLEAR_VALUE = '__CLEAR__';
+
 export function AdvancersForm({
   variant,
   candidatePool,
@@ -130,13 +134,24 @@ export function AdvancersForm({
               <CardContent className="space-y-3">
                 <Select
                   value={pick?.teamId ?? ''}
-                  onValueChange={(value) => onRankChange(rank, value || null)}
+                  onValueChange={(value) => {
+                    if (value === CLEAR_VALUE) {
+                      onRankChange(rank, null);
+                      return;
+                    }
+                    onRankChange(rank, value || null);
+                  }}
                   disabled={disabled}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Pick a team" />
                   </SelectTrigger>
                   <SelectContent>
+                    {filled && (
+                      <SelectItem value={CLEAR_VALUE}>
+                        <span className="text-muted-foreground">(none)</span>
+                      </SelectItem>
+                    )}
                     {candidatePool.map((team) => {
                       const isOwnPick = pick?.teamId === team.id;
                       const isUsedElsewhere = !isOwnPick && pickedTeamIds.has(team.id);


### PR DESCRIPTION
## Summary

Two small UX improvements on the Admin Advancers page (`/admin/advancers`):

### 1. Top-8 ranks — add "(none)" to clear a rank

The shared `AdvancersForm` rank picker let admins/users swap teams between ranks but had no way to unset one. Added a "(none)" sentinel option that only appears when the rank is currently filled. Used in both the admin variant and the user wizard variant.

### 2. R32 bracket dropdowns — disable already-assigned advancers

Each slot dropdown showed every advancer, even if it was already assigned to another slot. Picking a duplicate produced a confusing `unique (tournament_id, team_id)` constraint error from `admin_set_r32_bracket`. Now: teams assigned to another slot render as disabled with an "(assigned elsewhere)" label, preventing the mistake at the UI layer.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 279/279 passing
- [x] `npx eslint src` — clean
- [ ] On `/admin/advancers`, pick a team for rank 1 → reopen rank 1 dropdown → "(none)" appears and clears it.
- [ ] On `/admin/advancers`, assign team X to M2:2 → open M5:2 dropdown → team X is grayed out with "(assigned elsewhere)".
- [ ] Saving/clearing works through both flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)