### PR TITLE
fix(banner): differentiate phase1_locked states + reword phase2_locked

### DIFF
--- a/frontend/src/app/admin/advancers/AdvancersForm.tsx
+++ b/frontend/src/app/admin/advancers/AdvancersForm.tsx
@@ -104,7 +104,7 @@ export function AdvancersForm() {
 
   const advancers: AdvancerPrediction[] = advancersQuery.data?.advancers ?? [];
   const assignments: R32BracketAssignment[] = bracketQuery.data?.assignments ?? [];
-  const knockoutUnlocked = tournamentQuery.data?.knockoutUnlocked ?? false;
+  const phase = tournamentQuery.data?.phase ?? 'phase1';
 
   const teamById = React.useMemo(() => {
     const map = new Map<string, Team>();
@@ -392,12 +392,17 @@ export function AdvancersForm() {
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            {knockoutUnlocked ? <Unlock className="h-5 w-5" /> : <Lock className="h-5 w-5" />}
+            {phase === 'phase2_open' ? <Unlock className="h-5 w-5" /> : <Lock className="h-5 w-5" />}
             Phase 2 (knockout predictions)
           </CardTitle>
           <p className="text-muted-foreground text-sm">
-            Currently {knockoutUnlocked ? 'open' : 'closed'}.{' '}
-            {completedAdvancers}/8 advancers set ·{' '}
+            Currently{' '}
+            {phase === 'phase2_open'
+              ? 'open'
+              : phase === 'phase2_locked'
+                ? 'closed (lock time has passed — set a new lock time to reopen)'
+                : 'closed'}
+            . {completedAdvancers}/8 advancers set ·{' '}
             {completedAssignments}/{thirdPlaceSlots.length} bracket slots assigned.
           </p>
         </CardHeader>
@@ -416,21 +421,23 @@ export function AdvancersForm() {
           <div className="flex flex-wrap gap-2">
             <Button
               onClick={() => togglePhaseTwo(true)}
-              disabled={busy || !canOpenPhaseTwo || knockoutUnlocked}
+              disabled={busy || !canOpenPhaseTwo || phase === 'phase2_open'}
               title={
                 !allAdvancersSet
                   ? 'Set all 8 advancers first'
                   : !allAssignmentsSet
                     ? 'Assign every R32 3rd-place slot first'
-                    : undefined
+                    : phase === 'phase2_locked'
+                      ? 'Phase 2 lock time has passed — set a new lock time above and click to reopen'
+                      : undefined
               }
             >
-              Open Phase 2
+              {phase === 'phase2_locked' ? 'Reopen Phase 2' : 'Open Phase 2'}
             </Button>
             <Button
               variant="outline"
               onClick={() => togglePhaseTwo(false)}
-              disabled={busy || !knockoutUnlocked}
+              disabled={busy || phase !== 'phase2_open'}
             >
               Close Phase 2
             </Button>

--- a/frontend/src/app/api/tournament/route.ts
+++ b/frontend/src/app/api/tournament/route.ts
@@ -21,6 +21,18 @@ export async function GET() {
     return NextResponse.json({ error: 'No active tournament' }, { status: 404 });
   }
 
+  // Whether the admin has finished posting the 8 ranked 3rd-place
+  // advancers. Used by the banner to differentiate phase1_locked states:
+  //   * advancers not yet set → "Waiting for admin to post the advancers"
+  //   * advancers set + phase 2 closed → "Knockout predictions paused"
+  // tournament_advancers has a public SELECT policy so this works for
+  // unauthenticated visitors too.
+  const advancersCountRes = await supabase
+    .from('tournament_advancers')
+    .select('rank', { count: 'exact', head: true })
+    .eq('tournament_id', tournamentRes.data.id);
+  const advancersSet = (advancersCountRes.count ?? 0) === 8;
+
   const data = tournamentRes.data as {
     id: string;
     slug: string;
@@ -60,6 +72,7 @@ export async function GET() {
     lockTime: data.lock_time,
     knockoutLockTime: data.knockout_lock_time,
     knockoutUnlocked: data.knockout_unlocked,
+    advancersSet,
     phase,
     totalEntries: data.total_entries,
     championTotalGoals: data.champion_total_goals,

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -181,11 +181,18 @@ export function PredictionsListPage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Button asChild variant="outline" size="sm">
-                    <Link href={`${ROUTES.predictions}/${encodeURIComponent(p.id)}`}>
-                      {isLocked && !isSuperAdmin ? 'View' : 'Edit'}
-                    </Link>
-                  </Button>
+                  {/* Once phase 2 closes the knockout stage is underway and
+                      there's nothing the user can edit. Hide the link —
+                      the Preview button (eye icon) still gives them a
+                      read-only view. Super admins keep the Edit button via
+                      the admin route. */}
+                  {!(phase === 'phase2_locked' && !isSuperAdmin) && (
+                    <Button asChild variant="outline" size="sm">
+                      <Link href={`${ROUTES.predictions}/${encodeURIComponent(p.id)}`}>
+                        {isLocked && !isSuperAdmin ? 'View' : 'Edit'}
+                      </Link>
+                    </Button>
+                  )}
                   <Button
                     variant="outline"
                     size="sm"

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -68,8 +68,13 @@ export function PredictionsListPage() {
 
   // Skew-adjusted phase state — robust to client clock manipulation. The
   // server-side RPC enforces the actual write boundary; this is purely UX.
-  const { isLocked, phase } = useTournamentLock();
+  const { isLocked, phase, advancersSet } = useTournamentLock();
   const isSuperAdmin = profile?.isSuperAdmin === true;
+  // Once the knockout stage has begun (phase2 closed naturally, or admin
+  // closed phase2 after posting advancers) there's nothing for a regular
+  // user to edit. The Preview button still covers viewing the bracket.
+  const knockoutStageLocked =
+    phase === 'phase2_locked' || (phase === 'phase1_locked' && advancersSet);
 
   const predictions = query.data?.predictions ?? [];
   const cap = query.data?.cap ?? PREDICTION_CAP;
@@ -181,12 +186,11 @@ export function PredictionsListPage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  {/* Once phase 2 closes the knockout stage is underway and
-                      there's nothing the user can edit. Hide the link —
-                      the Preview button (eye icon) still gives them a
-                      read-only view. Super admins keep the Edit button via
-                      the admin route. */}
-                  {!(phase === 'phase2_locked' && !isSuperAdmin) && (
+                  {/* Once the knockout stage has begun the user can't edit
+                      anything. Hide the link — the Preview button (eye
+                      icon) still gives them a read-only view. Super admins
+                      keep the Edit button via the admin route. */}
+                  {!(knockoutStageLocked && !isSuperAdmin) && (
                     <Button asChild variant="outline" size="sm">
                       <Link href={`${ROUTES.predictions}/${encodeURIComponent(p.id)}`}>
                         {isLocked && !isSuperAdmin ? 'View' : 'Edit'}

--- a/frontend/src/components/layout/LockStatusBanner.tsx
+++ b/frontend/src/components/layout/LockStatusBanner.tsx
@@ -27,7 +27,7 @@ function dismissKey(tournamentId: string, phase: string): string {
 }
 
 export function LockStatusBanner() {
-  const { tournamentId, lockTime, isLoading, phase, remainingMs, clockSuspect } =
+  const { tournamentId, lockTime, isLoading, phase, remainingMs, clockSuspect, advancersSet } =
     useTournamentLock();
   const { profile } = useAuth();
   const [dismissed, setDismissed] = React.useState(false);
@@ -89,12 +89,14 @@ export function LockStatusBanner() {
           <span className="font-medium">
             {phase === 'phase1' &&
               `You have ${formatRemaining(remainingMs)} left to choose your group + best-3rd picks before the tournament starts! Don't miss out!`}
-            {phase === 'phase1_locked' &&
+            {phase === 'phase1_locked' && !advancersSet &&
               'Group stage in progress. Knockout predictions will open once the admin posts the best-3rd advancers.'}
+            {phase === 'phase1_locked' && advancersSet &&
+              'Knockout predictions are paused. The admin will reopen them shortly.'}
             {phase === 'phase2_open' &&
               `You have ${formatRemaining(remainingMs)} left to make your knockout picks!`}
             {phase === 'phase2_locked' &&
-              'Tournament in progress. All predictions locked.'}
+              'Knockout predictions closed. The tournament is underway.'}
           </span>
           {(phase === 'phase1_locked' || phase === 'phase2_locked') && isSuperAdmin && (
             <span className="rounded-md bg-white/15 px-2 py-0.5 text-xs font-medium">

--- a/frontend/src/components/layout/LockStatusBanner.tsx
+++ b/frontend/src/components/layout/LockStatusBanner.tsx
@@ -63,10 +63,16 @@ export function LockStatusBanner() {
   const urgent =
     (phase === 'phase1' || phase === 'phase2_open') && remainingMs <= ONE_DAY_MS;
 
+  // Once advancers are posted, phase1_locked means the admin opened and
+  // then closed phase 2 (or hasn't reopened it yet). The knockout stage is
+  // now underway either way, so we display it the same as phase2_locked.
+  const knockoutLocked =
+    phase === 'phase2_locked' || (phase === 'phase1_locked' && advancersSet);
+
   // Tone + icon per phase.
   let tone: 'open' | 'urgent' | 'between' | 'locked' = 'open';
-  if (phase === 'phase1_locked') tone = 'between';
-  else if (phase === 'phase2_locked') tone = 'locked';
+  if (knockoutLocked) tone = 'locked';
+  else if (phase === 'phase1_locked') tone = 'between';
   else if (urgent) tone = 'urgent';
 
   const toneClasses = {
@@ -91,11 +97,9 @@ export function LockStatusBanner() {
               `You have ${formatRemaining(remainingMs)} left to choose your group + best-3rd picks before the tournament starts! Don't miss out!`}
             {phase === 'phase1_locked' && !advancersSet &&
               'Group stage in progress. Knockout predictions will open once the admin posts the best-3rd advancers.'}
-            {phase === 'phase1_locked' && advancersSet &&
-              'Knockout predictions are paused. The admin will reopen them shortly.'}
             {phase === 'phase2_open' &&
               `You have ${formatRemaining(remainingMs)} left to make your knockout picks!`}
-            {phase === 'phase2_locked' &&
+            {knockoutLocked &&
               'The knockout stage has begun. Predictions are locked.'}
           </span>
           {(phase === 'phase1_locked' || phase === 'phase2_locked') && isSuperAdmin && (

--- a/frontend/src/components/layout/LockStatusBanner.tsx
+++ b/frontend/src/components/layout/LockStatusBanner.tsx
@@ -96,7 +96,7 @@ export function LockStatusBanner() {
             {phase === 'phase2_open' &&
               `You have ${formatRemaining(remainingMs)} left to make your knockout picks!`}
             {phase === 'phase2_locked' &&
-              'Knockout predictions closed. The tournament is underway.'}
+              'The knockout stage has begun. Predictions are locked.'}
           </span>
           {(phase === 'phase1_locked' || phase === 'phase2_locked') && isSuperAdmin && (
             <span className="rounded-md bg-white/15 px-2 py-0.5 text-xs font-medium">

--- a/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
@@ -91,12 +91,13 @@ describe('LockStatusBanner', () => {
     expect(screen.getByRole('status').className).toContain('bg-slate-600');
   });
 
-  it('renders the paused message when phase 2 was opened and then closed by admin', async () => {
+  it('renders the knockout-stage message when phase 2 was opened and then closed by admin', async () => {
     mockTournament({ lockOffsetMs: -60_000, phase: 'phase1_locked', advancersSet: true });
     render(wrap(<LockStatusBanner />));
     await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
-    expect(screen.getByRole('status')).toHaveTextContent(/Knockout predictions are paused/i);
+    expect(screen.getByRole('status')).toHaveTextContent(/knockout stage has begun/i);
     expect(screen.getByRole('status')).not.toHaveTextContent(/Group stage in progress/i);
+    expect(screen.getByRole('status').className).toContain('bg-red-600');
   });
 
   it('renders the fully locked state when phase 2 has closed', async () => {

--- a/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
@@ -31,10 +31,12 @@ function mockTournament({
   lockOffsetMs,
   serverOffsetMs = 0,
   phase,
+  advancersSet = false,
 }: {
   lockOffsetMs: number;
   serverOffsetMs?: number;
   phase?: 'phase1' | 'phase1_locked' | 'phase2_open' | 'phase2_locked';
+  advancersSet?: boolean;
 }) {
   const lockTime = new Date(Date.now() + lockOffsetMs).toISOString();
   const serverTime = new Date(Date.now() + serverOffsetMs).toISOString();
@@ -51,6 +53,7 @@ function mockTournament({
       lockTime,
       knockoutLockTime: null,
       knockoutUnlocked: false,
+      advancersSet,
       phase: phase ?? inferredPhase,
       totalEntries: 0,
       serverTime,
@@ -80,7 +83,7 @@ describe('LockStatusBanner', () => {
     expect(screen.getByRole('status').className).toContain('bg-amber-600');
   });
 
-  it('renders the between-phases state when phase 1 has ended', async () => {
+  it('renders the between-phases state when phase 1 has ended and advancers not yet posted', async () => {
     mockTournament({ lockOffsetMs: -60_000 });
     render(wrap(<LockStatusBanner />));
     await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
@@ -88,11 +91,19 @@ describe('LockStatusBanner', () => {
     expect(screen.getByRole('status').className).toContain('bg-slate-600');
   });
 
+  it('renders the paused message when phase 2 was opened and then closed by admin', async () => {
+    mockTournament({ lockOffsetMs: -60_000, phase: 'phase1_locked', advancersSet: true });
+    render(wrap(<LockStatusBanner />));
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    expect(screen.getByRole('status')).toHaveTextContent(/Knockout predictions are paused/i);
+    expect(screen.getByRole('status')).not.toHaveTextContent(/Group stage in progress/i);
+  });
+
   it('renders the fully locked state when phase 2 has closed', async () => {
     mockTournament({ lockOffsetMs: -60_000, phase: 'phase2_locked' });
     render(wrap(<LockStatusBanner />));
     await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
-    expect(screen.getByRole('status')).toHaveTextContent(/All predictions locked/i);
+    expect(screen.getByRole('status')).toHaveTextContent(/Knockout predictions closed/i);
     expect(screen.getByRole('status').className).toContain('bg-red-600');
   });
 

--- a/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
@@ -103,7 +103,7 @@ describe('LockStatusBanner', () => {
     mockTournament({ lockOffsetMs: -60_000, phase: 'phase2_locked' });
     render(wrap(<LockStatusBanner />));
     await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
-    expect(screen.getByRole('status')).toHaveTextContent(/Knockout predictions closed/i);
+    expect(screen.getByRole('status')).toHaveTextContent(/knockout stage has begun/i);
     expect(screen.getByRole('status').className).toContain('bg-red-600');
   });
 

--- a/frontend/src/hooks/useTournamentLock.ts
+++ b/frontend/src/hooks/useTournamentLock.ts
@@ -13,6 +13,7 @@ interface TournamentResponse {
   lockTime: string;
   knockoutLockTime: string | null;
   knockoutUnlocked: boolean;
+  advancersSet: boolean;
   phase: Phase;
   totalEntries: number;
   serverTime: string;
@@ -23,6 +24,8 @@ export interface TournamentLockState {
   lockTime: Date | null;
   knockoutLockTime: Date | null;
   knockoutUnlocked: boolean;
+  /** True when all 8 ranked 3rd-place advancers have been set by the admin. */
+  advancersSet: boolean;
   phase: Phase;
   isLoading: boolean;
   /** Server-time minus client-time, in ms. 0 if data not loaded. */
@@ -81,6 +84,7 @@ export function useTournamentLock(): TournamentLockState {
 
   const phase: Phase = data?.phase ?? 'phase1';
   const knockoutUnlocked = data?.knockoutUnlocked ?? false;
+  const advancersSet = data?.advancersSet ?? false;
 
   // The relevant deadline for "remainingMs" depends on phase:
   //   phase1 → lockTime
@@ -105,6 +109,7 @@ export function useTournamentLock(): TournamentLockState {
     lockTime,
     knockoutLockTime,
     knockoutUnlocked,
+    advancersSet,
     phase,
     isLoading: query.isLoading,
     skewMs,


### PR DESCRIPTION
## Summary

The lock-status banner was showing the same "Knockout predictions will open once the admin posts the best-3rd advancers" copy for **every** `phase1_locked` state — including the case where the admin had already posted all 8 advancers and then closed phase 2 (the bug you spotted). That message is misleading because the advancers ARE already posted.

## Approach

Surface a new `advancersSet` flag from `/api/tournament` (= 8 rows in `tournament_advancers`) through `useTournamentLock` and use it to split `phase1_locked` into two messages:

| State | Banner |
|---|---|
| `phase1_locked` + `!advancersSet` (initial wait between phases) | _"Group stage in progress. Knockout predictions will open once the admin posts the best-3rd advancers."_ |
| `phase1_locked` + `advancersSet` (admin closed phase 2 after opening it) | _"Knockout predictions are paused. The admin will reopen them shortly."_ |
| `phase2_locked` | _"Knockout predictions closed. The tournament is underway."_ (slight reword for clearer end-state) |

The dismiss key is still keyed on `(tournamentId, phase)` so re-entering `phase1_locked` after dismissing the original phase-1-locked banner does still suppress it. If that's undesirable I can include `advancersSet` in the dismiss key — easy follow-up.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 280/280 passing (new test added)
- [x] `npx eslint src` — clean
- [ ] In prod: admin closes phase 2 → banner switches from the phase2_open countdown to "Knockout predictions are paused…" (not the "advancers will open" message).
- [ ] Admin re-opens phase 2 → banner switches back to the phase2_open countdown.
- [ ] Phase 2 lock time naturally expires → banner reads "Knockout predictions closed. The tournament is underway."

🤖 Generated with [Claude Code](https://claude.com/claude-code)