### PR TITLE
fix(header): hydration mismatch on Radix triggers in Header

### DIFF
--- a/frontend/src/components/layout/AuthMenu.tsx
+++ b/frontend/src/components/layout/AuthMenu.tsx
@@ -9,11 +9,13 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useAuth } from '@/hooks/useAuth';
+import { useMounted } from '@/hooks/useMounted';
 import { ROUTES } from '@/lib/constants';
 
 export function AuthMenu() {
   const { user, profile, signOut } = useAuth();
   const router = useRouter();
+  const mounted = useMounted();
   const [isSigningOut, setIsSigningOut] = React.useState(false);
 
   const handleSignOut = async () => {
@@ -53,6 +55,20 @@ export function AuthMenu() {
   }
 
   const displayName = profile?.displayName || profile?.username || user.email;
+
+  // Defer the Radix Popover until after hydration. Radix uses useId()
+  // internally, and its IDs shift between SSR and client when other
+  // mount-gated components (ThemeToggle, etc.) re-render — producing a
+  // confusing aria-controls hydration mismatch. Rendering a plain
+  // (non-Radix) placeholder for the first paint sidesteps the issue.
+  if (!mounted) {
+    return (
+      <Button variant="outline" size="sm" className="gap-2" disabled>
+        <UserIcon className="h-4 w-4" />
+        <span className="max-w-[120px] truncate">{displayName}</span>
+      </Button>
+    );
+  }
 
   return (
     <Popover>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -9,6 +9,7 @@ import { ROUTES } from '@/lib/constants';
 import { AuthMenu } from '@/components/layout/AuthMenu';
 import { ThemeToggle } from '@/components/shared/ThemeToggle';
 import { useAuthContext } from '@/providers/AuthProvider';
+import { useMounted } from '@/hooks/useMounted';
 import {
   NavigationMenu,
   NavigationMenuList,
@@ -28,6 +29,7 @@ const baseNavLinks = [
 export function Header() {
   const pathname = usePathname();
   const { profile } = useAuthContext();
+  const mounted = useMounted();
   const navLinks = profile?.isAdmin
     ? [...baseNavLinks, { label: 'Admin', href: ROUTES.admin }]
     : baseNavLinks;
@@ -73,40 +75,49 @@ export function Header() {
 
         <div className="flex items-center gap-2 md:hidden">
           <AuthMenu />
-          <Sheet>
-            <SheetTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label="Open menu">
-                <Menu className="h-5 w-5" />
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="right">
-              <SheetHeader>
-                <SheetTitle>Navigation</SheetTitle>
-              </SheetHeader>
-              <nav className="mt-6 flex flex-col space-y-4">
-                {navLinks.map((link) => (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    className={cn(
-                      'hover:text-foreground rounded-md px-3 py-2 text-lg transition-colors',
-                      isActive(link.href)
-                        ? 'bg-accent text-accent-foreground font-semibold'
-                        : 'text-muted-foreground'
-                    )}
-                  >
-                    {link.label}
-                  </Link>
-                ))}
-              </nav>
-              <div className="mt-6 flex flex-col gap-4 border-t pt-6">
-                <div className="flex items-center gap-2">
-                  <span className="text-muted-foreground text-sm">Theme:</span>
-                  <ThemeToggle />
+          {/* Same hydration-mismatch dodge as AuthMenu: defer the Radix
+              Sheet until after mount so its useId-driven aria-controls
+              doesn't drift between SSR and client. */}
+          {mounted ? (
+            <Sheet>
+              <SheetTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="Open menu">
+                  <Menu className="h-5 w-5" />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="right">
+                <SheetHeader>
+                  <SheetTitle>Navigation</SheetTitle>
+                </SheetHeader>
+                <nav className="mt-6 flex flex-col space-y-4">
+                  {navLinks.map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className={cn(
+                        'hover:text-foreground rounded-md px-3 py-2 text-lg transition-colors',
+                        isActive(link.href)
+                          ? 'bg-accent text-accent-foreground font-semibold'
+                          : 'text-muted-foreground'
+                      )}
+                    >
+                      {link.label}
+                    </Link>
+                  ))}
+                </nav>
+                <div className="mt-6 flex flex-col gap-4 border-t pt-6">
+                  <div className="flex items-center gap-2">
+                    <span className="text-muted-foreground text-sm">Theme:</span>
+                    <ThemeToggle />
+                  </div>
                 </div>
-              </div>
-            </SheetContent>
-          </Sheet>
+              </SheetContent>
+            </Sheet>
+          ) : (
+            <Button variant="ghost" size="icon" aria-label="Open menu" disabled>
+              <Menu className="h-5 w-5" />
+            </Button>
+          )}
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary

You hit a React hydration warning on the reset-password page (and any signed-in page):

```
+ aria-controls="radix-_R_16inebmmlb_"   (client)
- aria-controls="radix-_R_4qinebmmlb_"   (server)
```

### Why it happens

Radix's `useId()` assigns IDs by render position. We already have one mount-gated component in the Header — `ThemeToggle` (which uses `useMounted` to swap a placeholder for the real theme-aware button after mount). When the post-hydration re-render happens, the useId counter for subsequent Radix components in the same render tree drifts, so the AuthMenu Popover triggers (desktop + mobile copies) and the mobile menu Sheet trigger end up with different aria-controls between SSR and client.

### Fix

Apply the same mount-gate pattern to the two affected Radix triggers:

- **AuthMenu** (signed-in branch): render a plain disabled `<Button>` showing the user's display name during SSR + initial hydration; swap to the `<Popover>`-wrapped version after mount.
- **Header Sheet** (mobile menu): render a plain disabled `<Button>` with the menu icon during SSR + initial hydration; swap to the `<Sheet>`-wrapped version after mount.

The placeholders don't call `useId`, so the SSR HTML and client first render match exactly — no more aria-controls drift.

### Side-effect

Visible: the avatar/menu buttons are momentarily disabled before the bundle mounts (sub-100ms in practice). The signed-out state (sign-in / sign-up buttons) and the desktop nav are unaffected — those don't go through Radix triggers in the header.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 280/280 passing
- [x] `npx eslint src` — clean
- [ ] Load `/reset-password` (or any signed-in page): no hydration warning in console.
- [ ] Click the avatar button → Popover still opens correctly.
- [ ] On mobile, click the menu icon → Sheet still opens correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)