### PR TITLE
feat(wizard): start at Round of 32 when phase 2 is open

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -322,7 +322,21 @@ export function PredictionsPageContent({
   const [currentStep, setCurrentStep] = React.useState<Step>('groups');
   const tabsContentRef = React.useRef<HTMLDivElement | null>(null);
   const userInteractedRef = React.useRef(false);
+  const initialStepSet = React.useRef(false);
   const nameRef = React.useRef<HTMLInputElement>(null);
+
+  // Once we know the phase and have hydrated, jump straight to Round of 32
+  // when phase 2 is open — group + advancer picks are frozen at that point
+  // so the user's only remaining work is the knockout bracket. Runs once;
+  // later navigation is up to the user.
+  React.useEffect(() => {
+    if (initialStepSet.current) return;
+    if (!hydrated) return;
+    initialStepSet.current = true;
+    if (phase === 'phase2_open') {
+      setCurrentStep('round_of_32');
+    }
+  }, [hydrated, phase]);
 
   const groups = groupsQuery.data;
   const teams = teamsQuery.data;


### PR DESCRIPTION
## Summary

When phase 2 is open the user's group + advancer picks are frozen — the only remaining work is the knockout bracket. Land them on the **Round of 32** step instead of Group Stage so they don't have to click past frozen sections to get to what they can actually edit.

## Implementation

A single `useEffect` that runs once after `hydrated` flips true (so we know both the prediction's draft state and the tournament phase). If `phase === 'phase2_open'` at that point, set `currentStep = 'round_of_32'`. The ref-guarded `initialStepSet.current` prevents re-firing — later navigation is up to the user.

Edge cases handled:
- **Phase 2 hasn't opened yet** → unchanged, lands on `groups`.
- **Phase 2 opens mid-session while the wizard is mounted** → user stays put on whatever step they were viewing (no surprise jump).
- **Phase 2 locked / phase 1 locked** → unchanged. Read-only anyway; staying on `groups` is fine.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 279/279 passing
- [x] `npx eslint src` — clean
- [ ] Open an existing submitted prediction while phase 1 is open → lands on Group Stage (unchanged).
- [ ] Admin opens phase 2 → user reloads a prediction → wizard lands on Round of 32.
- [ ] Same flow but the user clicks Group Stage in the stepper → stays on Group Stage; doesn't snap back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)