### PR TITLE
fix(auth): sign out after signup confirmation; redirect to /login?confirmed=1

### DIFF
--- a/frontend/src/app/auth/callback/__tests__/route.test.ts
+++ b/frontend/src/app/auth/callback/__tests__/route.test.ts
@@ -9,6 +9,7 @@ const supabaseMock = {
   auth: {
     verifyOtp: jest.fn(),
     exchangeCodeForSession: jest.fn(),
+    signOut: jest.fn(),
   },
 };
 
@@ -29,6 +30,8 @@ describe('GET /auth/callback', () => {
   beforeEach(() => {
     supabaseMock.auth.verifyOtp.mockReset();
     supabaseMock.auth.exchangeCodeForSession.mockReset();
+    supabaseMock.auth.signOut.mockReset();
+    supabaseMock.auth.signOut.mockResolvedValue({ error: null });
   });
 
   it('sets reset_intent cookie when verifyOtp succeeds for type=recovery', async () => {
@@ -48,7 +51,7 @@ describe('GET /auth/callback', () => {
     expect(setCookie.toLowerCase()).toContain('samesite=strict');
   });
 
-  it('does NOT set reset_intent cookie when verifyOtp succeeds for type=signup', async () => {
+  it('signs out and redirects to /login?confirmed=1 when verifyOtp succeeds for type=signup', async () => {
     supabaseMock.auth.verifyOtp.mockResolvedValue({
       data: { user: { id: 'user-1' } },
       error: null,
@@ -59,6 +62,8 @@ describe('GET /auth/callback', () => {
       )
     );
     expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://localhost:3000/login?confirmed=1');
+    expect(supabaseMock.auth.signOut).toHaveBeenCalledTimes(1);
     expect(res.headers.get('set-cookie') ?? '').not.toContain(RESET_INTENT_COOKIE);
   });
 

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -21,6 +21,16 @@ export async function GET(request: NextRequest) {
       type: rawType as EmailOtpType,
     });
     if (!error) {
+      // verifyOtp for signup mints a session as a side effect, overwriting
+      // any existing session cookie in this browser. Email confirmation is
+      // proof of ownership, not authentication: drop the just-minted session
+      // and send the user to /login so they sign in explicitly. (Side effect:
+      // any prior user logged into this browser is signed out — unavoidable
+      // since their cookie was overwritten by verifyOtp above.)
+      if (rawType === 'signup') {
+        await supabase.auth.signOut();
+        return NextResponse.redirect(`${origin}/login?confirmed=1`);
+      }
       const response = NextResponse.redirect(`${origin}${next}`);
       if (rawType === 'recovery' && data.user) {
         const intent = signResetIntent(data.user.id);

--- a/frontend/src/app/login/LoginForm.tsx
+++ b/frontend/src/app/login/LoginForm.tsx
@@ -23,11 +23,15 @@ export function LoginForm({ redirectTo }: LoginFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const resetToastShown = React.useRef(false);
+  const confirmedToastShown = React.useRef(false);
   React.useEffect(() => {
-    if (resetToastShown.current) return;
-    if (searchParams.get('reset') === 'success') {
+    if (!resetToastShown.current && searchParams.get('reset') === 'success') {
       resetToastShown.current = true;
       toast.success('Password updated. Please sign in with your new password.');
+    }
+    if (!confirmedToastShown.current && searchParams.get('confirmed') === '1') {
+      confirmedToastShown.current = true;
+      toast.success('Email confirmed. Please sign in to continue.');
     }
   }, [searchParams]);
   const [email, setEmail] = React.useState('');


### PR DESCRIPTION
## Problem

When a new user's signup confirmation email was clicked in a browser that already had another user logged in, the new user was confirmed in the DB but the browser remained logged in as the prior user. Two issues stacked:

1. **GoTrue's \`/auth/v1/verify\` marks \`email_confirmed_at\` immediately**, before any redirect or PKCE code exchange. So even though our subsequent \`exchangeCodeForSession\` failed (no \`code_verifier\` in this browser — same cross-browser problem we just fixed for password reset), the user was already confirmed.
2. The PKCE failure meant our app never replaced the existing session cookie. The previously logged-in user remained authenticated, and a freshly confirmed user could never get a session this way.

Even in the *successful* PKCE/token_hash case, \`verifyOtp({ type: 'signup' })\` mints a session as a side effect and overwrites whatever was in \`sb-…-auth-token\` — silently swapping the logged-in identity. Email confirmation should be proof of ownership, not authentication.

## Fix (this PR)

In \`/auth/callback\`'s \`token_hash\` branch, when \`type=signup\`:
- Call \`supabase.auth.signOut()\` to discard the just-minted session.
- Redirect to \`/login?confirmed=1\` regardless of \`next\`.

\`LoginForm\` shows a toast on \`?confirmed=1\` (\"Email confirmed. Please sign in to continue.\"), mirroring the existing \`?reset=success\` pattern.

Side effect we accept: if a different user was logged into this browser, they are signed out (their cookie was already overwritten by \`verifyOtp\` before \`signOut\` cleared it). This is unavoidable and is the safer of two evils — the alternative is silently switching the active account from a link click.

## Required pairing: Supabase Dashboard change

This PR assumes the **Confirm signup** email template is updated to route through the \`token_hash\` branch (same approach as the recent password-reset fix):

\`\`\`
{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&type=signup&next=/login?confirmed=1
\`\`\`

Without this template change, signup confirmations still hit the PKCE \`?code=\` branch and fail to \`/login?error=confirmation_failed\` (unchanged behavior — still preferable to silent session swap, but the user-friendly path requires the template change).

## Tests

- \`auth/callback/route.test.ts\`: updated the \`type=signup\` case to assert \`signOut\` is called and the redirect Location is \`/login?confirmed=1\`. Other branches (recovery token_hash, PKCE recovery, PKCE non-recovery, confirmation failure) unchanged.
- Full suite: **291/291 pass**, \`tsc --noEmit\` clean.
- Repo-wide ESLint hits a Node OOM in this dev env (pre-existing); scoped lint of changed files passes.

## Manual verification plan

1. Apply the Supabase Dashboard template change above.
2. With user A logged in on a browser, sign up user B from another device.
3. Click B's confirmation email in user A's browser.
4. Expect: redirect to \`/login?confirmed=1\` with the toast, no one logged in, user A's prior session cleared, user B confirmed in DB. Sign in as B works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)