### PR TITLE
fix(predictions): show Phase-1-only entries on leaderboard + unlock admin nav

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -267,6 +267,12 @@ export function PredictionsPageContent({
   // Per-phase editability for the user-side forms. Super admin bypasses both.
   const phase1Editable = phase === 'phase1' || isSuperAdmin;
   const phase2Editable = phase === 'phase2_open' || isSuperAdmin;
+  // Super admin can keep navigating between steps after the tournament
+  // locks (they're the only role whose forms remain editable through
+  // locks — phase1Editable/phase2Editable above). Without this bypass
+  // the Continue button + step tabs get force-disabled by isLocked,
+  // stranding super admin on the Groups step in the admin editor.
+  const bypassLockNav = isSuperAdmin;
 
   const tournamentQuery = useQuery<{
     id: string;
@@ -547,7 +553,7 @@ export function PredictionsPageContent({
   };
 
   const stepperStatus = (value: Step): StepperStep['status'] => {
-    if (isLocked) return 'locked';
+    if (isLocked && !bypassLockNav) return 'locked';
     if (stepStatus[value]) return 'done';
     if (value === currentStep) return 'current';
     return 'upcoming';
@@ -562,7 +568,7 @@ export function PredictionsPageContent({
 
   const topSteps: StepperStep[] = TOP_STEPS.map((value) => {
     let status: StepperStep['status'];
-    if (isLocked) {
+    if (isLocked && !bypassLockNav) {
       status = 'locked';
     } else if (phase2TabsLocked && (value === 'knockout' || value === 'tiebreaker')) {
       status = 'locked';
@@ -1020,7 +1026,7 @@ export function PredictionsPageContent({
             <Button
               type="button"
               onClick={goToNextStep}
-              disabled={!currentStepComplete || isLocked}
+              disabled={!currentStepComplete || (isLocked && !bypassLockNav)}
               className="sm:w-auto"
             >
               {nextStepLabel ? `Continue to ${nextStepLabel}` : 'Continue'}

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -15,6 +15,11 @@ const toastSuccess = jest.fn();
 const toastError = jest.fn();
 const toastInfo = jest.fn();
 
+// Per-test override for the AuthProvider mock. Defaults to a logged-in
+// non-admin user; individual tests flip isSuperAdmin to exercise the
+// super-admin lock bypass on the wizard's navigation.
+let mockAuthProfile: { isSuperAdmin?: boolean } | null = null;
+
 jest.mock('@tanstack/react-query', () => {
   const actual = jest.requireActual('@tanstack/react-query');
   return {
@@ -27,7 +32,7 @@ jest.mock('@tanstack/react-query', () => {
 jest.mock('@/providers/AuthProvider', () => ({
   useAuthContext: () => ({
     user: { id: 'user-1' },
-    profile: null,
+    profile: mockAuthProfile,
     loading: false,
     signOut: jest.fn(),
     refreshProfile: jest.fn(),
@@ -228,6 +233,7 @@ beforeEach(() => {
   toastSuccess.mockReset();
   toastError.mockReset();
   toastInfo.mockReset();
+  mockAuthProfile = null;
   global.fetch = jest.fn();
 });
 
@@ -331,6 +337,34 @@ describe('PredictionsPageContent — stepper navigation', () => {
     // Only the top row is rendered when not on a knockout step; assert all top tabs are disabled.
     const tabs = screen.getAllByRole('tab');
     tabs.forEach((tab) => expect(tab).toBeDisabled());
+  });
+
+  it('lets a super admin advance past Groups when the tournament is locked', async () => {
+    // Super admin keeps full write access through phase1_locked (admin
+    // RPC bypasses the lock check). The wizard nav must follow suit so
+    // they can actually reach Best 3rds + the knockout sub-steps when
+    // editing a user's bracket post-lock.
+    mockAuthProfile = { isSuperAdmin: true };
+    configureQueries({
+      tournamentLockTime: new Date(Date.now() - 1000).toISOString(),
+      phase: 'phase1_locked',
+    });
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="create" />);
+
+    // Wait for the wizard to hydrate past the skeleton; the badge text
+    // still says "Predictions Locked" on the Submit button so the admin
+    // knows the tournament state, even though nav is unlocked for them.
+    await screen.findByText('Predictions Locked');
+    expect(screen.getByRole('tab', { name: /Group Stage/ })).not.toBeDisabled();
+    expect(screen.getByRole('tab', { name: /Best 3rds/ })).not.toBeDisabled();
+
+    await user.click(screen.getByTestId('fill-all-groups'));
+
+    const continueBtn = screen.getByRole('button', { name: /Continue to Best 3rds/ });
+    expect(continueBtn).toBeEnabled();
+    await user.click(continueBtn);
+    expect(screen.getByTestId('advancers-form')).toBeInTheDocument();
   });
 });
 

--- a/supabase/migrations/0032_phase1_complete_drafts_on_leaderboard.sql
+++ b/supabase/migrations/0032_phase1_complete_drafts_on_leaderboard.sql
@@ -1,0 +1,441 @@
+-- Phase 1 complete drafts count for the leaderboard.
+--
+-- Bug: a user who finishes group + best-3rds picks in Phase 1 and clicks
+-- "Save Phase 1 Picks" creates a row with submitted_at = null. The full
+-- "Submit Prediction" button is gated on the bracket + tiebreaker being
+-- complete (Phase 2 fields), which Phase 1 users can't fill, and once
+-- Phase 1 locks the RPC refuses any further writes. The leaderboard +
+-- per-user rank + public bracket preview RPCs all filter on
+-- `submitted_at is not null`, so the user's paid, Phase-1-complete
+-- prediction is silently excluded for the rest of the tournament.
+--
+-- Fix: treat a prediction as eligible if it is either explicitly
+-- submitted OR has a complete Phase 1 pick set (12 group rows + 8
+-- advancer rows). Backfill submitted_at on existing complete drafts in
+-- tournaments past phase1 so the ORDER BY tiebreaker (submitted_at asc)
+-- has a stable value.
+--
+-- All three RPCs are re-defined from 0031 / 0029 with the relaxed WHERE
+-- clause; everything else (scoring math, payment gate, columns) is
+-- unchanged.
+
+-- ========== helper: prediction_phase1_complete ==========
+-- Returns true iff the prediction has all 12 group picks and 8 advancer
+-- rows. STABLE so callers can inline it in WHERE clauses.
+
+create or replace function public.prediction_phase1_complete(p_prediction_id uuid)
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+    select
+        (select count(*) from public.group_predictions where prediction_id = p_prediction_id) = 12
+        and (select count(*) from public.advancer_predictions where prediction_id = p_prediction_id) = 8;
+$$;
+
+grant execute on function public.prediction_phase1_complete(uuid) to anon, authenticated;
+
+-- ========== backfill ==========
+-- Stamp submitted_at on every complete-Phase-1 draft whose tournament is
+-- past phase 1 (locked / phase 2 / completed). New predictions stay
+-- unstamped until either (a) the user / admin explicitly submits or
+-- (b) the relaxed filter below picks them up after the lock flips.
+
+update public.predictions p
+   set submitted_at = now()
+ where p.submitted_at is null
+   and public.tournament_phase(p.tournament_id) <> 'phase1'
+   and public.prediction_phase1_complete(p.id);
+
+-- ========== get_leaderboard ==========
+
+create or replace function public.get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    total_goals int,
+    total_count bigint
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 8 else 6 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 4
+                    when gp.first_team_id = gs.first_team_id or gp.second_team_id = gs.second_team_id
+                        then 3
+                    when gp.first_team_id = gs.second_team_id or gp.second_team_id = gs.first_team_id
+                        then 2
+                    else 0
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 1.25
+                    when ta_team.team_id is not null then 1.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    r16_scores as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_32', 5, 3)),
+    qf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_16', 6, 3)),
+    sf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'quarter_finals', 8, 4)),
+    f_scores   as (select * from public.knockout_round_scores(p_tournament_id, 'semi_finals', 10, 5)),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 15 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M32'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 5 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M31'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M31'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(r16.round_points, 0)
+             + coalesce(qf.round_points, 0)
+             + coalesce(sf.round_points, 0)
+             + coalesce(fs.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points
+        from public.predictions p
+        left join r16_scores r16 on r16.prediction_id = p.id
+        left join qf_scores qf on qf.prediction_id = p.id
+        left join sf_scores sf on sf.prediction_id = p.id
+        left join f_scores fs on fs.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            pr.username::text as username,
+            coalesce(gsc.group_points, 0) as group_points,
+            coalesce(asc_.advancer_points, 0)::numeric as advancer_points,
+            coalesce(ksc.knockout_points, 0) as knockout_points,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0))::numeric as points,
+            p.total_goals,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        join public.profiles pr on pr.id = p.user_id
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        rank,
+        prediction_id,
+        prediction_name,
+        username,
+        points,
+        group_points,
+        advancer_points,
+        knockout_points,
+        total_goals,
+        count(*) over () as total_count
+    from ranked
+    order by rank
+    offset greatest(p_page - 1, 0) * greatest(p_page_size, 1)
+    limit greatest(p_page_size, 1);
+$$;
+
+-- ========== get_leaderboard_rank ==========
+
+create or replace function public.get_leaderboard_rank(
+    p_tournament_id uuid,
+    p_user_id uuid,
+    p_page_size int default 25
+)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    rank int,
+    page int,
+    points numeric
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 8 else 6 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 4
+                    when gp.first_team_id = gs.first_team_id or gp.second_team_id = gs.second_team_id
+                        then 3
+                    when gp.first_team_id = gs.second_team_id or gp.second_team_id = gs.first_team_id
+                        then 2
+                    else 0
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 1.25
+                    when ta_team.team_id is not null then 1.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    r16_scores as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_32', 5, 3)),
+    qf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_16', 6, 3)),
+    sf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'quarter_finals', 8, 4)),
+    f_scores   as (select * from public.knockout_round_scores(p_tournament_id, 'semi_finals', 10, 5)),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 15 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M32'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 5 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M31'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M31'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(r16.round_points, 0)
+             + coalesce(qf.round_points, 0)
+             + coalesce(sf.round_points, 0)
+             + coalesce(fs.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points
+        from public.predictions p
+        left join r16_scores r16 on r16.prediction_id = p.id
+        left join qf_scores qf on qf.prediction_id = p.id
+        left join sf_scores sf on sf.prediction_id = p.id
+        left join f_scores fs on fs.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            p.user_id,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0))::numeric as points,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        prediction_id,
+        prediction_name,
+        rank,
+        ((rank - 1) / greatest(p_page_size, 1) + 1)::int as page,
+        points
+    from ranked
+    where user_id = p_user_id
+    order by rank;
+$$;
+
+-- ========== get_public_prediction ==========
+-- Mirrors the relaxed eligibility filter so the leaderboard → bracket
+-- detail click-through doesn't 404 on Phase-1-complete drafts.
+
+create or replace function public.get_public_prediction(p_prediction_id uuid)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    total_goals int,
+    submitted_at timestamptz,
+    groups jsonb,
+    knockout jsonb,
+    advancers jsonb
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with elig as (
+        select p.id, p.user_id, p.tournament_id, p.prediction_name, p.total_goals, p.submitted_at
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        join public.tournaments t on t.id = p.tournament_id
+        where p.id = p_prediction_id
+          and auth.uid() is not null
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and tp.paid_at <= t.lock_time
+    )
+    select
+        e.id as prediction_id,
+        e.prediction_name::text,
+        pr.username::text as username,
+        e.total_goals,
+        e.submitted_at,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'group_id', gp.group_id,
+                'first_team_id', gp.first_team_id,
+                'second_team_id', gp.second_team_id,
+                'third_team_id', gp.third_team_id,
+                'fourth_team_id', gp.fourth_team_id
+            ) order by gp.group_id)
+            from public.group_predictions gp
+            where gp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as groups,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'match_id', kp.match_id,
+                'winner_team_id', kp.winner_team_id
+            ) order by kp.match_id)
+            from public.knockout_predictions kp
+            where kp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as knockout,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'rank', ap.rank,
+                'team_id', ap.team_id
+            ) order by ap.rank)
+            from public.advancer_predictions ap
+            where ap.prediction_id = e.id),
+            '[]'::jsonb
+        ) as advancers
+    from elig e
+    join public.profiles pr on pr.id = e.user_id;
+$$;

--- a/supabase/tests/scoring_phase1_complete_eligibility.test.sql
+++ b/supabase/tests/scoring_phase1_complete_eligibility.test.sql
@@ -1,0 +1,115 @@
+-- supabase/tests/scoring_phase1_complete_eligibility.test.sql
+--
+-- Locks down the relaxed eligibility filter in migration 0032: a paid
+-- prediction with all 12 group + 8 advancer rows appears on the
+-- leaderboard even when submitted_at is null (the user only ever
+-- clicked "Save Phase 1 Picks" before the tournament locked). An
+-- incomplete Phase 1 draft still stays hidden.
+
+begin;
+create extension if not exists pgtap with schema extensions;
+set search_path to public, extensions;
+\ir lib/_fixtures.psql
+
+select plan(5);
+
+-- ----- Helpers shared by this file only.
+
+-- Fills all 12 groups for a prediction with the alphabetical team order
+-- for each group. Real picks don't matter — we just need 12 rows so
+-- prediction_phase1_complete() returns true.
+create or replace function pg_temp.fill_all_groups(p_prediction uuid) returns void
+language sql as $$
+    insert into public.group_predictions
+        (prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id)
+    select
+        p_prediction,
+        g.id,
+        pg_temp.team_at(g.id, 0),
+        pg_temp.team_at(g.id, 1),
+        pg_temp.team_at(g.id, 2),
+        pg_temp.team_at(g.id, 3)
+    from public.groups g;
+$$;
+
+-- Fills 8 advancer rows for a prediction using its own 3rd-place picks.
+-- The RPC enforces "team_id is in your 3rd-place picks" but we insert
+-- directly here — the leaderboard scoring math doesn't validate that.
+create or replace function pg_temp.fill_all_advancers(p_prediction uuid) returns void
+language sql as $$
+    insert into public.advancer_predictions (prediction_id, rank, team_id)
+    select p_prediction, gs.rn, gs.third_team_id
+    from (
+        select
+            row_number() over (order by group_id) as rn,
+            third_team_id
+        from public.group_predictions
+        where prediction_id = p_prediction
+        order by group_id
+        limit 8
+    ) gs;
+$$;
+
+do $$
+declare
+  v_user uuid;
+  v_tid  uuid;
+  v_lock timestamptz;
+begin
+  v_user := pg_temp.mk_user('phase1_complete_user');
+  -- Past-lock so the tournament is in phase1_locked.
+  v_tid  := pg_temp.mk_tournament('phase1 eligibility', interval '-1 hour');
+  perform pg_temp.put_id('t',    v_tid);
+  perform pg_temp.put_id('user', v_user);
+
+  select lock_time into v_lock from public.tournaments where id = v_tid;
+
+  -- (a) Paid, submitted_at null, all 12 groups + 8 advancers filled
+  --     -> SHOULD appear on the leaderboard under the relaxed filter.
+  perform pg_temp.put_id('p_phase1_complete', pg_temp.mk_prediction(
+    v_tid, v_user, 'phase 1 complete draft', null, null, true, v_lock - interval '1 day'));
+  perform pg_temp.fill_all_groups(pg_temp.tid('p_phase1_complete'));
+  perform pg_temp.fill_all_advancers(pg_temp.tid('p_phase1_complete'));
+
+  -- (b) Paid, submitted_at null, NO group or advancer rows
+  --     -> stays excluded (the eligibility test already covers this;
+  --     re-asserted here for symmetry).
+  perform pg_temp.put_id('p_empty_draft', pg_temp.mk_prediction(
+    v_tid, v_user, 'empty draft', null, null, true, v_lock - interval '1 day'));
+
+  -- (c) Paid, submitted_at null, 12 groups but ONLY 4 advancers
+  --     -> stays excluded (partial Phase 1 isn't enough).
+  perform pg_temp.put_id('p_partial_advancers', pg_temp.mk_prediction(
+    v_tid, v_user, 'partial advancers draft', null, null, true, v_lock - interval '1 day'));
+  perform pg_temp.fill_all_groups(pg_temp.tid('p_partial_advancers'));
+  insert into public.advancer_predictions (prediction_id, rank, team_id)
+  select pg_temp.tid('p_partial_advancers'), rn, third_team_id
+    from (
+      select row_number() over (order by group_id) as rn, third_team_id
+        from public.group_predictions
+       where prediction_id = pg_temp.tid('p_partial_advancers')
+       order by group_id
+       limit 4
+    ) s;
+
+  -- (d) UNPAID complete Phase 1 draft -> still excluded (payment gate
+  --     is independent of the submitted_at relaxation).
+  perform pg_temp.put_id('p_unpaid_complete', pg_temp.mk_prediction(
+    v_tid, v_user, 'unpaid complete draft', null, null, false));
+  perform pg_temp.fill_all_groups(pg_temp.tid('p_unpaid_complete'));
+  perform pg_temp.fill_all_advancers(pg_temp.tid('p_unpaid_complete'));
+end $$;
+
+select isnt(pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p_phase1_complete')), null,
+            'paid + complete Phase 1 (submitted_at null) -> appears on leaderboard');
+select is(  pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p_empty_draft')),     null,
+            'paid empty draft (submitted_at null) -> still excluded');
+select is(  pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p_partial_advancers')), null,
+            'paid partial Phase 1 (4 of 8 advancers) -> still excluded');
+select is(  pg_temp.lb_rank(pg_temp.tid('t'), pg_temp.tid('p_unpaid_complete')), null,
+            'unpaid complete Phase 1 -> still excluded (payment gate intact)');
+select is(  pg_temp.lb_total_count(pg_temp.tid('t')), 1::bigint,
+            'total_count counts only the eligible Phase 1 draft');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Fixes two bugs that both bite once the tournament leaves Phase 1.

## Bug 1 — Phase-1-only paid predictions silently disappear from the leaderboard

In Phase 1 the only commit action available to users is **Save Phase 1 Picks**, which calls `submit_predictions` with `submit: false`. That writes `submitted_at = null`. The full **Submit Prediction** button is gated on the knockout bracket + tiebreaker (Phase 2 fields the user can't fill yet), and once Phase 1 locks the RPC refuses any further writes (`'predictions are locked'`).

`get_leaderboard`, `get_leaderboard_rank`, and `get_public_prediction` all filter on `submitted_at is not null`, so a paid user with complete group + best-3rd picks vanishes from the leaderboard forever. Scoring works; eligibility doesn't.

**Fix (`supabase/migrations/0032_phase1_complete_drafts_on_leaderboard.sql`):**
- New helper `public.prediction_phase1_complete(uuid) returns boolean` — true iff the prediction has 12 group rows + 8 advancer rows.
- Backfill `submitted_at = now()` on every complete-Phase-1 draft whose tournament is past phase 1.
- Re-define `get_leaderboard`, `get_leaderboard_rank`, and `get_public_prediction` with `(p.submitted_at is not null or public.prediction_phase1_complete(p.id))`. Payment gate, 5-pick cap, per-row scoring math are all unchanged.

**Locked down by `supabase/tests/scoring_phase1_complete_eligibility.test.sql`** (4 cases):
- paid + complete Phase 1, `submitted_at` null → appears
- paid empty draft → still excluded
- paid Phase 1 with 4 / 8 advancers → still excluded
- unpaid complete Phase 1 → still excluded (payment gate intact)

## Bug 2 — Admin can't advance past Groups when the tournament is locked

`PredictionsPageContent`'s stepper-status function, `topSteps` builder, and Continue button all force-disable when `isLocked`. The form fields (`phase1Editable` / `phase2Editable`) already bypass the lock for super admins — the nav code just missed the memo. Result: a super admin opening `/admin/users/[id]/predictions/[id]` in `phase1_locked` can't reach Best 3rds (button greyed, tabs greyed).

**Fix (`frontend/src/app/predictions/PredictionsPageContent.tsx`):**
- Add `const bypassLockNav = isSuperAdmin;` next to the existing `phase1Editable` / `phase2Editable` flags.
- Change three `isLocked` references to `(isLocked && !bypassLockNav)`: `stepperStatus`, `topSteps`, and the Continue button.
- Locked badge and Submit button still reflect the real lock state — only navigation gates change.

**Locked down with a new Jest case** in `PredictionsPageContent.test.tsx`: super admin in `phase1_locked` fills groups, clicks Continue, lands on Best 3rds. The existing "all tabs disabled when locked" test still covers the regular-user path (mock profile is reset between tests).

## Verification
- `npm test` — 286/286 pass
- `npm run typecheck` — clean
- `npx eslint src` — clean (full `npm run lint` is a pre-existing problem; it tries to lint the `.open-next/` build output and crashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)