### PR TITLE
test(scoring): add pgTAP suite for get_leaderboard

### DIFF
--- a/supabase/tests/lib/_fixtures.psql
+++ b/supabase/tests/lib/_fixtures.psql
@@ -1,0 +1,150 @@
+-- supabase/tests/_fixtures.sql
+--
+-- Shared pgTAP fixture helpers for the scoring suite. NOT a test file — has no
+-- plan/finish. Each scoring_*.test.sql includes this with `\ir _fixtures.sql`
+-- at the top of its transaction so the temporary helpers are defined for the
+-- session and rolled back at the end. Bypasses every admin RPC by inserting
+-- straight into the underlying tables — these tests lock down the scoring
+-- math, not the validation paths.
+
+-- ----- ID registry: lets multi-statement tests refer back to inserted rows.
+create temp table if not exists test_ids (key text primary key, val uuid);
+
+create or replace function pg_temp.tid(k text) returns uuid
+language sql stable as $$
+  select val from test_ids where key = k
+$$;
+
+create or replace function pg_temp.put_id(k text, v uuid) returns uuid
+language sql as $$
+  insert into test_ids (key, val) values (k, v) returning val
+$$;
+
+-- ----- Fixture builders.
+
+create or replace function pg_temp.mk_user(uname text) returns uuid
+language plpgsql as $$
+declare
+  uid uuid := gen_random_uuid();
+begin
+  insert into auth.users (
+    id, instance_id, aud, role,
+    email, encrypted_password, email_confirmed_at,
+    raw_app_meta_data, raw_user_meta_data,
+    created_at, updated_at,
+    confirmation_token, recovery_token, email_change_token_new, email_change
+  )
+  values (
+    uid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+    uname || '@scoring-test.local', '', now(),
+    '{}'::jsonb, jsonb_build_object('username', uname),
+    now(), now(),
+    '', '', '', ''
+  );
+  return uid;
+end $$;
+
+create or replace function pg_temp.mk_tournament(
+  p_name text,
+  p_lock_after interval default interval '7 days',
+  p_champ_goals int default null
+) returns uuid
+language plpgsql as $$
+declare
+  tid uuid := gen_random_uuid();
+begin
+  -- get_leaderboard is called with an explicit tournament_id, so the test
+  -- tournament does not need to be the singleton-active one. Leaving
+  -- is_active = false avoids contending with seed.sql's active row across
+  -- parallel test files via the partial unique index.
+  insert into public.tournaments (
+    id, slug, name, status, lock_time, is_active, champion_total_goals
+  )
+  values (
+    tid, 'scoring-test-' || tid::text, p_name,
+    'group_stage', now() + p_lock_after, false, p_champ_goals
+  );
+  return tid;
+end $$;
+
+create or replace function pg_temp.mk_prediction(
+  p_tournament uuid,
+  p_user uuid,
+  p_name text,
+  p_total_goals int default null,
+  p_submitted_at timestamptz default now(),
+  p_paid boolean default true,
+  p_paid_at timestamptz default null
+) returns uuid
+language plpgsql as $$
+declare
+  pid uuid := gen_random_uuid();
+  t_lock timestamptz;
+begin
+  insert into public.predictions (
+    id, user_id, tournament_id, prediction_name, total_goals, submitted_at
+  )
+  values (pid, p_user, p_tournament, p_name, p_total_goals, p_submitted_at);
+
+  if p_paid then
+    select lock_time into t_lock from public.tournaments where id = p_tournament;
+    insert into public.tournament_payments (
+      user_id, tournament_id, marked_by, prediction_id, paid_at
+    )
+    values (
+      p_user, p_tournament, p_user, pid,
+      coalesce(p_paid_at, t_lock - interval '1 hour')
+    );
+  end if;
+
+  return pid;
+end $$;
+
+-- Stable team lookup: Nth team (0-indexed) in a group, ordered by id.
+create or replace function pg_temp.team_at(g text, n int) returns text
+language sql stable as $$
+  select id from public.teams where group_id = g order by id offset n limit 1
+$$;
+
+-- Total points for a prediction on the leaderboard (or null if filtered out).
+create or replace function pg_temp.lb_points(p_tournament uuid, p_prediction uuid)
+returns numeric
+language sql stable as $$
+  select points from public.get_leaderboard(p_tournament, 1, 100)
+   where prediction_id = p_prediction
+$$;
+
+create or replace function pg_temp.lb_group(p_tournament uuid, p_prediction uuid)
+returns int
+language sql stable as $$
+  select group_points from public.get_leaderboard(p_tournament, 1, 100)
+   where prediction_id = p_prediction
+$$;
+
+create or replace function pg_temp.lb_knockout(p_tournament uuid, p_prediction uuid)
+returns int
+language sql stable as $$
+  select knockout_points from public.get_leaderboard(p_tournament, 1, 100)
+   where prediction_id = p_prediction
+$$;
+
+create or replace function pg_temp.lb_advancers(p_tournament uuid, p_prediction uuid)
+returns numeric
+language sql stable as $$
+  select advancer_points from public.get_leaderboard(p_tournament, 1, 100)
+   where prediction_id = p_prediction
+$$;
+
+create or replace function pg_temp.lb_rank(p_tournament uuid, p_prediction uuid)
+returns int
+language sql stable as $$
+  select rank from public.get_leaderboard(p_tournament, 1, 100)
+   where prediction_id = p_prediction
+$$;
+
+create or replace function pg_temp.lb_total_count(p_tournament uuid)
+returns bigint
+language sql stable as $$
+  select coalesce(max(total_count), 0)
+    from public.get_leaderboard(p_tournament, 1, 100)
+$$;

