### PR TITLE
fix(rls): allow users to write their own advancer_predictions

### DIFF
--- a/supabase/migrations/0030_advancer_predictions_rls_fix.sql
+++ b/supabase/migrations/0030_advancer_predictions_rls_fix.sql
@@ -1,0 +1,51 @@
+-- Fix advancer_predictions RLS so the user-side submit path actually works.
+--
+-- Bug: migration 0025 added the table with a single write policy that only
+-- allowed admins:
+--
+--   create policy "advancer_predictions_no_direct_write"
+--       on public.advancer_predictions for all
+--       using (public.is_admin())
+--       with check (public.is_admin());
+--
+-- The intent was "only the RPC can write, never direct REST", but the
+-- assumption was wrong — submit_predictions is SECURITY INVOKER, so when a
+-- regular user calls it, the INSERT runs as that user and is checked
+-- against the table's RLS. The admin-only WITH CHECK rejects every save
+-- and surfaces as "new row violates row-level security policy for table
+-- advancer_predictions" / "request failed" in the wizard.
+--
+-- group_predictions (0002) handles the same pattern correctly: a single
+-- "write_own_before_lock" policy that lets users INSERT/UPDATE/DELETE rows
+-- whose owning prediction belongs to them and whose tournament is still
+-- before lock_time. Mirror that exactly. admin_submit_predictions is
+-- SECURITY DEFINER and bypasses RLS, so super-admin god-mode writes still
+-- work in phase 2 / past lock without an extra admin policy.
+
+drop policy if exists "advancer_predictions_no_direct_write" on public.advancer_predictions;
+
+create policy "advancer_predictions_write_own_before_lock"
+    on public.advancer_predictions for all
+    using (
+        public.is_admin()
+        or exists (
+            select 1 from public.predictions p
+            where p.id = advancer_predictions.prediction_id
+              and p.user_id = auth.uid()
+              and public.is_before_lock(p.tournament_id)
+        )
+    )
+    with check (
+        public.is_admin()
+        or exists (
+            select 1 from public.predictions p
+            where p.id = advancer_predictions.prediction_id
+              and p.user_id = auth.uid()
+              and public.is_before_lock(p.tournament_id)
+        )
+    );
+
+-- The authenticated role needs insert/update/delete grants too (not just
+-- SELECT). 0025 only granted SELECT. group_predictions gets the broader
+-- grant via 0011_prediction_writes_grants.
+grant insert, update, delete on public.advancer_predictions to authenticated;


### PR DESCRIPTION
## Summary

Reported bug: Save Progress was failing in Phase 1 for both Group Stage and Third Place Advancers in local dev.

**Postgres log** revealed the actual cause:
> `new row violates row-level security policy for table "advancer_predictions"`

`safeMessage` was rewriting it to *"request failed"* on the wire, which masked it from the UI until #81 broadened the whitelist.

### Root cause

Migration 0025 added `advancer_predictions` with a single write policy that only allowed admins:

```sql
create policy "advancer_predictions_no_direct_write"
    on public.advancer_predictions for all
    using (public.is_admin())
    with check (public.is_admin());
```

My assumption was *"writes only via the RPC"*, but `submit_predictions` is `SECURITY INVOKER` — so when a regular user calls it, the INSERT runs as that user and gets blocked by this policy. The RPC writes groups + advancers in a single transaction, so when the advancer insert rolls back, the user sees the *Group Stage* save fail too. That's why both sections were broken.

### Fix

Mirror what `group_predictions` already does (`group_predictions_write_own_before_lock` in migration 0002): allow writes when the owning prediction belongs to the caller AND the tournament is still before lock. `admin_submit_predictions` is `SECURITY DEFINER` and bypasses RLS, so super-admin god-mode in Phase 2 / past lock continues to work.

Also adds the missing `insert / update / delete` grants on the table (0025 only granted `SELECT`).

## Test plan

- [x] `supabase db reset` — all 30 migrations apply
- [x] `npm test` — 280/280 passing
- [x] `npx eslint src` — clean
- [ ] In local dev: in Phase 1 as a regular user, fill some groups and click Save Progress → saves cleanly (was: "request failed"). Same with advancer picks.
- [ ] Logs no longer show `new row violates row-level security policy for table "advancer_predictions"` on save.

## Deploy note

Push this migration to prod **before or with** the next frontend deploy so production users aren't blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)