### PR TITLE
fix(auth): gate password reset to recovery-origin sessions

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -9,3 +9,7 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Server-only (never expose to the client)
 # Required for admin API routes (result submission, etc.)
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# HMAC secret used to gate /api/auth/reset-password to recovery-origin sessions.
+# Generate with: openssl rand -base64 48
+RESET_INTENT_SECRET=replace-me-with-at-least-32-random-bytes

--- a/frontend/src/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/frontend/src/app/api/auth/reset-password/__tests__/route.test.ts
@@ -3,10 +3,13 @@
  */
 import { NextRequest } from 'next/server';
 
+process.env.RESET_INTENT_SECRET = 'test-secret-must-be-at-least-32-characters-long';
+
 const supabaseMock = {
   auth: {
     getUser: jest.fn(),
     updateUser: jest.fn(),
+    signOut: jest.fn(),
   },
 };
 
@@ -16,19 +19,31 @@ jest.mock('@/lib/supabase/server', () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { POST } = require('../route');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { signResetIntent, RESET_INTENT_COOKIE } = require('@/lib/auth/reset-intent');
 
-function postRequest(body: unknown) {
+function postRequest(body: unknown, cookieValue?: string) {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (cookieValue !== undefined) {
+    headers.cookie = `${RESET_INTENT_COOKIE}=${cookieValue}`;
+  }
   return new NextRequest('http://localhost:3000/api/auth/reset-password', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers,
     body: JSON.stringify(body),
   });
+}
+
+function validCookieFor(userId: string): string {
+  return signResetIntent(userId).value;
 }
 
 describe('POST /api/auth/reset-password', () => {
   beforeEach(() => {
     supabaseMock.auth.getUser.mockReset();
     supabaseMock.auth.updateUser.mockReset();
+    supabaseMock.auth.signOut.mockReset();
+    supabaseMock.auth.signOut.mockResolvedValue({ error: null });
   });
 
   it('returns 400 when password is too short', async () => {
@@ -42,11 +57,46 @@ describe('POST /api/auth/reset-password', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns 401 when no recovery session', async () => {
+  it('returns 401 when no session', async () => {
     supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
     const res = await POST(postRequest({ password: 'longenough1' }));
     expect(res.status).toBe(401);
     expect(supabaseMock.auth.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when reset_intent cookie is missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    const res = await POST(postRequest({ password: 'longenough1' }));
+    expect(res.status).toBe(403);
+    expect(supabaseMock.auth.updateUser).not.toHaveBeenCalled();
+    expect(supabaseMock.auth.signOut).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when reset_intent cookie has tampered HMAC', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    const valid = validCookieFor('u1');
+    // Flip the last char to break HMAC
+    const tampered = valid.slice(0, -1) + (valid.endsWith('A') ? 'B' : 'A');
+    const res = await POST(postRequest({ password: 'longenough1' }, tampered));
+    expect(res.status).toBe(403);
+    expect(supabaseMock.auth.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when reset_intent cookie is for a different user', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    const cookieForOther = validCookieFor('u2');
+    const res = await POST(postRequest({ password: 'longenough1' }, cookieForOther));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when reset_intent cookie is expired', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    const realNow = Date.now;
+    Date.now = () => realNow() - 1000 * 1000; // 1000 seconds ago — beyond 900s TTL
+    const stale = validCookieFor('u1');
+    Date.now = realNow;
+    const res = await POST(postRequest({ password: 'longenough1' }, stale));
+    expect(res.status).toBe(403);
   });
 
   it('returns 400 when supabase rejects the password', async () => {
@@ -54,18 +104,23 @@ describe('POST /api/auth/reset-password', () => {
     supabaseMock.auth.updateUser.mockResolvedValue({
       error: { message: 'New password should be different' },
     });
-    const res = await POST(postRequest({ password: 'longenough1' }));
+    const res = await POST(postRequest({ password: 'longenough1' }, validCookieFor('u1')));
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toMatch(/should be different/i);
+    expect(supabaseMock.auth.signOut).not.toHaveBeenCalled();
   });
 
-  it('returns 200 ok on success', async () => {
+  it('returns 200, signs out, and clears the cookie on success', async () => {
     supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
     supabaseMock.auth.updateUser.mockResolvedValue({ error: null });
-    const res = await POST(postRequest({ password: 'longenough1' }));
+    const res = await POST(postRequest({ password: 'longenough1' }, validCookieFor('u1')));
     expect(res.status).toBe(200);
     expect(supabaseMock.auth.updateUser).toHaveBeenCalledWith({ password: 'longenough1' });
+    expect(supabaseMock.auth.signOut).toHaveBeenCalledTimes(1);
     expect(await res.json()).toEqual({ ok: true });
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain(`${RESET_INTENT_COOKIE}=`);
+    expect(setCookie.toLowerCase()).toContain('max-age=0');
   });
 });

--- a/frontend/src/app/api/auth/reset-password/route.ts
+++ b/frontend/src/app/api/auth/reset-password/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerSupabase } from '@/lib/supabase/server';
+import {
+  RESET_INTENT_COOKIE,
+  clearResetIntentCookie,
+  verifyResetIntent,
+} from '@/lib/auth/reset-intent';
 
 interface ResetPasswordPayload {
   password?: unknown;
@@ -24,10 +29,23 @@ export async function POST(request: NextRequest) {
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+  const cookieValue = request.cookies.get(RESET_INTENT_COOKIE)?.value;
+  if (!verifyResetIntent(cookieValue, user.id)) {
+    return NextResponse.json(
+      { error: 'Reset link expired or invalid. Please request a new password reset email.' },
+      { status: 403 }
+    );
+  }
+
   const { error } = await supabase.auth.updateUser({ password });
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 400 });
   }
 
-  return NextResponse.json({ ok: true });
+  await supabase.auth.signOut();
+
+  const response = NextResponse.json({ ok: true });
+  const cleared = clearResetIntentCookie();
+  response.cookies.set(cleared.name, cleared.value, cleared.options);
+  return response;
 }

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import type { EmailOtpType } from '@supabase/supabase-js';
 import { getServerSupabase } from '@/lib/supabase/server';
 import { ROUTES } from '@/lib/constants';
+import { signResetIntent } from '@/lib/auth/reset-intent';
 
 const OTP_TYPES: EmailOtpType[] = ['signup', 'invite', 'magiclink', 'recovery', 'email_change', 'email'];
 
@@ -15,12 +16,17 @@ export async function GET(request: NextRequest) {
   const supabase = await getServerSupabase();
 
   if (tokenHash && rawType && (OTP_TYPES as string[]).includes(rawType)) {
-    const { error } = await supabase.auth.verifyOtp({
+    const { data, error } = await supabase.auth.verifyOtp({
       token_hash: tokenHash,
       type: rawType as EmailOtpType,
     });
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      const response = NextResponse.redirect(`${origin}${next}`);
+      if (rawType === 'recovery' && data.user) {
+        const intent = signResetIntent(data.user.id);
+        response.cookies.set(intent.name, intent.value, intent.options);
+      }
+      return response;
     }
   }
 

--- a/frontend/src/app/login/LoginForm.tsx
+++ b/frontend/src/app/login/LoginForm.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -21,6 +21,15 @@ type FieldName = 'email' | 'password';
 
 export function LoginForm({ redirectTo }: LoginFormProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const resetToastShown = React.useRef(false);
+  React.useEffect(() => {
+    if (resetToastShown.current) return;
+    if (searchParams.get('reset') === 'success') {
+      resetToastShown.current = true;
+      toast.success('Password updated. Please sign in with your new password.');
+    }
+  }, [searchParams]);
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
   const [touched, setTouched] = React.useState<Record<FieldName, boolean>>({

--- a/frontend/src/app/reset-password/ResetPasswordForm.tsx
+++ b/frontend/src/app/reset-password/ResetPasswordForm.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -77,8 +76,7 @@ export function ResetPasswordForm() {
       return;
     }
 
-    toast.success('Password updated');
-    router.push(ROUTES.predictions);
+    router.push(`${ROUTES.login}?reset=success`);
     router.refresh();
   };
 

--- a/frontend/src/app/reset-password/__tests__/ResetPasswordForm.test.tsx
+++ b/frontend/src/app/reset-password/__tests__/ResetPasswordForm.test.tsx
@@ -43,7 +43,7 @@ describe('ResetPasswordForm', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('posts password and redirects to predictions on success', async () => {
+  it('posts password and redirects to login on success', async () => {
     fetchMock.mockResolvedValue({ ok: true } as Response);
     const user = userEvent.setup();
     render(<ResetPasswordForm />);
@@ -60,8 +60,8 @@ describe('ResetPasswordForm', () => {
       })
     );
     await screen.findByRole('button', { name: /Updating…|Update password/i });
-    expect(toastSuccessMock).toHaveBeenCalled();
-    expect(mockPush).toHaveBeenCalledWith('/predictions');
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/login?reset=success');
   });
 
   it('surfaces server errors', async () => {

--- a/frontend/src/lib/auth/reset-intent.ts
+++ b/frontend/src/lib/auth/reset-intent.ts
@@ -1,0 +1,71 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export const RESET_INTENT_COOKIE = 'reset_intent';
+const TTL_SECONDS = 900;
+
+interface CookieOptions {
+  httpOnly: true;
+  secure: boolean;
+  sameSite: 'strict';
+  path: string;
+  maxAge: number;
+}
+
+function baseOptions(maxAge: number): CookieOptions {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/api/auth/reset-password',
+    maxAge,
+  };
+}
+
+function getSecret(): string {
+  const secret = process.env.RESET_INTENT_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error('RESET_INTENT_SECRET must be set to at least 32 characters');
+  }
+  return secret;
+}
+
+function hmac(message: string): string {
+  return createHmac('sha256', getSecret()).update(message).digest('base64url');
+}
+
+export function signResetIntent(userId: string) {
+  const iat = Math.floor(Date.now() / 1000);
+  const mac = hmac(`${userId}.${iat}`);
+  return {
+    name: RESET_INTENT_COOKIE,
+    value: `${iat}.${mac}`,
+    options: baseOptions(TTL_SECONDS),
+  };
+}
+
+export function verifyResetIntent(cookieValue: string | undefined, userId: string): boolean {
+  if (!cookieValue) return false;
+  const dot = cookieValue.indexOf('.');
+  if (dot <= 0) return false;
+  const iatStr = cookieValue.slice(0, dot);
+  const mac = cookieValue.slice(dot + 1);
+  const iat = Number.parseInt(iatStr, 10);
+  if (!Number.isFinite(iat)) return false;
+
+  const now = Math.floor(Date.now() / 1000);
+  if (now < iat || now - iat > TTL_SECONDS) return false;
+
+  const expected = hmac(`${userId}.${iat}`);
+  const a = Buffer.from(mac);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export function clearResetIntentCookie() {
+  return {
+    name: RESET_INTENT_COOKIE,
+    value: '',
+    options: baseOptions(0),
+  };
+}


### PR DESCRIPTION
## Summary

Security audit found two account-takeover risks in the password-reset flow. This PR closes both.

- **Anyone-with-a-session could reset the password.** `/api/auth/reset-password` only checked `getUser()` and then `updateUser({password})`. A normal logged-in user (shared computer, hijacked token, etc.) could change the password without going through email. Now the endpoint requires a short-lived HMAC-signed `reset_intent` cookie that is only set when `/auth/callback` succeeds for `verifyOtp({type:'recovery'})` — i.e. the user actually clicked the email link minted for *them*. Cookie is httpOnly, sameSite=strict, path-scoped to `/api/auth/reset-password`, TTL 15 min.
- **Recovery session lingered after abandon.** Supabase's recovery flow creates a full session on link click. If the user closed the tab without resetting, they stayed signed in. On successful reset we now call `signOut()` and the form redirects to `/login?reset=success`, forcing re-auth with the new password.

## Audit notes (unchanged, no action needed)

- All admin RPCs gate on `is_admin()` (`admin_submit_predictions`, `admin_set_user_admin`, `admin_delete_user`, `admin_update_profile`, `admin_set_prediction_payment`, `admin_list_users`).
- Service-role client only imported from server route handlers.
- `prevent_admin_self_elevation` + `prevent_super_admin_change` triggers in place.
- `/api/auth/forgot-password` returns `{ok:true}` uniformly — no enumeration.

## Out of scope (tracked for follow-up)

- `signOut({scope:'others'})` on password change — kills sessions on *other* devices when a user resets. Standard mitigation, deferred per scoping.
- Cloudflare WAF rate-limit rules from CLAUDE.md (deploy-time config).

## Deployment

Requires `RESET_INTENT_SECRET` (32+ random bytes). Generate with `openssl rand -base64 48`.

- Local: add to `frontend/.env` (or `.env.local`) — see `.env.example`.
- Cloudflare Workers prod: `wrangler secret put RESET_INTENT_SECRET`.

The cookie helper uses `node:crypto` (`createHmac`, `timingSafeEqual`); already available via `nodejs_compat` in `wrangler.toml`.

## Test plan

- [x] `npm test` — 285/285 pass (incl. new tests: missing cookie → 403, tampered HMAC → 403, cross-user cookie → 403, expired cookie → 403, happy path → 200 + signOut + cookie cleared)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on changed files
- [ ] Manual: trigger forgot-password → click inbucket link → expect `/reset-password`, submit new password → expect `/login?reset=success` with success toast → log in with new password
- [ ] Manual attacker scenario: log in normally, hit `/api/auth/reset-password` via devtools fetch → expect 403
- [ ] Manual expiry: click link, wait >15 min, submit → expect 403