--- a/supabase/tests/scoring_advancers.test.sql
+++ b/supabase/tests/scoring_advancers.test.sql
@@ -1,0 +1,95 @@
+-- supabase/tests/scoring_advancers.test.sql
+--
+-- Locks down the ranked-advancer scoring weights set in 0031:
+--   exact rank match in top-8 : 1.25
+--   anywhere in top-8 set      : 1.00
+--   else                       : 0
+--   max (8 exact)              : 10.00
+
+begin;
+create extension if not exists pgtap with schema extensions;
+set search_path to public, extensions;
+\ir lib/_fixtures.psql
+
+select plan(4);
+
+do $$
+declare
+  v_user uuid;
+  v_tid  uuid;
+  -- 8 teams that will be the actual advancers (any teams, no group_standings needed
+  -- because we bypass admin_set_tournament_advancer and write the table directly).
+  adv text[];
+  -- 8 teams that are NOT in the advancers set.
+  out_set text[];
+  i int;
+begin
+  v_user := pg_temp.mk_user('scoring_advancers_user');
+  v_tid  := pg_temp.mk_tournament('advancer scoring');
+  perform pg_temp.put_id('t',    v_tid);
+  perform pg_temp.put_id('user', v_user);
+
+  adv := array[
+    pg_temp.team_at('A', 0), pg_temp.team_at('B', 0),
+    pg_temp.team_at('C', 0), pg_temp.team_at('D', 0),
+    pg_temp.team_at('E', 0), pg_temp.team_at('F', 0),
+    pg_temp.team_at('G', 0), pg_temp.team_at('H', 0)
+  ];
+  out_set := array[
+    pg_temp.team_at('I', 0), pg_temp.team_at('I', 1),
+    pg_temp.team_at('J', 0), pg_temp.team_at('J', 1),
+    pg_temp.team_at('K', 0), pg_temp.team_at('K', 1),
+    pg_temp.team_at('L', 0), pg_temp.team_at('L', 1)
+  ];
+
+  for i in 1..8 loop
+    insert into public.tournament_advancers (tournament_id, rank, team_id)
+      values (v_tid, i, adv[i]);
+  end loop;
+
+  perform pg_temp.put_id('p_all_exact',     pg_temp.mk_prediction(v_tid, v_user, 'all 8 exact'));
+  perform pg_temp.put_id('p_all_wrong_rank',pg_temp.mk_prediction(v_tid, v_user, 'all 8 wrong rank'));
+  perform pg_temp.put_id('p_half_miss',     pg_temp.mk_prediction(v_tid, v_user, '4 exact and 4 miss'));
+  perform pg_temp.put_id('p_zero',          pg_temp.mk_prediction(v_tid, v_user, '0 in top-8'));
+
+  -- p_all_exact: 8 picks all in exact rank -> 8 * 1.25 = 10.0
+  for i in 1..8 loop
+    insert into public.advancer_predictions (prediction_id, rank, team_id)
+      values (pg_temp.tid('p_all_exact'), i, adv[i]);
+  end loop;
+
+  -- p_all_wrong_rank: every team in set but rotated one slot -> 8 * 1.0 = 8.0
+  for i in 1..8 loop
+    insert into public.advancer_predictions (prediction_id, rank, team_id)
+      values (pg_temp.tid('p_all_wrong_rank'), i, adv[((i % 8) + 1)]);
+  end loop;
+
+  -- p_half_miss: ranks 1..4 exact, ranks 5..8 outside the set ->
+  --   4 * 1.25 + 4 * 0 = 5.0
+  for i in 1..4 loop
+    insert into public.advancer_predictions (prediction_id, rank, team_id)
+      values (pg_temp.tid('p_half_miss'), i, adv[i]);
+  end loop;
+  for i in 5..8 loop
+    insert into public.advancer_predictions (prediction_id, rank, team_id)
+      values (pg_temp.tid('p_half_miss'), i, out_set[i]);
+  end loop;
+
+  -- p_zero: every pick outside the set -> 0
+  for i in 1..8 loop
+    insert into public.advancer_predictions (prediction_id, rank, team_id)
+      values (pg_temp.tid('p_zero'), i, out_set[i]);
+  end loop;
+end $$;
+
+select is(pg_temp.lb_advancers(pg_temp.tid('t'), pg_temp.tid('p_all_exact')),       10.0::numeric,
+          '8 advancers picked in exact rank -> 10.0 (max)');
+select is(pg_temp.lb_advancers(pg_temp.tid('t'), pg_temp.tid('p_all_wrong_rank')),   8.0::numeric,
+          '8 advancers all in set but every rank wrong -> 8.0');
+select is(pg_temp.lb_advancers(pg_temp.tid('t'), pg_temp.tid('p_half_miss')),        5.0::numeric,
+          '4 exact + 4 not in set -> 5.0');
+select is(pg_temp.lb_advancers(pg_temp.tid('t'), pg_temp.tid('p_zero')),             0::numeric,
+          '0 picks in top-8 set -> 0');
+
+select * from finish();
+rollback;

