### PR TITLE
feat(scoring): bump advancer set-membership from 0.25 to 1.0

### DIFF
--- a/frontend/src/app/HomePageContent.tsx
+++ b/frontend/src/app/HomePageContent.tsx
@@ -359,7 +359,7 @@ export function HomePageContent() {
                 <span className="text-muted-foreground">
                   Team in the actual top 8 (any rank)
                 </span>
-                <span className="font-semibold">+0.25 pts</span>
+                <span className="font-semibold">+1 pt</span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">Team at the exact correct rank</span>
@@ -369,7 +369,7 @@ export function HomePageContent() {
                 <span className="font-semibold">Bonuses stack:</span>{' '}
                 <span className="text-muted-foreground">
                   a team in the correct rank earns the full <span className="font-semibold">
-                    +0.5
+                    +1.25
                   </span>{' '}
                   (set + rank).
                 </span>

--- a/frontend/src/components/predictions/AdvancersForm.tsx
+++ b/frontend/src/components/predictions/AdvancersForm.tsx
@@ -79,8 +79,8 @@ export function AdvancersForm({
                 first.
               </p>
               <p>
-                <strong>Per pick:</strong> +0.25 if your team is in the actual top 8;
-                additional +0.25 if it&apos;s at the exact rank. Max <strong>+4 points</strong>{' '}
+                <strong>Per pick:</strong> +1 if your team is in the actual top 8;
+                additional +0.25 if it&apos;s at the exact rank. Max <strong>+10 points</strong>{' '}
                 across all 8 ranks.
               </p>
             </>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -10,14 +10,14 @@ export const TOURNAMENT_CONFIG = {
 } as const;
 
 // Group stage: 11 standard groups × 6 (exact-order top-2) + Group I "Group of Death" exact-order = 8.
-// Advancers: 8 ranked 3rd-place picks × 0.5 (correct team + correct rank) = 4 max.
+// Advancers: 8 ranked 3rd-place picks × 1.25 (set + rank) = 10 max.
 // Knockout: per-team correct-side maxes — R16 16×5 + QF 8×6 + SF 4×8 + Final 2×10 = 180 — plus
 // flat bonuses (champion 15, 3rd-place winner 5) = 200.
 export const SCORING = {
   maxGroupPoints: 74,
-  maxAdvancerPoints: 4,
+  maxAdvancerPoints: 10,
   maxKnockoutPoints: 200,
-  maxTotalPoints: 278,
+  maxTotalPoints: 284,
 } as const;
 
 /**

--- a/supabase/migrations/0031_advancer_scoring_bump.sql
+++ b/supabase/migrations/0031_advancer_scoring_bump.sql
@@ -1,0 +1,331 @@
+-- Advancers v2.1: bump set-membership weight.
+--
+-- Old weights (0028): +0.25 set, +0.25 rank → max 4 advancer points.
+-- New weights:        +1.00 set, +0.25 rank → max 10 advancer points.
+--
+-- Per advancer pick:
+--   * team in the actual top-8 AND at the same rank → 1.25 (1 + 0.25)
+--   * team in the actual top-8 (any rank)           → 1.00
+--   * else                                          → 0
+--
+-- New leaderboard max: 74 (groups) + 10 (advancers) + 200 (knockout) = 284.
+
+create or replace function public.get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    total_goals int,
+    total_count bigint
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 8 else 6 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 4
+                    when gp.first_team_id = gs.first_team_id or gp.second_team_id = gs.second_team_id
+                        then 3
+                    when gp.first_team_id = gs.second_team_id or gp.second_team_id = gs.first_team_id
+                        then 2
+                    else 0
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 1.25
+                    when ta_team.team_id is not null then 1.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    r16_scores as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_32', 5, 3)),
+    qf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_16', 6, 3)),
+    sf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'quarter_finals', 8, 4)),
+    f_scores   as (select * from public.knockout_round_scores(p_tournament_id, 'semi_finals', 10, 5)),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 15 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M32'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 5 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M31'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M31'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(r16.round_points, 0)
+             + coalesce(qf.round_points, 0)
+             + coalesce(sf.round_points, 0)
+             + coalesce(fs.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points
+        from public.predictions p
+        left join r16_scores r16 on r16.prediction_id = p.id
+        left join qf_scores qf on qf.prediction_id = p.id
+        left join sf_scores sf on sf.prediction_id = p.id
+        left join f_scores fs on fs.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            pr.username::text as username,
+            coalesce(gsc.group_points, 0) as group_points,
+            coalesce(asc_.advancer_points, 0)::numeric as advancer_points,
+            coalesce(ksc.knockout_points, 0) as knockout_points,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0))::numeric as points,
+            p.total_goals,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc
+            )::int as rank
+        from public.predictions p
+        join public.profiles pr on pr.id = p.user_id
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and p.submitted_at is not null
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        rank,
+        prediction_id,
+        prediction_name,
+        username,
+        points,
+        group_points,
+        advancer_points,
+        knockout_points,
+        total_goals,
+        count(*) over () as total_count
+    from ranked
+    order by rank
+    offset greatest(p_page - 1, 0) * greatest(p_page_size, 1)
+    limit greatest(p_page_size, 1);
+$$;
+
+-- ========== get_leaderboard_rank ==========
+
+create or replace function public.get_leaderboard_rank(
+    p_tournament_id uuid,
+    p_user_id uuid,
+    p_page_size int default 25
+)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    rank int,
+    page int,
+    points numeric
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 8 else 6 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 4
+                    when gp.first_team_id = gs.first_team_id or gp.second_team_id = gs.second_team_id
+                        then 3
+                    when gp.first_team_id = gs.second_team_id or gp.second_team_id = gs.first_team_id
+                        then 2
+                    else 0
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 1.25
+                    when ta_team.team_id is not null then 1.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    r16_scores as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_32', 5, 3)),
+    qf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_16', 6, 3)),
+    sf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'quarter_finals', 8, 4)),
+    f_scores   as (select * from public.knockout_round_scores(p_tournament_id, 'semi_finals', 10, 5)),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 15 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M32'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 5 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M31'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M31'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(r16.round_points, 0)
+             + coalesce(qf.round_points, 0)
+             + coalesce(sf.round_points, 0)
+             + coalesce(fs.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points
+        from public.predictions p
+        left join r16_scores r16 on r16.prediction_id = p.id
+        left join qf_scores qf on qf.prediction_id = p.id
+        left join sf_scores sf on sf.prediction_id = p.id
+        left join f_scores fs on fs.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            p.user_id,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0))::numeric as points,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc
+            )::int as rank
+        from public.predictions p
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and p.submitted_at is not null
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        prediction_id,
+        prediction_name,
+        rank,
+        ((rank - 1) / greatest(p_page_size, 1) + 1)::int as page,
+        points
+    from ranked
+    where user_id = p_user_id
+    order by rank;
+$$;


### PR DESCRIPTION
## Summary

Per product direction, the Best 3rd-Place Advancers set-membership bonus is going from **+0.25 → +1.0**. The exact-rank bonus stays at **+0.25** and continues to stack with the set bonus.

| Match | Old | **New** |
|---|---|---|
| Team in actual top-8 AND at same rank | +0.5 | **+1.25** |
| Team in actual top-8 (any rank) | +0.25 | **+1.0** |
| Not in top-8 | 0 | 0 |

| Total | Old | **New** |
|---|---|---|
| Max advancer points | 4 | **10** |
| Max leaderboard total (groups 74 + advancers + knockout 200) | 278 | **284** |

## Changes

- **Migration 0031**: redefines `get_leaderboard` and `get_leaderboard_rank` with the new case-coefficients in the `advancer_scores` CTE.
- **`frontend/src/lib/constants.ts`**: `maxAdvancerPoints: 4 → 10`, `maxTotalPoints: 278 → 284`.
- **`frontend/src/app/HomePageContent.tsx`** (scoring breakdown card): `+0.25 → +1 pt` for set, stack-total `+0.5 → +1.25`.
- **`frontend/src/components/predictions/AdvancersForm.tsx`** ("How is this scored?" callout): same copy update.

## Test plan

- [x] `supabase db reset` — all 31 migrations apply
- [x] `npm run typecheck` — clean
- [x] `npm test` — 281/281 passing (the constants test asserts `maxGroupPoints + maxAdvancerPoints + maxKnockoutPoints === maxTotalPoints`)
- [x] `npx eslint src` — clean
- [ ] In local dev: pick 8 advancers; admin sets the actual top-8 with, e.g., 4 matches and 1 in the correct rank → leaderboard row reads `4.25` advancer points (3×1.00 + 1×1.25).
- [ ] Homepage `/`: scoring breakdown reads `+1 pt` set, `+0.25` rank, "+1.25 (set + rank)", and "Maximum Advancer Points: 10 pts". Total card reads 284.

## Deploy note

Push migration 0031 to prod before/with the next frontend deploy so the new constants match the RPC output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)