### PR TITLE
fix(wizard): surface advancer errors + gate Submit on full completion

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -472,20 +472,15 @@ export function PredictionsPageContent({
     totalKnockoutMatches > 0 && completedKnockoutMatches === totalKnockoutMatches;
   const isTiebreakerComplete = totalGoals !== null;
 
-  // Which fields the current submit can actually accept depends on phase. The
-  // server-side RPC (submit_predictions in 0022) raises 'phase 1 only fields
-  // allowed' if a phase-1 payload includes knockout or total_goals, and
-  // 'phase 1 ended; group + bundle picks are frozen' on the inverse — so the
-  // wizard has to gate completeness on the same partition. Routes that go
-  // through admin_submit_predictions (super admin editing themselves in non-
-  // phase-1 phases, or any admin editing a user) bypass the guard and need
-  // everything filled to count as complete.
   const usesAdminRoute = effectiveApiBasePath.startsWith('/api/admin/');
-  const isPredictionsComplete = usesAdminRoute
-    ? isGroupsComplete && isAdvancersComplete && isBracketComplete && isTiebreakerComplete
-    : phase === 'phase2_open'
-      ? isBracketComplete && isTiebreakerComplete
-      : isGroupsComplete && isAdvancersComplete;
+  // Submit ("mark this prediction submitted") requires the bracket to be
+  // fully built — i.e. every section, across both phases, complete. Save
+  // Progress doesn't use this gate; users save partial drafts in either
+  // phase. In Phase 1 the knockout UI is read-only for regular users so
+  // isBracketComplete is naturally false and Submit stays disabled until
+  // Phase 2 opens.
+  const isPredictionsComplete =
+    isGroupsComplete && isAdvancersComplete && isBracketComplete && isTiebreakerComplete;
 
   const trimmedName = predictionName.trim();
   const nameError =
@@ -1001,7 +996,9 @@ export function PredictionsPageContent({
             <p className="text-muted-foreground text-sm">
               {isPredictionsComplete
                 ? 'Submit puts this bracket on the leaderboard once an admin marks it paid.'
-                : 'Save progress to keep working — or complete every pick to submit.'}
+                : phase === 'phase1'
+                  ? 'Save progress to keep working. You can submit once Phase 2 opens and the knockout bracket is complete.'
+                  : 'Save progress to keep working — or complete every pick to submit.'}
             </p>
           </div>
           <div className="flex flex-col gap-2 sm:flex-row">

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -31,11 +31,22 @@ const KNOWN_ERROR_FRAGMENTS = [
   'prediction name taken',
   'prediction not found',
   'could not generate unique username',
-  'invalid bundle group letter',
-  'unknown bundle slot',
   'phase 1 ended',
   'phase 1 only fields allowed',
+  // Advancers v2 (migrations 0025-0028)
   'all 8 advancers must be set',
+  'advancer rank must be',
+  'duplicate advancer rank',
+  'duplicate advancer team',
+  'advancer team',
+  'advancer rank set must be',
+  'not a 3rd-place team',
+  'team is already assigned to',
+  // R32 bracket assignment (migration 0026)
+  'is not in the top-8 advancers',
+  'is not a 3rd-place slot',
+  'unknown r32 match',
+  'all r32 3rd-place bracket slots',
 ] as const;
 
 export function safeMessage(


### PR DESCRIPTION
## Summary

You reported Save Progress / Submit "failing" in Phase 1. Two issues:

### 1. The actual failure was being masked

`safeMessage` only lets whitelisted error fragments through to the UI; anything else gets rewritten to a generic *"request failed"*. The advancer validation errors added in 0027 weren't on the list — so when the RPC raised e.g. *"advancer team X not in your 3rd-place picks"* (or duplicate-rank / duplicate-team variants), the user just saw *"request failed"* with no actionable info.

Adds the new error fragments:

- `'advancer rank must be'`, `'duplicate advancer rank'`, `'duplicate advancer team'`, `'advancer team'`, `'advancer rank set must be'`, `'not a 3rd-place team'`, `'team is already assigned to'`
- R32 bracket (0026): `'is not in the top-8 advancers'`, `'is not a 3rd-place slot'`, `'unknown r32 match'`, `'all r32 3rd-place bracket slots'`

Also drops the now-dead bundle fragments (`'invalid bundle group letter'`, `'unknown bundle slot'`).

### 2. Submit now requires full completion

Per your direction: Submit should only fire once the entire bracket (groups + advancers + knockout + tiebreaker) is filled, **not** when only Phase 1 sections are complete. Simplify `isPredictionsComplete` to always require all four sections.

In Phase 1 the knockout UI is read-only for regular users (`phase2Editable` is false), so `isBracketComplete` stays false and Submit is naturally disabled. Save Progress continues to work in any open phase (Phase 1 or Phase 2 open) — it never used the completeness gate.

Also added a phase-aware hint in the "Ready to submit?" card: in Phase 1 it now reads *"Save progress to keep working. You can submit once Phase 2 opens and the knockout bracket is complete."*

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 280/280 passing
- [x] `npx eslint src` — clean
- [ ] Phase 1: Submit button stays disabled even after filling groups + advancers. Save Progress works.
- [ ] Phase 1: If a submit fails because an advancer team isn't in the user's 3rd-place picks, the toast now reads the actual server error (e.g. "advancer team brz not in your 3rd-place picks").
- [ ] Phase 2 open: Submit enables once knockout + tiebreaker are complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)