--- a/supabase/tests/scoring_eligibility.test.sql
+++ b/supabase/tests/scoring_eligibility.test.sql
@@ -1,0 +1,64 @@
+-- supabase/tests/scoring_eligibility.test.sql
+--
+-- Locks down which predictions are eligible to appear on the leaderboard.
+-- The CTE inside get_leaderboard filters out anything missing one of:
+--   * p.submitted_at is not null
+--   * a tournament_payments row for the prediction with
+--     paid_at <= tournaments.lock_time
+
+begin;
+create extension if not exists pgtap with schema extensions;
+set search_path to public, extensions;
+\ir lib/_fixtures.psql
+
+select plan(6);
+
+do $$
+declare
+  v_user uuid;
+  v_tid  uuid;
+  v_lock timestamptz;
+begin
+  v_user := pg_temp.mk_user('scoring_eligibility_user');
+  v_tid  := pg_temp.mk_tournament('eligibility', interval '7 days');
+  perform pg_temp.put_id('t',    v_tid);
+  perform pg_temp.put_id('user', v_user);
+
+  select lock_time into v_lock from public.tournaments where id = v_tid;
+
+  -- Paid one day before lock -> on leaderboard.
+  perform pg_temp.put_id('p_paid_before', pg_temp.mk_prediction(
+    v_tid, v_user, 'paid before lock', null, now(), true, v_lock - interval '1 day'));
+
+  -- Paid exactly at lock_time -> on leaderboard (boundary, paid_at <= lock_time).
+  perform pg_temp.put_id('p_paid_exact', pg_temp.mk_prediction(
+    v_tid, v_user, 'paid at lock', null, now(), true, v_lock));
+
+  -- Paid after lock_time -> filtered out.
+  perform pg_temp.put_id('p_paid_after', pg_temp.mk_prediction(
+    v_tid, v_user, 'paid after lock', null, now(), true, v_lock + interval '1 hour'));
+
+  -- No payment row -> filtered out.
+  perform pg_temp.put_id('p_unpaid', pg_temp.mk_prediction(
+    v_tid, v_user, 'unpaid', null, now(), false));
+
+  -- Paid in time but never submitted -> filtered out (submitted_at is null).
+  perform pg_temp.put_id('p_unsubmitted', pg_temp.mk_prediction(
+    v_tid, v_user, 'unsubmitted', null, null, true, v_lock - interval '1 day'));
+end $$;
+
+select isnt(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p_paid_before')), null,
+            'paid before lock -> appears on leaderboard');
+select isnt(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p_paid_exact')),  null,
+            'paid_at = lock_time -> still appears (filter is <=)');
+select is(  pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p_paid_after')),  null,
+            'paid after lock -> filtered out');
+select is(  pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p_unpaid')),      null,
+            'no payment row -> filtered out');
+select is(  pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p_unsubmitted')), null,
+            'submitted_at null -> filtered out (even when paid in time)');
+select is(  pg_temp.lb_total_count(pg_temp.tid('t')), 2::bigint,
+            'total_count reflects only the 2 eligible predictions');
+
+select * from finish();
+rollback;

