### PR TITLE
feat(admin): consolidate phase lock controls on Tournament tab

### DIFF
--- a/frontend/src/app/admin/advancers/AdvancersForm.tsx
+++ b/frontend/src/app/admin/advancers/AdvancersForm.tsx
@@ -2,15 +2,11 @@
 
 import * as React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Lock, Unlock } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { AdvancersForm as RankPicker } from '@/components/predictions/AdvancersForm';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -37,13 +33,6 @@ interface BracketResponse {
   assignments: Array<{ matchId: string; slot: 1 | 2; teamId: string }>;
 }
 
-interface TournamentResponse {
-  id: string;
-  knockoutUnlocked: boolean;
-  knockoutLockTime: string | null;
-  phase: 'phase1' | 'phase1_locked' | 'phase2_open' | 'phase2_locked';
-}
-
 interface GroupStandingRow {
   group_id: string;
   third_team_id: string | null;
@@ -57,13 +46,6 @@ async function fetchJSON<T>(url: string): Promise<T> {
   return res.json();
 }
 
-function toLocalDatetimeInput(iso: string | null): string {
-  if (!iso) return '';
-  const d = new Date(iso);
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
 export function AdvancersForm() {
   const queryClient = useQueryClient();
   const advancersQuery = useQuery<TournamentAdvancersResponse>({
@@ -73,10 +55,6 @@ export function AdvancersForm() {
   const bracketQuery = useQuery<BracketResponse>({
     queryKey: ['admin-r32-bracket'],
     queryFn: () => fetchJSON('/api/admin/r32-bracket'),
-  });
-  const tournamentQuery = useQuery<TournamentResponse>({
-    queryKey: ['tournament'],
-    queryFn: () => fetchJSON('/api/tournament'),
   });
   const teamsQuery = useQuery<Team[]>({
     queryKey: ['teams'],
@@ -95,16 +73,8 @@ export function AdvancersForm() {
     enabled: !!tournamentId,
   });
 
-  const [phaseTwoLockInput, setPhaseTwoLockInput] = React.useState<string>('');
-  const [busy, setBusy] = React.useState(false);
-
-  React.useEffect(() => {
-    setPhaseTwoLockInput(toLocalDatetimeInput(tournamentQuery.data?.knockoutLockTime ?? null));
-  }, [tournamentQuery.data?.knockoutLockTime]);
-
   const advancers: AdvancerPrediction[] = advancersQuery.data?.advancers ?? [];
   const assignments: R32BracketAssignment[] = bracketQuery.data?.assignments ?? [];
-  const phase = tournamentQuery.data?.phase ?? 'phase1';
 
   const teamById = React.useMemo(() => {
     const map = new Map<string, Team>();
@@ -145,8 +115,6 @@ export function AdvancersForm() {
   const completedAdvancers = advancers.length;
   const completedAssignments = assignments.length;
   const allAdvancersSet = completedAdvancers === 8;
-  const allAssignmentsSet = completedAssignments === thirdPlaceSlots.length;
-  const canOpenPhaseTwo = allAdvancersSet && allAssignmentsSet;
 
   const handleRankChange = async (rank: number, teamId: string | null) => {
     if (!tournamentId) return;
@@ -217,42 +185,8 @@ export function AdvancersForm() {
     }
   };
 
-  const togglePhaseTwo = async (unlock: boolean) => {
-    if (!tournamentId) return;
-    setBusy(true);
-    try {
-      const res = await fetch('/api/admin/tournament', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          id: tournamentId,
-          knockoutUnlocked: unlock,
-          knockoutLockTime: unlock && phaseTwoLockInput
-            ? new Date(phaseTwoLockInput).toISOString()
-            : null,
-        }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(String(body.error ?? 'Failed'));
-      }
-      toast.success(unlock ? 'Phase 2 opened' : 'Phase 2 closed');
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['tournament'] }),
-        queryClient.invalidateQueries({ queryKey: ['admin-advancers'] }),
-      ]);
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed');
-    } finally {
-      setBusy(false);
-    }
-  };
-
   const loading =
-    advancersQuery.isLoading ||
-    tournamentQuery.isLoading ||
-    teamsQuery.isLoading ||
-    matchesQuery.isLoading;
+    advancersQuery.isLoading || teamsQuery.isLoading || matchesQuery.isLoading;
 
   return (
     <div className="space-y-10">
@@ -261,7 +195,8 @@ export function AdvancersForm() {
           <h2 className="text-xl font-semibold">Top-8 advancers</h2>
           <p className="text-muted-foreground text-sm">
             Rank the 8 best 3rd-place teams in descending order. Choices are the 12 teams
-            you&apos;ve entered as 3rd-place in group standings.
+            you&apos;ve entered as 3rd-place in group standings. Phase 2 controls live on the{' '}
+            <span className="font-mono">Tournament</span> tab.
           </p>
         </div>
         {loading ? (
@@ -388,62 +323,6 @@ export function AdvancersForm() {
           {completedAssignments} / {thirdPlaceSlots.length} bracket slots assigned.
         </p>
       </section>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            {phase === 'phase2_open' ? <Unlock className="h-5 w-5" /> : <Lock className="h-5 w-5" />}
-            Phase 2 (knockout predictions)
-          </CardTitle>
-          <p className="text-muted-foreground text-sm">
-            Currently{' '}
-            {phase === 'phase2_open'
-              ? 'open'
-              : phase === 'phase2_locked'
-                ? 'closed (lock time has passed — set a new lock time to reopen)'
-                : 'closed'}
-            . {completedAdvancers}/8 advancers set ·{' '}
-            {completedAssignments}/{thirdPlaceSlots.length} bracket slots assigned.
-          </p>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="space-y-1">
-            <Label htmlFor="phase2-lock">Knockout lock time (when phase 2 closes)</Label>
-            <Input
-              id="phase2-lock"
-              type="datetime-local"
-              value={phaseTwoLockInput}
-              onChange={(e) => setPhaseTwoLockInput(e.target.value)}
-              className="max-w-sm"
-              disabled={busy}
-            />
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              onClick={() => togglePhaseTwo(true)}
-              disabled={busy || !canOpenPhaseTwo || phase === 'phase2_open'}
-              title={
-                !allAdvancersSet
-                  ? 'Set all 8 advancers first'
-                  : !allAssignmentsSet
-                    ? 'Assign every R32 3rd-place slot first'
-                    : phase === 'phase2_locked'
-                      ? 'Phase 2 lock time has passed — set a new lock time above and click to reopen'
-                      : undefined
-              }
-            >
-              {phase === 'phase2_locked' ? 'Reopen Phase 2' : 'Open Phase 2'}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => togglePhaseTwo(false)}
-              disabled={busy || phase !== 'phase2_open'}
-            >
-              Close Phase 2
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Lock, Unlock } from 'lucide-react';
 import { toast } from 'sonner';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { AdminNav } from '@/components/admin/AdminNav';
@@ -16,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import type { KnockoutMatch } from '@/types/tournament';
 
 interface TournamentInfo {
   id: string;
@@ -23,13 +25,33 @@ interface TournamentInfo {
   name: string;
   status: 'upcoming' | 'group_stage' | 'knockout' | 'completed';
   lockTime: string;
+  knockoutLockTime: string | null;
+  knockoutUnlocked: boolean;
+  phase: 'phase1' | 'phase1_locked' | 'phase2_open' | 'phase2_locked';
   totalEntries: number;
   championTotalGoals: number | null;
 }
 
+interface AdvancersResponse {
+  tournamentId: string;
+  advancers: Array<{ rank: number; teamId: string }>;
+}
+
+interface BracketResponse {
+  tournamentId: string;
+  assignments: Array<{ matchId: string; slot: 1 | 2; teamId: string }>;
+}
+
 const STATUSES = ['upcoming', 'group_stage', 'knockout', 'completed'] as const;
 
-function toDatetimeLocal(iso: string): string {
+async function fetchJSON<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
+  return res.json();
+}
+
+function toDatetimeLocal(iso: string | null): string {
+  if (!iso) return '';
   const d = new Date(iso);
   const pad = (n: number) => n.toString().padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
@@ -39,22 +61,37 @@ export function TournamentSettingsForm() {
   const queryClient = useQueryClient();
   const tournament = useQuery<TournamentInfo>({
     queryKey: ['tournament'],
-    queryFn: async () => {
-      const res = await fetch('/api/tournament');
-      if (!res.ok) throw new Error('Failed to load tournament');
-      return res.json();
-    },
+    queryFn: () => fetchJSON('/api/tournament'),
+  });
+
+  // Phase 2 toggle pre-flight checks: all 8 advancers + all R32 3rd-place
+  // bracket slots must be assigned. These queries mirror the ones the
+  // /admin/advancers page used to own when it hosted the Phase 2 controls.
+  const advancersQuery = useQuery<AdvancersResponse>({
+    queryKey: ['admin-advancers'],
+    queryFn: () => fetchJSON('/api/admin/third-place-advancers'),
+  });
+  const bracketQuery = useQuery<BracketResponse>({
+    queryKey: ['admin-r32-bracket'],
+    queryFn: () => fetchJSON('/api/admin/r32-bracket'),
+  });
+  const matchesQuery = useQuery<KnockoutMatch[]>({
+    queryKey: ['knockout-matches'],
+    queryFn: () => fetchJSON('/api/knockout-matches'),
   });
 
   const [status, setStatus] = React.useState<TournamentInfo['status']>('upcoming');
   const [lockTime, setLockTime] = React.useState('');
+  const [phaseTwoLockInput, setPhaseTwoLockInput] = React.useState('');
   const [championGoals, setChampionGoals] = React.useState('');
   const [saving, setSaving] = React.useState(false);
+  const [busyPhase2, setBusyPhase2] = React.useState(false);
 
   React.useEffect(() => {
     if (!tournament.data) return;
     setStatus(tournament.data.status);
     setLockTime(toDatetimeLocal(tournament.data.lockTime));
+    setPhaseTwoLockInput(toDatetimeLocal(tournament.data.knockoutLockTime));
     setChampionGoals(
       tournament.data.championTotalGoals == null ? '' : String(tournament.data.championTotalGoals)
     );
@@ -100,77 +137,193 @@ export function TournamentSettingsForm() {
     }
   };
 
+  // Phase 2 derived state.
+  const advancersCount = advancersQuery.data?.advancers.length ?? 0;
+  const assignmentsCount = bracketQuery.data?.assignments.length ?? 0;
+  const thirdPlaceSlotCount = React.useMemo(() => {
+    let n = 0;
+    for (const m of matchesQuery.data ?? []) {
+      if (m.stage !== 'round_of_32') continue;
+      if (m.team1Source.startsWith('3-')) n++;
+      if (m.team2Source.startsWith('3-')) n++;
+    }
+    return n;
+  }, [matchesQuery.data]);
+
+  const allAdvancersSet = advancersCount === 8;
+  const allAssignmentsSet =
+    thirdPlaceSlotCount > 0 && assignmentsCount === thirdPlaceSlotCount;
+  const canOpenPhaseTwo = allAdvancersSet && allAssignmentsSet;
+  const phase = tournament.data?.phase ?? 'phase1';
+
+  const togglePhaseTwo = async (unlock: boolean) => {
+    if (!tournament.data) return;
+    setBusyPhase2(true);
+    try {
+      const res = await fetch('/api/admin/tournament', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: tournament.data.id,
+          knockoutUnlocked: unlock,
+          knockoutLockTime:
+            unlock && phaseTwoLockInput ? new Date(phaseTwoLockInput).toISOString() : null,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? 'Failed');
+      }
+      toast.success(unlock ? 'Phase 2 opened' : 'Phase 2 closed');
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['tournament'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-advancers'] }),
+      ]);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed');
+    } finally {
+      setBusyPhase2(false);
+    }
+  };
+
   return (
     <PageLayout>
       <h1 className="mb-2 text-3xl font-bold">Admin</h1>
       <AdminNav />
 
-      <Card className="max-w-2xl">
-        <CardHeader>
-          <CardTitle>Tournament settings</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {tournament.isLoading || !tournament.data ? (
-            <p className="text-muted-foreground text-sm">Loading…</p>
-          ) : (
-            <>
-              <div className="space-y-1">
-                <Label>Name</Label>
-                <p className="text-sm">{tournament.data.name}</p>
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="status">Status</Label>
-                <Select
-                  value={status}
-                  onValueChange={(v) => setStatus(v as TournamentInfo['status'])}
-                >
-                  <SelectTrigger id="status">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {STATUSES.map((s) => (
-                      <SelectItem key={s} value={s}>
-                        {s}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="lockTime">Lock time</Label>
-                <Input
-                  id="lockTime"
-                  type="datetime-local"
-                  value={lockTime}
-                  onChange={(e) => setLockTime(e.target.value)}
-                />
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="championGoals">Champion&apos;s total goals (tiebreaker)</Label>
-                <Input
-                  id="championGoals"
-                  type="number"
-                  min={0}
-                  max={50}
-                  step={1}
-                  placeholder="Leave blank until tournament ends"
-                  value={championGoals}
-                  onChange={(e) => setChampionGoals(e.target.value)}
-                />
-                <p className="text-muted-foreground text-xs">
-                  Total goals scored by the World Cup champion across all 8 of their tournament
-                  matches (regulation and extra time only — penalty-shootout goals don&apos;t
-                  count). Used as the tiebreaker on the leaderboard. Leave blank until the
-                  tournament is complete.
-                </p>
-              </div>
-              <Button onClick={handleSave} disabled={saving}>
-                {saving ? 'Saving…' : 'Save changes'}
+      <div className="max-w-2xl space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Tournament settings</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {tournament.isLoading || !tournament.data ? (
+              <p className="text-muted-foreground text-sm">Loading…</p>
+            ) : (
+              <>
+                <div className="space-y-1">
+                  <Label>Name</Label>
+                  <p className="text-sm">{tournament.data.name}</p>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="status">Status</Label>
+                  <Select
+                    value={status}
+                    onValueChange={(v) => setStatus(v as TournamentInfo['status'])}
+                  >
+                    <SelectTrigger id="status">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STATUSES.map((s) => (
+                        <SelectItem key={s} value={s}>
+                          {s}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="lockTime">Phase 1 lock time</Label>
+                  <Input
+                    id="lockTime"
+                    type="datetime-local"
+                    value={lockTime}
+                    onChange={(e) => setLockTime(e.target.value)}
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    When group + advancer picks freeze. Tournament-wide cutoff for new
+                    predictions.
+                  </p>
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="championGoals">Champion&apos;s total goals (tiebreaker)</Label>
+                  <Input
+                    id="championGoals"
+                    type="number"
+                    min={0}
+                    max={50}
+                    step={1}
+                    placeholder="Leave blank until tournament ends"
+                    value={championGoals}
+                    onChange={(e) => setChampionGoals(e.target.value)}
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    Total goals scored by the World Cup champion across all 8 of their tournament
+                    matches (regulation and extra time only — penalty-shootout goals don&apos;t
+                    count). Used as the tiebreaker on the leaderboard. Leave blank until the
+                    tournament is complete.
+                  </p>
+                </div>
+                <Button onClick={handleSave} disabled={saving}>
+                  {saving ? 'Saving…' : 'Save changes'}
+                </Button>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              {phase === 'phase2_open' ? <Unlock className="h-5 w-5" /> : <Lock className="h-5 w-5" />}
+              Phase 2 (knockout predictions)
+            </CardTitle>
+            <p className="text-muted-foreground text-sm">
+              Currently{' '}
+              {phase === 'phase2_open'
+                ? 'open'
+                : phase === 'phase2_locked'
+                  ? 'closed (lock time has passed — set a new lock time to reopen)'
+                  : 'closed'}
+              . {advancersCount}/8 advancers set ·{' '}
+              {assignmentsCount}/{thirdPlaceSlotCount || 8} bracket slots assigned.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="phase2-lock">Phase 2 lock time</Label>
+              <Input
+                id="phase2-lock"
+                type="datetime-local"
+                value={phaseTwoLockInput}
+                onChange={(e) => setPhaseTwoLockInput(e.target.value)}
+                className="max-w-sm"
+                disabled={busyPhase2}
+              />
+              <p className="text-muted-foreground text-xs">
+                When knockout predictions freeze. Set + click Open Phase 2 to start the knockout
+                window. Advancers + R32 bracket assignments must be filled on the{' '}
+                <span className="font-mono">/admin/advancers</span> tab first.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                onClick={() => togglePhaseTwo(true)}
+                disabled={busyPhase2 || !canOpenPhaseTwo || phase === 'phase2_open'}
+                title={
+                  !allAdvancersSet
+                    ? 'Set all 8 advancers first'
+                    : !allAssignmentsSet
+                      ? 'Assign every R32 3rd-place slot first'
+                      : phase === 'phase2_locked'
+                        ? 'Phase 2 lock time has passed — set a new lock time above and click to reopen'
+                        : undefined
+                }
+              >
+                {phase === 'phase2_locked' ? 'Reopen Phase 2' : 'Open Phase 2'}
               </Button>
-            </>
-          )}
-        </CardContent>
-      </Card>
+              <Button
+                variant="outline"
+                onClick={() => togglePhaseTwo(false)}
+                disabled={busyPhase2 || phase !== 'phase2_open'}
+              >
+                Close Phase 2
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
     </PageLayout>
   );
 }

--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -84,7 +84,8 @@ export function TournamentSettingsForm() {
   const [lockTime, setLockTime] = React.useState('');
   const [phaseTwoLockInput, setPhaseTwoLockInput] = React.useState('');
   const [championGoals, setChampionGoals] = React.useState('');
-  const [saving, setSaving] = React.useState(false);
+  const [savingSettings, setSavingSettings] = React.useState(false);
+  const [savingPhase1, setSavingPhase1] = React.useState(false);
   const [busyPhase2, setBusyPhase2] = React.useState(false);
 
   React.useEffect(() => {
@@ -97,7 +98,7 @@ export function TournamentSettingsForm() {
     );
   }, [tournament.data]);
 
-  const handleSave = async () => {
+  const handleSaveSettings = async () => {
     if (!tournament.data) return;
 
     let championTotalGoals: number | null | undefined;
@@ -112,7 +113,7 @@ export function TournamentSettingsForm() {
       championTotalGoals = parsed;
     }
 
-    setSaving(true);
+    setSavingSettings(true);
     try {
       const res = await fetch('/api/admin/tournament', {
         method: 'PATCH',
@@ -120,7 +121,6 @@ export function TournamentSettingsForm() {
         body: JSON.stringify({
           id: tournament.data.id,
           status,
-          lockTime: new Date(lockTime).toISOString(),
           championTotalGoals,
         }),
       });
@@ -128,12 +128,41 @@ export function TournamentSettingsForm() {
         const body = await res.json().catch(() => ({}));
         throw new Error(body.error ?? 'Failed to save');
       }
-      toast.success('Tournament updated');
+      toast.success('Tournament settings updated');
       await queryClient.invalidateQueries({ queryKey: ['tournament'] });
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to save');
     } finally {
-      setSaving(false);
+      setSavingSettings(false);
+    }
+  };
+
+  const handleSavePhase1Lock = async () => {
+    if (!tournament.data) return;
+    if (!lockTime) {
+      toast.error('Pick a Phase 1 lock time first');
+      return;
+    }
+    setSavingPhase1(true);
+    try {
+      const res = await fetch('/api/admin/tournament', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: tournament.data.id,
+          lockTime: new Date(lockTime).toISOString(),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? 'Failed to save');
+      }
+      toast.success('Phase 1 lock time updated');
+      await queryClient.invalidateQueries({ queryKey: ['tournament'] });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to save');
+    } finally {
+      setSavingPhase1(false);
     }
   };
 
@@ -224,19 +253,6 @@ export function TournamentSettingsForm() {
                   </Select>
                 </div>
                 <div className="space-y-1">
-                  <Label htmlFor="lockTime">Phase 1 lock time</Label>
-                  <Input
-                    id="lockTime"
-                    type="datetime-local"
-                    value={lockTime}
-                    onChange={(e) => setLockTime(e.target.value)}
-                  />
-                  <p className="text-muted-foreground text-xs">
-                    When group + advancer picks freeze. Tournament-wide cutoff for new
-                    predictions.
-                  </p>
-                </div>
-                <div className="space-y-1">
                   <Label htmlFor="championGoals">Champion&apos;s total goals (tiebreaker)</Label>
                   <Input
                     id="championGoals"
@@ -255,11 +271,47 @@ export function TournamentSettingsForm() {
                     tournament is complete.
                   </p>
                 </div>
-                <Button onClick={handleSave} disabled={saving}>
-                  {saving ? 'Saving…' : 'Save changes'}
+                <Button onClick={handleSaveSettings} disabled={savingSettings}>
+                  {savingSettings ? 'Saving…' : 'Save changes'}
                 </Button>
               </>
             )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              {phase === 'phase1' ? <Unlock className="h-5 w-5" /> : <Lock className="h-5 w-5" />}
+              Phase 1 (group + advancer predictions)
+            </CardTitle>
+            <p className="text-muted-foreground text-sm">
+              Currently{' '}
+              {phase === 'phase1'
+                ? 'open — users can edit groups + advancers'
+                : 'closed — group + advancer picks are frozen'}
+              .
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="lockTime">Phase 1 lock time</Label>
+              <Input
+                id="lockTime"
+                type="datetime-local"
+                value={lockTime}
+                onChange={(e) => setLockTime(e.target.value)}
+                className="max-w-sm"
+                disabled={savingPhase1}
+              />
+              <p className="text-muted-foreground text-xs">
+                When group + advancer picks freeze. Tournament-wide cutoff for new
+                predictions.
+              </p>
+            </div>
+            <Button onClick={handleSavePhase1Lock} disabled={savingPhase1}>
+              {savingPhase1 ? 'Saving…' : 'Save Phase 1 lock time'}
+            </Button>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary

Per your request:

1. **Rename "Lock time" → "Phase 1 lock time"** on the Tournament tab, with a one-line helper explaining what it does.
2. **Move the Phase 2 lock card** (lock time input + Open/Close/Reopen buttons) from `/admin/advancers` to `/admin/tournament`, so all tournament-wide locking lives in one place.

The Advancers tab keeps the 8-rank picker and the R32 bracket assignment grid — those are scoring/data inputs, not lock controls. A small note in the Advancers heading points the admin to the Tournament tab for Phase 2 toggling.

The Phase 2 controls still gate on the same preflight checks (all 8 advancers set + all R32 3rd-place slots assigned) — the queries that drive those checks are now fetched on the Tournament tab too.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 281/281 passing
- [x] `npx eslint src` — clean
- [ ] `/admin/tournament`: shows "Phase 1 lock time" + a separate Phase 2 lock card with the same Open/Close behavior as before.
- [ ] `/admin/advancers`: Phase 2 card no longer appears; rank picker + R32 bracket assignment still work.
- [ ] End-to-end: set 8 advancers + all R32 assignments on Advancers tab → Open Phase 2 on Tournament tab → predictions page shows phase2_open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)