### PR TITLE
chore(deploy): require RESET_INTENT_SECRET in wrangler

### DIFF
--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -8,7 +8,7 @@ directory = ".open-next/assets"
 binding = "ASSETS"
 
 [secrets]
-required = ["SUPABASE_SERVICE_ROLE_KEY"]
+required = ["SUPABASE_SERVICE_ROLE_KEY","RESET_INTENT_SECRET"]
 
 
 # Environment variables are set via the Cloudflare dashboard or `wrangler secret put`.


### PR DESCRIPTION
Follow-up to #90.

Adds `RESET_INTENT_SECRET` to the `[secrets].required` list in `wrangler.toml` so the deploy checklist surfaces the new server-only env var alongside `SUPABASE_SERVICE_ROLE_KEY`. The runtime reads it via `process.env.RESET_INTENT_SECRET` in `src/lib/auth/reset-intent.ts`.

Set on Workers with:
```
cd frontend && npx wrangler secret put RESET_INTENT_SECRET
```

## Test plan
- [x] No code paths changed; deploy config only.