--- a/supabase/tests/scoring_group.test.sql
+++ b/supabase/tests/scoring_group.test.sql
@@ -1,0 +1,80 @@
+-- supabase/tests/scoring_group.test.sql
+--
+-- Locks down group-stage scoring tiers in get_leaderboard
+-- (migrations 0006 + 0031). Tiers per CLAUDE.md:
+--   both correct exact order: 6 (8 for Group I)
+--   both correct swapped:     4
+--   one correct in same slot: 3
+--   one correct in wrong slot:2
+--   else:                     0
+
+begin;
+create extension if not exists pgtap with schema extensions;
+set search_path to public, extensions;
+\ir lib/_fixtures.psql
+
+select plan(7);
+
+do $$
+declare
+  v_user uuid;
+  v_tid  uuid;
+  a1 text; a2 text; a3 text; a4 text;
+  i1 text; i2 text; i3 text; i4 text;
+begin
+  v_user := pg_temp.mk_user('scoring_group_user');
+  v_tid  := pg_temp.mk_tournament('group scoring');
+  perform pg_temp.put_id('t',    v_tid);
+  perform pg_temp.put_id('user', v_user);
+
+  a1 := pg_temp.team_at('A', 0); a2 := pg_temp.team_at('A', 1);
+  a3 := pg_temp.team_at('A', 2); a4 := pg_temp.team_at('A', 3);
+  i1 := pg_temp.team_at('I', 0); i2 := pg_temp.team_at('I', 1);
+  i3 := pg_temp.team_at('I', 2); i4 := pg_temp.team_at('I', 3);
+
+  -- Actual standings: A=[a1,a2,a3,a4], I=[i1,i2,i3,i4].
+  insert into public.group_standings
+    (tournament_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id)
+  values
+    (v_tid, 'A', a1, a2, a3, a4),
+    (v_tid, 'I', i1, i2, i3, i4);
+
+  -- One prediction per tier. Each only fills the group it is testing,
+  -- so the other 11 groups contribute 0 and isolate the assertion.
+  perform pg_temp.put_id('p_exact',     pg_temp.mk_prediction(v_tid, v_user, 'A exact'));
+  perform pg_temp.put_id('p_swap',      pg_temp.mk_prediction(v_tid, v_user, 'A swap'));
+  perform pg_temp.put_id('p_one_slot',  pg_temp.mk_prediction(v_tid, v_user, 'A one in slot'));
+  perform pg_temp.put_id('p_one_wrong', pg_temp.mk_prediction(v_tid, v_user, 'A one wrong slot'));
+  perform pg_temp.put_id('p_zero',      pg_temp.mk_prediction(v_tid, v_user, 'A zero'));
+  perform pg_temp.put_id('p_i_exact',   pg_temp.mk_prediction(v_tid, v_user, 'I exact'));
+  perform pg_temp.put_id('p_i_swap',    pg_temp.mk_prediction(v_tid, v_user, 'I swap'));
+
+  insert into public.group_predictions
+    (prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id)
+  values
+    (pg_temp.tid('p_exact'),     'A', a1, a2, a3, a4),
+    (pg_temp.tid('p_swap'),      'A', a2, a1, a3, a4),
+    (pg_temp.tid('p_one_slot'),  'A', a1, a3, a2, a4),  -- first correct, second wrong
+    (pg_temp.tid('p_one_wrong'), 'A', a2, a3, a1, a4),  -- a2 in slot 1 instead of slot 2
+    (pg_temp.tid('p_zero'),      'A', a3, a4, a1, a2),
+    (pg_temp.tid('p_i_exact'),   'I', i1, i2, i3, i4),
+    (pg_temp.tid('p_i_swap'),    'I', i2, i1, i3, i4);
+end $$;
+
+select is(pg_temp.lb_group(pg_temp.tid('t'), pg_temp.tid('p_exact')),     6,
+          'group A exact top-2 -> 6');
+select is(pg_temp.lb_group(pg_temp.tid('t'), pg_temp.tid('p_swap')),      4,
+          'group A swapped top-2 -> 4');
+select is(pg_temp.lb_group(pg_temp.tid('t'), pg_temp.tid('p_one_slot')),  3,
+          'group A one correct in same slot -> 3');
+select is(pg_temp.lb_group(pg_temp.tid('t'), pg_temp.tid('p_one_wrong')), 2,
+          'group A one correct in wrong slot -> 2');
+select is(pg_temp.lb_group(pg_temp.tid('t'), pg_temp.tid('p_zero')),      0,
+          'group A neither top-2 picked -> 0');
+select is(pg_temp.lb_group(pg_temp.tid('t'), pg_temp.tid('p_i_exact')),   8,
+          'Group I (Group of Death) exact -> 8 (bonus)');
+select is(pg_temp.lb_group(pg_temp.tid('t'), pg_temp.tid('p_i_swap')),    4,
+          'Group I swapped -> 4 (no bonus on swap)');
+
+select * from finish();
+rollback;

