### PR TITLE
feat(pages): add /about, /rules, /terms, /privacy

### DIFF
--- a/frontend/src/app/HomePageContent.tsx
+++ b/frontend/src/app/HomePageContent.tsx
@@ -5,11 +5,12 @@ import { useQuery } from '@tanstack/react-query';
 import { Clock, Trophy, Users, UserPlus, Target, Award, ChevronRight } from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
+import { ScoringBreakdown } from '@/components/marketing/ScoringBreakdown';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { SCORING, ROUTES, TOURNAMENT_CONFIG } from '@/lib/constants';
+import { ROUTES, TOURNAMENT_CONFIG } from '@/lib/constants';
 import type { TournamentInfo } from '@/types/tournament';
 
 interface TournamentResponse {
@@ -215,194 +216,7 @@ export function HomePageContent() {
         </div>
       </section>
 
-      <section className="py-12">
-        <h2 className="mb-8 text-center text-2xl font-bold md:text-3xl">Scoring Breakdown</h2>
-        <div className="grid gap-6 md:grid-cols-2">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Users className="text-primary h-5 w-5" />
-                Group Stage
-              </CardTitle>
-              <CardDescription>
-                Scored on the top two finishers in each of the {TOURNAMENT_CONFIG.totalGroups}{' '}
-                groups
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">Both top 2, exact order</span>
-                  <span className="font-semibold">+6 points</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">Both top 2, swapped</span>
-                  <span className="font-semibold">+4 points</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">One correct, in correct slot</span>
-                  <span className="font-semibold">+3 points</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">One correct, in wrong slot</span>
-                  <span className="font-semibold">+2 points</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">None correct</span>
-                  <span className="font-semibold">+0 points</span>
-                </div>
-                <div className="bg-muted/50 rounded-md p-3 text-sm">
-                  <span className="font-semibold">Group of Death (Group I):</span>{' '}
-                  <span className="text-muted-foreground">
-                    Both top 2 in exact order pays <span className="font-semibold">+8</span> instead
-                    of +6.
-                  </span>
-                </div>
-                <div className="border-t pt-3">
-                  <div className="flex items-center justify-between font-semibold">
-                    <span>Maximum Group Points</span>
-                    <span className="text-primary">{SCORING.maxGroupPoints} pts</span>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Trophy className="text-primary h-5 w-5" />
-                Knockout Stage
-              </CardTitle>
-              <CardDescription>
-                Each round, every team that advances scores you points — more if you had them in
-                the right slot.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
-                <div className="flex items-center justify-between gap-4">
-                  <span className="text-muted-foreground">
-                    Round of 16{' '}
-                    <span className="text-muted-foreground/70 text-xs">(per team advancing)</span>
-                  </span>
-                  <span className="font-semibold whitespace-nowrap">+5 / +3 pts</span>
-                </div>
-                <div className="flex items-center justify-between gap-4">
-                  <span className="text-muted-foreground">
-                    Quarter-finals{' '}
-                    <span className="text-muted-foreground/70 text-xs">(per team advancing)</span>
-                  </span>
-                  <span className="font-semibold whitespace-nowrap">+6 / +3 pts</span>
-                </div>
-                <div className="flex items-center justify-between gap-4">
-                  <span className="text-muted-foreground">
-                    Semi-finals{' '}
-                    <span className="text-muted-foreground/70 text-xs">(per team advancing)</span>
-                  </span>
-                  <span className="font-semibold whitespace-nowrap">+8 / +4 pts</span>
-                </div>
-                <div className="flex items-center justify-between gap-4">
-                  <span className="text-muted-foreground">
-                    Final{' '}
-                    <span className="text-muted-foreground/70 text-xs">(per finalist)</span>
-                  </span>
-                  <span className="font-semibold whitespace-nowrap">+10 / +5 pts</span>
-                </div>
-                <div className="flex items-center justify-between gap-4">
-                  <span className="text-muted-foreground">Third Place Match Winner</span>
-                  <span className="font-semibold">+5 pts</span>
-                </div>
-                <div className="flex items-center justify-between gap-4">
-                  <span className="text-muted-foreground">World Cup Champion</span>
-                  <span className="font-semibold">+15 pts</span>
-                </div>
-                <div className="bg-muted/50 rounded-md p-3 text-xs">
-                  <span className="font-semibold">Correct slot vs. wrong slot:</span>{' '}
-                  <span className="text-muted-foreground">
-                    Correct slot = the team advanced from the bracket match you predicted. Wrong
-                    slot = the team advanced, but from a different match in the same round.
-                  </span>
-                </div>
-                <div className="bg-muted/50 rounded-md p-3 text-xs">
-                  <span className="font-semibold">Round of 32:</span>{' '}
-                  <span className="text-muted-foreground">
-                    Picks aren&apos;t scored on their own — they decide which teams sit in your
-                    Round-of-16 slots.
-                  </span>
-                </div>
-                <div className="border-t pt-3">
-                  <div className="flex items-center justify-between font-semibold">
-                    <span>Maximum Knockout Points</span>
-                    <span className="text-primary">{SCORING.maxKnockoutPoints} pts</span>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-
-        <Card className="mt-6">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Target className="text-primary h-5 w-5" />
-              Best 3rd-Place Advancers
-            </CardTitle>
-            <CardDescription>
-              FIFA 2026 advances 8 of the 12 group third-place teams to the Round of 32. Pick
-              8 teams from your group-stage 3rd-place predictions and rank them — best first.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">
-                  Team in the actual top 8 (any rank)
-                </span>
-                <span className="font-semibold">+1 pt</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">Team at the exact correct rank</span>
-                <span className="font-semibold">+0.25 pts</span>
-              </div>
-              <div className="bg-muted/50 rounded-md p-3 text-xs">
-                <span className="font-semibold">Bonuses stack:</span>{' '}
-                <span className="text-muted-foreground">
-                  a team in the correct rank earns the full <span className="font-semibold">
-                    +1.25
-                  </span>{' '}
-                  (set + rank).
-                </span>
-              </div>
-              <div className="border-t pt-3">
-                <div className="flex items-center justify-between font-semibold">
-                  <span>Maximum Advancer Points</span>
-                  <span className="text-primary">{SCORING.maxAdvancerPoints} pts</span>
-                </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="mt-6">
-          <CardContent className="flex flex-col items-center justify-between gap-4 py-6 sm:flex-row">
-            <div>
-              <p className="text-muted-foreground text-sm">Tiebreaker</p>
-              <p className="font-medium">
-                Predict the total goals scored by the World Cup champion across all 8 of their
-                tournament matches. Closest to actual wins.
-              </p>
-              <p className="text-muted-foreground mt-1 text-xs">
-                Regulation and extra time only — penalty-shootout goals don&apos;t count.
-              </p>
-            </div>
-            <div className="text-center sm:text-right">
-              <p className="text-muted-foreground text-sm">Maximum Total Points</p>
-              <p className="text-primary text-3xl font-bold">{SCORING.maxTotalPoints}</p>
-            </div>
-          </CardContent>
-        </Card>
-      </section>
+      <ScoringBreakdown />
 
       <section className="py-12">
         <Card className="bg-primary/5 border-primary/20">

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,0 +1,133 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ChevronRight, ClipboardList, Trophy, UserPlus, Users } from 'lucide-react';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { ROUTES, TOURNAMENT_CONFIG } from '@/lib/constants';
+
+export const metadata: Metadata = {
+  title: 'About | World Cup 2026',
+  description:
+    'About the World Cup 2026 Prediction Game — submit bracket predictions, earn points for correct picks, and climb the leaderboard.',
+};
+
+export default function AboutPage() {
+  return (
+    <PageLayout>
+      <section className="py-12 text-center md:py-16">
+        <Badge variant="outline" className="mb-4">
+          About
+        </Badge>
+        <h1 className="mb-4 text-3xl font-bold tracking-tight md:text-5xl">
+          About the <span className="text-primary">Prediction Game</span>
+        </h1>
+        <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
+          A friendly bracket-prediction game for the FIFA World Cup 2026. Lock in your picks
+          before kickoff, watch results roll in, and see how your bracket stacks up against
+          everyone else&apos;s.
+        </p>
+      </section>
+
+      <section className="py-8">
+        <h2 className="mb-8 text-center text-2xl font-bold md:text-3xl">How it works</h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <Card>
+            <CardHeader>
+              <UserPlus className="text-primary mb-2 h-8 w-8" />
+              <CardTitle>1. Create an account</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground text-sm">
+                Sign up with an email and password. We&apos;ll generate a username you can
+                change later from your account page.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <ClipboardList className="text-primary mb-2 h-8 w-8" />
+              <CardTitle>2. Submit predictions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground text-sm">
+                Pick group standings, fill in the knockout bracket, and set your tiebreaker.
+                You can save up to five named predictions and edit any of them until lock.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <Users className="text-primary mb-2 h-8 w-8" />
+              <CardTitle>3. Results post</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground text-sm">
+                As matches finish, the admin posts the real-world results and points are
+                awarded automatically for each of your predictions.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <Trophy className="text-primary mb-2 h-8 w-8" />
+              <CardTitle>4. Climb the leaderboard</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground text-sm">
+                Every prediction is its own leaderboard entry. The closer you are to the
+                actual results, the higher you rank.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section className="py-12">
+        <Card>
+          <CardHeader>
+            <CardTitle>What you predict</CardTitle>
+            <CardDescription>
+              Three layers, all submitted before a single tournament-wide lock time.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="text-muted-foreground space-y-3 text-sm">
+              <li>
+                <span className="text-foreground font-semibold">Group stage standings.</span>{' '}
+                Rank teams 1st through 4th for all {TOURNAMENT_CONFIG.totalGroups} groups, plus
+                pick eight teams from your 3rd-place picks to be the best 3rd-place advancers.
+              </li>
+              <li>
+                <span className="text-foreground font-semibold">Knockout bracket.</span> Pick a
+                winner for every match from the Round of 32 through the final, including the
+                third-place match.
+              </li>
+              <li>
+                <span className="text-foreground font-semibold">Tiebreaker.</span> Predict the
+                total goals scored by the eventual champion across their eight tournament
+                matches (regulation + extra time only).
+              </li>
+            </ul>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Button asChild>
+                <Link href={ROUTES.rules}>
+                  Read the full rules
+                  <ChevronRight className="ml-1 h-4 w-4" />
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href={ROUTES.register}>Create an account</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,193 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Separator } from '@/components/ui/separator';
+import { Badge } from '@/components/ui/badge';
+import { ROUTES } from '@/lib/constants';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy | World Cup 2026',
+  description:
+    'Privacy Policy for the World Cup 2026 Prediction Game — what data we collect, how it is used, and your rights.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <PageLayout>
+      <article className="mx-auto max-w-3xl py-12">
+        <Badge variant="outline" className="mb-4">
+          Legal
+        </Badge>
+        <h1 className="mb-2 text-3xl font-bold tracking-tight md:text-4xl">Privacy Policy</h1>
+        <p className="text-muted-foreground mb-8 text-sm">Last updated: 2026-05-14</p>
+
+        <div className="space-y-8 text-sm leading-relaxed">
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">Overview</h2>
+            <p className="text-muted-foreground">
+              This policy explains what information the World Cup 2026 Prediction Game
+              collects about you, how we use it, and the choices you have. We try to keep
+              the answer short: we collect what we need to run the game, and nothing we
+              don&apos;t.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">What we collect</h2>
+            <ul className="text-muted-foreground ml-6 list-disc space-y-2">
+              <li>
+                <span className="text-foreground font-semibold">Account information.</span>{' '}
+                The email and password you use to register, plus a username (auto-generated
+                at signup; you can change it from your account page) and an optional display
+                name and avatar URL.
+              </li>
+              <li>
+                <span className="text-foreground font-semibold">Your predictions.</span>{' '}
+                Group-stage picks, knockout bracket picks, tiebreaker, prediction names, and
+                related metadata such as when each prediction was last saved.
+              </li>
+              <li>
+                <span className="text-foreground font-semibold">Payment status.</span>{' '}
+                Whether and when an admin marked a prediction as paid for leaderboard
+                eligibility. We do not collect or store payment-card details on this site.
+              </li>
+              <li>
+                <span className="text-foreground font-semibold">Basic request metadata.</span>{' '}
+                IP address, user agent, and similar information needed to deliver the site
+                and apply abuse / rate-limiting protections at the network edge.
+              </li>
+            </ul>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">How we use it</h2>
+            <ul className="text-muted-foreground ml-6 list-disc space-y-2">
+              <li>To authenticate you and keep your session active.</li>
+              <li>To save, score, and display your predictions.</li>
+              <li>
+                To display your username, prediction name, and points on the public
+                leaderboard once a prediction is marked paid and the tournament locks. (See{' '}
+                <Link href={ROUTES.rules} className="underline">
+                  rules
+                </Link>{' '}
+                for the scoring details.)
+              </li>
+              <li>
+                To protect the Service from abuse — including rate limiting, request
+                filtering, and incident investigation.
+              </li>
+            </ul>
+            <p className="text-muted-foreground mt-3">
+              We do not sell your personal information, and we do not use it for advertising.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">
+              Service providers we use
+            </h2>
+            <ul className="text-muted-foreground ml-6 list-disc space-y-2">
+              <li>
+                <span className="text-foreground font-semibold">Supabase</span> — hosts our
+                Postgres database and handles authentication (email + password) on our
+                behalf.
+              </li>
+              <li>
+                <span className="text-foreground font-semibold">Cloudflare</span> — delivers
+                the site, terminates TLS, and applies network-level rate limiting and bot
+                protection.
+              </li>
+            </ul>
+            <p className="text-muted-foreground mt-3">
+              These providers process data on our behalf under their own privacy and
+              security commitments. Your data may be processed in regions outside your
+              own.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">Cookies</h2>
+            <p className="text-muted-foreground mb-3">
+              We use a small number of strictly-necessary cookies to keep you signed in and
+              to remember a few UI preferences (such as your theme). We do not use
+              third-party advertising cookies or cross-site trackers.
+            </p>
+            <p className="text-muted-foreground">
+              You can clear these cookies at any time in your browser settings; doing so will
+              sign you out.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">What is public</h2>
+            <p className="text-muted-foreground">
+              Once your prediction is marked paid and the tournament locks, your username,
+              prediction name, and points become visible on the public leaderboard. Your
+              email address, password, and unpaid predictions are never shown publicly.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">Your rights</h2>
+            <p className="text-muted-foreground mb-3">
+              You can ask us to access, correct, export, or delete the personal data we hold
+              about you by contacting us using the address below. We&apos;ll respond within
+              a reasonable time and may need to verify your identity first.
+            </p>
+            <p className="text-muted-foreground">
+              Depending on where you live, you may have additional rights under laws such as
+              the GDPR or your local equivalent.
+              {/* TODO: confirm jurisdiction-specific language with legal review */}
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">Children</h2>
+            <p className="text-muted-foreground">
+              The Service is not directed at children. If we learn we have collected
+              personal data from a child below the applicable age in their jurisdiction, we
+              will delete it.
+              {/* TODO: confirm minimum-age threshold and any region-specific notices */}
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">Changes to this policy</h2>
+            <p className="text-muted-foreground">
+              We may update this policy from time to time. Material changes will be
+              reflected by updating the &quot;Last updated&quot; date above. Significant
+              changes may be announced in the Service.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">Contact</h2>
+            <p className="text-muted-foreground">
+              Privacy questions or requests? Contact us at [contact email TBD].
+              {/* TODO: replace with a real contact email before launch */}
+            </p>
+          </section>
+        </div>
+      </article>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from 'next';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { ScoringBreakdown } from '@/components/marketing/ScoringBreakdown';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+export const metadata: Metadata = {
+  title: 'Rules | World Cup 2026',
+  description:
+    'Game rules and scoring breakdown for the World Cup 2026 Prediction Game — predictions, lock time, payment, leaderboard, and how points are calculated.',
+};
+
+export default function RulesPage() {
+  return (
+    <PageLayout>
+      <section className="py-12 text-center md:py-16">
+        <Badge variant="outline" className="mb-4">
+          Rules
+        </Badge>
+        <h1 className="mb-4 text-3xl font-bold tracking-tight md:text-5xl">Game Rules</h1>
+        <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
+          Everything you need to know to play — what you predict, when it locks, and exactly
+          how points are awarded.
+        </p>
+      </section>
+
+      <section className="py-8">
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>How predictions work</CardTitle>
+              <CardDescription>The basics of submitting a bracket.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="text-muted-foreground space-y-3 text-sm">
+                <li>
+                  <span className="text-foreground font-semibold">Account required.</span>{' '}
+                  You need a registered account to submit predictions.
+                </li>
+                <li>
+                  <span className="text-foreground font-semibold">
+                    Up to five named predictions.
+                  </span>{' '}
+                  Each account can save as many as five separate predictions per tournament.
+                  Each has its own name, picks, and tiebreaker.
+                </li>
+                <li>
+                  <span className="text-foreground font-semibold">Edit until lock.</span> Any
+                  prediction can be edited (or deleted, if unpaid) right up until the
+                  tournament-wide lock time.
+                </li>
+                <li>
+                  <span className="text-foreground font-semibold">
+                    Independently scored.
+                  </span>{' '}
+                  Predictions don&apos;t combine. Each one is scored and ranked on its own —
+                  if you have several, each one occupies its own leaderboard row.
+                </li>
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Leaderboard eligibility</CardTitle>
+              <CardDescription>What gets you onto the public leaderboard.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="text-muted-foreground space-y-3 text-sm">
+                <li>
+                  <span className="text-foreground font-semibold">Per-prediction entry.</span>{' '}
+                  Each paid prediction is its own entry. A single account can have multiple
+                  ranks if it has multiple paid predictions.
+                </li>
+                <li>
+                  <span className="text-foreground font-semibold">
+                    Marked paid by an admin.
+                  </span>{' '}
+                  An admin marks each prediction as paid before lock. Only paid predictions
+                  appear on the leaderboard.
+                </li>
+                <li>
+                  <span className="text-foreground font-semibold">Unpaid still saves.</span>{' '}
+                  You can still create and edit unpaid predictions; they just won&apos;t be
+                  scored on the public ranking.
+                </li>
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <ScoringBreakdown />
+
+      <section className="py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Lock time</CardTitle>
+            <CardDescription>One deadline for the whole tournament.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground text-sm">
+              The tournament has a single, tournament-wide lock time. Once it passes, no
+              prediction can be created, edited, or deleted — every entry is frozen for
+              scoring. There is no per-match or per-round deadline; submit and adjust as often
+              as you like until the cutoff.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -1,0 +1,169 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Separator } from '@/components/ui/separator';
+import { Badge } from '@/components/ui/badge';
+import { ROUTES } from '@/lib/constants';
+
+export const metadata: Metadata = {
+  title: 'Terms of Use | World Cup 2026',
+  description:
+    'Terms of Use for the World Cup 2026 Prediction Game — accounts, acceptable use, predictions, and disclaimers.',
+};
+
+export default function TermsPage() {
+  return (
+    <PageLayout>
+      <article className="mx-auto max-w-3xl py-12">
+        <Badge variant="outline" className="mb-4">
+          Legal
+        </Badge>
+        <h1 className="mb-2 text-3xl font-bold tracking-tight md:text-4xl">Terms of Use</h1>
+        <p className="text-muted-foreground mb-8 text-sm">Last updated: 2026-05-14</p>
+
+        <div className="space-y-8 text-sm leading-relaxed">
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">1. Acceptance of terms</h2>
+            <p className="text-muted-foreground">
+              By creating an account or otherwise using the World Cup 2026 Prediction Game (the
+              &quot;Service&quot;), you agree to these Terms of Use. If you do not agree, do
+              not use the Service.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">
+              2. Eligibility and accounts
+            </h2>
+            <p className="text-muted-foreground mb-3">
+              You must be old enough under the laws of your jurisdiction to enter into a
+              binding contract in order to use the Service.
+              {/* TODO: confirm minimum-age threshold with legal review before launch */}
+            </p>
+            <p className="text-muted-foreground mb-3">
+              You agree to provide accurate information when registering, to keep your
+              credentials confidential, and to be responsible for activity that occurs under
+              your account. One account per person.
+            </p>
+            <p className="text-muted-foreground">
+              We may suspend or close accounts that appear to be duplicates, automated, or
+              used to abuse the Service.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">3. Acceptable use</h2>
+            <p className="text-muted-foreground mb-3">You agree not to:</p>
+            <ul className="text-muted-foreground ml-6 list-disc space-y-2">
+              <li>Scrape, crawl, or otherwise harvest data from the Service automatically.</li>
+              <li>
+                Attempt to disrupt the leaderboard, scoring, or any other Service feature.
+              </li>
+              <li>
+                Probe, scan, or attempt to gain unauthorized access to accounts, systems, or
+                data.
+              </li>
+              <li>Harass, threaten, or abuse other users.</li>
+              <li>Use the Service to do anything illegal under applicable law.</li>
+            </ul>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">
+              4. Predictions and scoring
+            </h2>
+            <p className="text-muted-foreground mb-3">
+              Predictions, scoring, and leaderboard eligibility are governed by the rules
+              published at <Link href={ROUTES.rules} className="underline">/rules</Link>. We
+              may amend those rules before the tournament-wide lock time; once the lock time
+              passes, the rules in force at that moment apply to scoring for the tournament.
+            </p>
+            <p className="text-muted-foreground">
+              Match results, group standings, and other tournament outcomes are entered by
+              authorized administrators. We use reasonable care, but we make no guarantee
+              that any entry will be made within a particular time window.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">5. No affiliation</h2>
+            <p className="text-muted-foreground">
+              This is an independent, fan-run prediction game. It is not affiliated with,
+              endorsed by, or sponsored by FIFA, any participating football association, any
+              broadcaster, or any tournament sponsor. All team names, country names, and
+              tournament references are used for identification only.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">6. No warranty</h2>
+            <p className="text-muted-foreground">
+              The Service is provided &quot;as is&quot; and &quot;as available&quot;, without
+              warranties of any kind, express or implied. We do not warrant that the Service
+              will be uninterrupted, error-free, or available at any particular time, or that
+              scoring will be free of errors.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">
+              7. Limitation of liability
+            </h2>
+            <p className="text-muted-foreground">
+              To the maximum extent permitted by law, in no event will the operators of the
+              Service be liable for any indirect, incidental, special, consequential, or
+              punitive damages, or any loss of data or profits, arising out of or in
+              connection with your use of the Service.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">8. Changes to the terms</h2>
+            <p className="text-muted-foreground">
+              We may update these Terms of Use from time to time. Material changes will be
+              indicated by updating the &quot;Last updated&quot; date above. Your continued
+              use of the Service after a change takes effect constitutes acceptance of the
+              new terms.
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">9. Governing law</h2>
+            <p className="text-muted-foreground">
+              These terms are governed by the laws of [Jurisdiction TBD], without regard to
+              its conflict-of-law principles.
+              {/* TODO: set governing-law jurisdiction with legal review before launch */}
+            </p>
+          </section>
+
+          <Separator />
+
+          <section>
+            <h2 className="text-foreground mb-3 text-xl font-semibold">10. Contact</h2>
+            <p className="text-muted-foreground">
+              Questions about these terms? Contact us at [contact email TBD].
+              {/* TODO: replace with a real contact email before launch */}
+            </p>
+          </section>
+        </div>
+      </article>
+    </PageLayout>
+  );
+}

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -2,12 +2,13 @@
 
 import Link from 'next/link';
 import { Separator } from '@/components/ui/separator';
+import { ROUTES } from '@/lib/constants';
 
 const footerLinks = [
-  { label: 'About', href: '/about' },
-  { label: 'Rules', href: '/rules' },
-  { label: 'Terms', href: '/terms' },
-  { label: 'Privacy', href: '/privacy' },
+  { label: 'About', href: ROUTES.about },
+  { label: 'Rules', href: ROUTES.rules },
+  { label: 'Terms', href: ROUTES.terms },
+  { label: 'Privacy', href: ROUTES.privacy },
 ];
 
 export function Footer() {

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -24,6 +24,8 @@ const baseNavLinks = [
   { label: 'Home', href: ROUTES.home },
   { label: 'Predictions', href: ROUTES.predictions },
   { label: 'Leaderboard', href: ROUTES.leaderboard },
+  { label: 'Rules', href: ROUTES.rules },
+  { label: 'About', href: ROUTES.about },
 ];
 
 export function Header() {

--- a/frontend/src/components/marketing/ScoringBreakdown.tsx
+++ b/frontend/src/components/marketing/ScoringBreakdown.tsx
@@ -1,0 +1,197 @@
+import { Trophy, Users, Target } from 'lucide-react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { SCORING, TOURNAMENT_CONFIG } from '@/lib/constants';
+
+export function ScoringBreakdown() {
+  return (
+    <section className="py-12">
+      <h2 className="mb-8 text-center text-2xl font-bold md:text-3xl">Scoring Breakdown</h2>
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="text-primary h-5 w-5" />
+              Group Stage
+            </CardTitle>
+            <CardDescription>
+              Scored on the top two finishers in each of the {TOURNAMENT_CONFIG.totalGroups}{' '}
+              groups
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Both top 2, exact order</span>
+                <span className="font-semibold">+6 points</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Both top 2, swapped</span>
+                <span className="font-semibold">+4 points</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">One correct, in correct slot</span>
+                <span className="font-semibold">+3 points</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">One correct, in wrong slot</span>
+                <span className="font-semibold">+2 points</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">None correct</span>
+                <span className="font-semibold">+0 points</span>
+              </div>
+              <div className="bg-muted/50 rounded-md p-3 text-sm">
+                <span className="font-semibold">Group of Death (Group I):</span>{' '}
+                <span className="text-muted-foreground">
+                  Both top 2 in exact order pays <span className="font-semibold">+8</span> instead
+                  of +6.
+                </span>
+              </div>
+              <div className="border-t pt-3">
+                <div className="flex items-center justify-between font-semibold">
+                  <span>Maximum Group Points</span>
+                  <span className="text-primary">{SCORING.maxGroupPoints} pts</span>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Trophy className="text-primary h-5 w-5" />
+              Knockout Stage
+            </CardTitle>
+            <CardDescription>
+              Each round, every team that advances scores you points — more if you had them in
+              the right slot.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-4">
+                <span className="text-muted-foreground">
+                  Round of 16{' '}
+                  <span className="text-muted-foreground/70 text-xs">(per team advancing)</span>
+                </span>
+                <span className="font-semibold whitespace-nowrap">+5 / +3 pts</span>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <span className="text-muted-foreground">
+                  Quarter-finals{' '}
+                  <span className="text-muted-foreground/70 text-xs">(per team advancing)</span>
+                </span>
+                <span className="font-semibold whitespace-nowrap">+6 / +3 pts</span>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <span className="text-muted-foreground">
+                  Semi-finals{' '}
+                  <span className="text-muted-foreground/70 text-xs">(per team advancing)</span>
+                </span>
+                <span className="font-semibold whitespace-nowrap">+8 / +4 pts</span>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <span className="text-muted-foreground">
+                  Final{' '}
+                  <span className="text-muted-foreground/70 text-xs">(per finalist)</span>
+                </span>
+                <span className="font-semibold whitespace-nowrap">+10 / +5 pts</span>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <span className="text-muted-foreground">Third Place Match Winner</span>
+                <span className="font-semibold">+5 pts</span>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <span className="text-muted-foreground">World Cup Champion</span>
+                <span className="font-semibold">+15 pts</span>
+              </div>
+              <div className="bg-muted/50 rounded-md p-3 text-xs">
+                <span className="font-semibold">Correct slot vs. wrong slot:</span>{' '}
+                <span className="text-muted-foreground">
+                  Correct slot = the team advanced from the bracket match you predicted. Wrong
+                  slot = the team advanced, but from a different match in the same round.
+                </span>
+              </div>
+              <div className="bg-muted/50 rounded-md p-3 text-xs">
+                <span className="font-semibold">Round of 32:</span>{' '}
+                <span className="text-muted-foreground">
+                  Picks aren&apos;t scored on their own — they decide which teams sit in your
+                  Round-of-16 slots.
+                </span>
+              </div>
+              <div className="border-t pt-3">
+                <div className="flex items-center justify-between font-semibold">
+                  <span>Maximum Knockout Points</span>
+                  <span className="text-primary">{SCORING.maxKnockoutPoints} pts</span>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Target className="text-primary h-5 w-5" />
+            Best 3rd-Place Advancers
+          </CardTitle>
+          <CardDescription>
+            FIFA 2026 advances 8 of the 12 group third-place teams to the Round of 32. Pick
+            8 teams from your group-stage 3rd-place predictions and rank them — best first.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">
+                Team in the actual top 8 (any rank)
+              </span>
+              <span className="font-semibold">+1 pt</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Team at the exact correct rank</span>
+              <span className="font-semibold">+0.25 pts</span>
+            </div>
+            <div className="bg-muted/50 rounded-md p-3 text-xs">
+              <span className="font-semibold">Bonuses stack:</span>{' '}
+              <span className="text-muted-foreground">
+                a team in the correct rank earns the full <span className="font-semibold">
+                  +1.25
+                </span>{' '}
+                (set + rank).
+              </span>
+            </div>
+            <div className="border-t pt-3">
+              <div className="flex items-center justify-between font-semibold">
+                <span>Maximum Advancer Points</span>
+                <span className="text-primary">{SCORING.maxAdvancerPoints} pts</span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardContent className="flex flex-col items-center justify-between gap-4 py-6 sm:flex-row">
+          <div>
+            <p className="text-muted-foreground text-sm">Tiebreaker</p>
+            <p className="font-medium">
+              Predict the total goals scored by the World Cup champion across all 8 of their
+              tournament matches. Closest to actual wins.
+            </p>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Regulation and extra time only — penalty-shootout goals don&apos;t count.
+            </p>
+          </div>
+          <div className="text-center sm:text-right">
+            <p className="text-muted-foreground text-sm">Maximum Total Points</p>
+            <p className="text-primary text-3xl font-bold">{SCORING.maxTotalPoints}</p>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -47,6 +47,10 @@ export const ROUTES = {
   resetPassword: '/reset-password',
   admin: '/admin',
   account: '/account',
+  about: '/about',
+  rules: '/rules',
+  terms: '/terms',
+  privacy: '/privacy',
 } as const;
 
 export const API_ENDPOINTS = {


### PR DESCRIPTION
## Summary

- Wires up the four footer links that currently 404 (`/about`, `/rules`, `/terms`, `/privacy`).
- Extracts the scoring breakdown from `HomePageContent` into a shared `ScoringBreakdown` component reused on `/` and `/rules` — one source of truth for the point values.
- Adds **Rules** and **About** to the top Header nav (Terms / Privacy stay footer-only); centralises the four new paths in `ROUTES` and refactors `Footer.tsx` to use them.
- `/terms` and `/privacy` ship with TODO markers in the JSX for the three items that need legal sign-off before launch: governing-law jurisdiction, contact email, and minimum-age threshold.

## Test plan

- [x] `npm run typecheck`
- [x] `npx eslint` on the nine touched files (codebase-wide `npm run lint` OOMs in the stylish formatter — pre-existing, unrelated)
- [x] `npm test` — 281/281 pass, including the Footer test that asserts the four href values
- [ ] Reviewer eyeballs `/`, `/about`, `/rules`, `/terms`, `/privacy` in `npm run dev`
- [ ] Reviewer confirms the Header shows Rules + About in both desktop nav and the mobile sheet
- [ ] Legal review resolves the three `TODO:` markers in `/terms` and `/privacy` before launch (`grep -rn "TODO:" frontend/src/app/terms frontend/src/app/privacy`)