--- a/supabase/tests/scoring_knockout.test.sql
+++ b/supabase/tests/scoring_knockout.test.sql
@@ -1,0 +1,95 @@
+-- supabase/tests/scoring_knockout.test.sql
+--
+-- Locks down per-round knockout scoring + the champion / third-place
+-- flat bonuses. Tier table per CLAUDE.md / 0006_scoring_v2.sql:
+--   R16  (sourced from round_of_32):    correct slot +5,  wrong slot +3
+--   QF   (sourced from round_of_16):    correct slot +6,  wrong slot +3
+--   SF   (sourced from quarter_finals): correct slot +8,  wrong slot +4
+--   Final(sourced from semi_finals):    correct slot +10, wrong slot +5
+--   Bonuses: M32 (final winner) +15, M31 (third-place winner) +5
+
+begin;
+create extension if not exists pgtap with schema extensions;
+set search_path to public, extensions;
+\ir lib/_fixtures.psql
+
+select plan(8);
+
+do $$
+declare
+  v_user uuid;
+  v_tid  uuid;
+  -- Winners actually decided in each result row.
+  w_m1   text; w_m1_l  text;
+  w_m17  text; w_m17_l text;
+  w_m25  text; w_m25_l text;
+  w_m29  text; w_m29_l text;
+  w_m31  text; w_m31_l text;
+  w_m32  text; w_m32_l text;
+  t_other text;
+begin
+  v_user := pg_temp.mk_user('scoring_knockout_user');
+  v_tid  := pg_temp.mk_tournament('knockout scoring');
+  perform pg_temp.put_id('t',    v_tid);
+  perform pg_temp.put_id('user', v_user);
+
+  -- Pick distinct teams to be the actual winners. Group choice is arbitrary;
+  -- knockout_results doesn't validate against bracket sources.
+  w_m1  := pg_temp.team_at('A', 0); w_m1_l  := pg_temp.team_at('A', 1);
+  w_m17 := pg_temp.team_at('B', 0); w_m17_l := pg_temp.team_at('B', 1);
+  w_m25 := pg_temp.team_at('C', 0); w_m25_l := pg_temp.team_at('C', 1);
+  w_m29 := pg_temp.team_at('D', 0); w_m29_l := pg_temp.team_at('D', 1);
+  w_m31 := pg_temp.team_at('E', 0); w_m31_l := pg_temp.team_at('E', 1);
+  w_m32 := pg_temp.team_at('F', 0); w_m32_l := pg_temp.team_at('F', 1);
+  t_other := pg_temp.team_at('L', 0);  -- a team that wins nothing
+
+  insert into public.knockout_results
+    (tournament_id, match_id, winner_team_id, loser_team_id)
+  values
+    (v_tid, 'M1',  w_m1,  w_m1_l),
+    (v_tid, 'M17', w_m17, w_m17_l),
+    (v_tid, 'M25', w_m25, w_m25_l),
+    (v_tid, 'M29', w_m29, w_m29_l),
+    (v_tid, 'M31', w_m31, w_m31_l),
+    (v_tid, 'M32', w_m32, w_m32_l);
+
+  perform pg_temp.put_id('p_r16_correct',    pg_temp.mk_prediction(v_tid, v_user, 'R16 correct slot'));
+  perform pg_temp.put_id('p_r16_wrong_slot', pg_temp.mk_prediction(v_tid, v_user, 'R16 wrong slot'));
+  perform pg_temp.put_id('p_r16_zero',       pg_temp.mk_prediction(v_tid, v_user, 'R16 zero'));
+  perform pg_temp.put_id('p_qf_correct',     pg_temp.mk_prediction(v_tid, v_user, 'QF correct slot'));
+  perform pg_temp.put_id('p_sf_correct',     pg_temp.mk_prediction(v_tid, v_user, 'SF correct slot'));
+  perform pg_temp.put_id('p_final_correct',  pg_temp.mk_prediction(v_tid, v_user, 'Final correct slot'));
+  perform pg_temp.put_id('p_champion',       pg_temp.mk_prediction(v_tid, v_user, 'M32 champion'));
+  perform pg_temp.put_id('p_third',          pg_temp.mk_prediction(v_tid, v_user, 'M31 third place'));
+
+  insert into public.knockout_predictions (prediction_id, match_id, winner_team_id) values
+    (pg_temp.tid('p_r16_correct'),    'M1',  w_m1),
+    -- wrong-slot: pick the right team but at a different R32 match.
+    (pg_temp.tid('p_r16_wrong_slot'), 'M2',  w_m1),
+    (pg_temp.tid('p_r16_zero'),       'M1',  t_other),
+    (pg_temp.tid('p_qf_correct'),     'M17', w_m17),
+    (pg_temp.tid('p_sf_correct'),     'M25', w_m25),
+    (pg_temp.tid('p_final_correct'),  'M29', w_m29),
+    (pg_temp.tid('p_champion'),       'M32', w_m32),
+    (pg_temp.tid('p_third'),          'M31', w_m31);
+end $$;
+
+select is(pg_temp.lb_knockout(pg_temp.tid('t'), pg_temp.tid('p_r16_correct')),    5,
+          'R16 correct-slot from round_of_32 -> +5');
+select is(pg_temp.lb_knockout(pg_temp.tid('t'), pg_temp.tid('p_r16_wrong_slot')), 3,
+          'R16 wrong-slot (winner picked in different R32 match) -> +3');
+select is(pg_temp.lb_knockout(pg_temp.tid('t'), pg_temp.tid('p_r16_zero')),       0,
+          'R16 no overlap with actual winner -> 0');
+select is(pg_temp.lb_knockout(pg_temp.tid('t'), pg_temp.tid('p_qf_correct')),     6,
+          'QF correct-slot from round_of_16 -> +6');
+select is(pg_temp.lb_knockout(pg_temp.tid('t'), pg_temp.tid('p_sf_correct')),     8,
+          'SF correct-slot from quarter_finals -> +8');
+select is(pg_temp.lb_knockout(pg_temp.tid('t'), pg_temp.tid('p_final_correct')), 10,
+          'Final correct-slot from semi_finals -> +10');
+select is(pg_temp.lb_knockout(pg_temp.tid('t'), pg_temp.tid('p_champion')),      15,
+          'M32 champion picked correctly -> +15');
+select is(pg_temp.lb_knockout(pg_temp.tid('t'), pg_temp.tid('p_third')),          5,
+          'M31 third-place picked correctly -> +5');
+
+select * from finish();
+rollback;

--- a/supabase/tests/scoring_multi_prediction.test.sql
+++ b/supabase/tests/scoring_multi_prediction.test.sql
@@ -1,0 +1,84 @@
+-- supabase/tests/scoring_multi_prediction.test.sql
+--
+-- Locks down the multi-prediction leaderboard behavior introduced in 0012-0015:
+--   * a single user can hold multiple paid predictions in the same tournament
+--   * each paid prediction is its own leaderboard row (N paid predictions -> N rows)
+--   * those rows are ranked GLOBALLY by points across all users — NOT bucketed
+--     per user — so another user's prediction can interleave between two of
+--     the same user's rows
+--   * an unpaid prediction stays off the leaderboard even when other predictions
+--     by the same user are eligible
+--
+-- Test layout:
+--   User A   { high (6),  mid (4),  low (0),  high copy (6, unpaid) }
+--   User B   { between (5 from a correct R32 pick) }
+-- Expected leaderboard (high to low): a.high, b.between, a.mid, a.low.
+
+begin;
+create extension if not exists pgtap with schema extensions;
+set search_path to public, extensions;
+\ir lib/_fixtures.psql
+
+select plan(6);
+
+do $$
+declare
+  v_user_a uuid;
+  v_user_b uuid;
+  v_tid    uuid;
+  a1 text; a2 text; a3 text; a4 text;
+  w_m1 text; w_m1_l text;
+begin
+  v_user_a := pg_temp.mk_user('scoring_multi_a');
+  v_user_b := pg_temp.mk_user('scoring_multi_b');
+  v_tid    := pg_temp.mk_tournament('multi prediction');
+  perform pg_temp.put_id('t', v_tid);
+
+  a1 := pg_temp.team_at('A', 0); a2 := pg_temp.team_at('A', 1);
+  a3 := pg_temp.team_at('A', 2); a4 := pg_temp.team_at('A', 3);
+  w_m1 := pg_temp.team_at('B', 0); w_m1_l := pg_temp.team_at('B', 1);
+
+  insert into public.group_standings
+    (tournament_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id)
+  values (v_tid, 'A', a1, a2, a3, a4);
+
+  insert into public.knockout_results
+    (tournament_id, match_id, winner_team_id, loser_team_id)
+  values (v_tid, 'M1', w_m1, w_m1_l);
+
+  -- User A: three eligible predictions (6 / 4 / 0) and one unpaid copy of high.
+  perform pg_temp.put_id('a_high',   pg_temp.mk_prediction(v_tid, v_user_a, 'high'));
+  perform pg_temp.put_id('a_mid',    pg_temp.mk_prediction(v_tid, v_user_a, 'mid'));
+  perform pg_temp.put_id('a_low',    pg_temp.mk_prediction(v_tid, v_user_a, 'low'));
+  perform pg_temp.put_id('a_unpaid', pg_temp.mk_prediction(
+    v_tid, v_user_a, 'high copy', null, now(), false));
+
+  insert into public.group_predictions
+    (prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id)
+  values
+    (pg_temp.tid('a_high'),   'A', a1, a2, a3, a4),   -- exact -> 6
+    (pg_temp.tid('a_mid'),    'A', a2, a1, a3, a4),   -- swap  -> 4
+    (pg_temp.tid('a_unpaid'), 'A', a1, a2, a3, a4);   -- exact -> 6 but unpaid
+  -- a_low: no group picks -> 0
+
+  -- User B: one eligible prediction scoring 5 (R16 correct from M1).
+  perform pg_temp.put_id('b_single', pg_temp.mk_prediction(v_tid, v_user_b, 'between'));
+  insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+  values (pg_temp.tid('b_single'), 'M1', w_m1);
+end $$;
+
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('a_high')),   1,
+          'user A high-score prediction (6 pts) -> rank 1');
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('b_single')), 2,
+          'user B prediction (5 pts) interleaves between two of user A''s rows -> rank 2');
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('a_mid')),    3,
+          'user A mid-score prediction (4 pts) -> rank 3');
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('a_low')),    4,
+          'user A zero-point prediction -> rank 4 (still on the board, just last)');
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('a_unpaid')), null,
+          'user A unpaid prediction excluded even though other A predictions are eligible');
+select is(pg_temp.lb_total_count(pg_temp.tid('t')), 4::bigint,
+          'leaderboard surfaces 4 rows total (3 from user A + 1 from user B)');
+
+select * from finish();
+rollback;

--- a/supabase/tests/scoring_tiebreaker.test.sql
+++ b/supabase/tests/scoring_tiebreaker.test.sql
@@ -1,0 +1,54 @@
+-- supabase/tests/scoring_tiebreaker.test.sql
+--
+-- Locks down the leaderboard ordering when point totals tie. Per the
+-- row_number() OVER clause in get_leaderboard (0006/0031):
+--   1. points DESC
+--   2. abs(total_goals - tournaments.champion_total_goals) ASC NULLS LAST
+--   3. submitted_at ASC
+-- All predictions in this test score 0 points so the tiebreaker is the
+-- only driver of the ranking.
+
+begin;
+create extension if not exists pgtap with schema extensions;
+set search_path to public, extensions;
+\ir lib/_fixtures.psql
+
+select plan(5);
+
+do $$
+declare
+  v_user uuid;
+  v_tid  uuid;
+begin
+  v_user := pg_temp.mk_user('scoring_tiebreaker_user');
+  -- Champion scored 15 goals across the tournament.
+  v_tid  := pg_temp.mk_tournament('tiebreaker scoring', interval '7 days', 15);
+  perform pg_temp.put_id('t',    v_tid);
+  perform pg_temp.put_id('user', v_user);
+
+  -- Each prediction has identical (zero) points; only goals/submitted_at vary.
+  perform pg_temp.put_id('p1_perfect_early',
+    pg_temp.mk_prediction(v_tid, v_user, 'perfect goals early',   15, now() - interval '3 hours'));
+  perform pg_temp.put_id('p2_perfect_late',
+    pg_temp.mk_prediction(v_tid, v_user, 'perfect goals late',    15, now() - interval '1 hour'));
+  perform pg_temp.put_id('p3_off_by_5_late',
+    pg_temp.mk_prediction(v_tid, v_user, 'off by 5 later',        10, now() - interval '2 hours'));
+  perform pg_temp.put_id('p4_off_by_5_early',
+    pg_temp.mk_prediction(v_tid, v_user, 'off by 5 earlier',      20, now() - interval '4 hours'));
+  perform pg_temp.put_id('p5_null_goals',
+    pg_temp.mk_prediction(v_tid, v_user, 'null goals',          null, now() - interval '5 hours'));
+end $$;
+
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p1_perfect_early')), 1,
+          'closest goal diff + earliest submitted_at -> rank 1');
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p2_perfect_late')),  2,
+          'closest goal diff but later submission -> rank 2');
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p4_off_by_5_early')),3,
+          'same goal diff as p3 but earlier submission wins the secondary tie');
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p3_off_by_5_late')), 4,
+          'same goal diff, later submission -> rank 4');
+select is(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p5_null_goals')),    5,
+          'null total_goals -> ranked last (NULLS LAST on diff)');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
Locks down the scoring math in `get_leaderboard` (latest definition in `supabase/migrations/0031_advancer_scoring_bump.sql`) with a pgTAP suite under `supabase/tests/`. **36 assertions across 6 files, all passing locally via `supabase test db`.**

| File | Asserts | Covers |
|---|---|---|
| `scoring_group.test.sql` | 7 | Group-stage tiers (6 / 4 / 3 / 2 / 0) + Group I "Group of Death" +8 bonus, including that the bonus only fires on exact order, not on swap |
| `scoring_knockout.test.sql` | 8 | Per-round `knockout_round_scores` tiers (R16 5/3, QF 6/3, SF 8/4, Final 10/5) + M32 champion +15 + M31 third-place +5 |
| `scoring_advancers.test.sql` | 4 | Ranked-advancer weights (1.25 exact rank / 1.0 set membership / 0) and the 10-pt max |
| `scoring_tiebreaker.test.sql` | 5 | `row_number()` ordering: closest \|goals − champion_total_goals\| wins, NULL goals lands last, `submitted_at` breaks the remaining tie |
| `scoring_eligibility.test.sql` | 6 | Payment + submission filter: paid-before-lock in, `paid_at = lock_time` boundary in, paid-after-lock out, unpaid out, `submitted_at` NULL out |
| `scoring_multi_prediction.test.sql` | 6 | One user with multiple paid predictions occupies multiple ranked rows; another user's prediction interleaves between them; unpaid predictions excluded |

### Design notes
- Tests write straight to the underlying tables (`predictions`, `group_predictions`, `knockout_predictions`, `advancer_predictions`, `tournament_advancers`, `knockout_results`, `group_standings`, `tournament_payments`) and bypass the admin RPCs (`admin_set_tournament_advancer`, `admin_set_r32_bracket`, `admin_set_phase_two`) — the suite exercises the scoring path, not the validation paths.
- Each file wraps `BEGIN … ROLLBACK` so nothing persists.
- `mk_tournament` inserts with `is_active = false` to avoid contending with `seed.sql`'s active tournament via the partial unique index when files run in parallel.
- Shared fixture helpers live in `supabase/tests/lib/_fixtures.psql`. The `.psql` extension is deliberate — `supabase test db` invokes `pg_prove --ext .sql --recurse`, so the `.psql` suffix keeps the helpers out of the test glob.
- Usernames stick to `[A-Za-z0-9_]` and prediction names stick to `[A-Za-z0-9 _\-.''‘’]` to satisfy the schema check constraints.

### What is not covered (worth follow-ups)
- `get_leaderboard_rank` (same CTE shape but per-user)
- Pagination (`p_page` / `p_page_size`)
- The 284-pt perfect-pick ceiling end-to-end

## Test plan
- [ ] `supabase start && supabase test db` reports `Files=6, Tests=36 … Result: PASS`
- [ ] Open one of the test files and intentionally break a tier (e.g. change `'A exact'` picks from `[a1, a2, …]` to `[a2, a1, …]`) — re-running should fail the matching assertion