### PR TITLE
feat(copy): show $25 CAD per-prediction entry cost on home + rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
-> **Version:** 3.1.0
-> **Last Updated:** 2026-05-09
+> **Version:** 3.2.0
+> **Last Updated:** 2026-05-20
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 World Cup 2026 prediction game. Users register with a username/password, submit bracket predictions (group stage standings + knockout bracket + total goals tiebreaker) before a single tournament-wide lock time, and earn points based on how their predictions compare to admin-submitted real-world results. A leaderboard ranks all participants.
 
-**No blockchain, no wallets, no entry fees** — this is a pure web app backed by Supabase Postgres + Auth. The earlier Solana/Anchor architecture has been removed; any references to wallets, SOL, prize pools, or `@solana/*` packages are stale.
+**No blockchain, no wallets** — this is a pure web app backed by Supabase Postgres + Auth. Entry is paid out-of-band ($25 CAD per prediction; an admin marks `tournament_payments` paid before lock); see `frontend/src/lib/constants.ts` (`PRICING`) and migration `0008_payments.sql`. The earlier Solana/Anchor architecture has been removed; any references to wallets, SOL, prize pools, or `@solana/*` packages are stale.
 
 ## Tech Stack
 

--- a/frontend/src/app/HomePageContent.tsx
+++ b/frontend/src/app/HomePageContent.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ROUTES, TOURNAMENT_CONFIG } from '@/lib/constants';
+import { PRICING, ROUTES, TOURNAMENT_CONFIG } from '@/lib/constants';
 import type { TournamentInfo } from '@/types/tournament';
 
 interface TournamentResponse {
@@ -89,7 +89,8 @@ export function HomePageContent() {
           </h1>
           <p className="text-muted-foreground mb-8 text-lg md:text-xl">
             Submit your bracket predictions, earn points for correct picks, and climb the
-            leaderboard. Free to play — all you need is a username.
+            leaderboard. ${PRICING.entryFeeCAD} {PRICING.currency} per prediction — sign up
+            free, pay per entry.
           </p>
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Button asChild size="lg" className="min-w-[200px]">

--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -4,6 +4,7 @@ import { PageLayout } from '@/components/layout/PageLayout';
 import { ScoringBreakdown } from '@/components/marketing/ScoringBreakdown';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { PRICING } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Rules | World Cup 2026',
@@ -70,15 +71,19 @@ export default function RulesPage() {
               <ul className="text-muted-foreground space-y-3 text-sm">
                 <li>
                   <span className="text-foreground font-semibold">Per-prediction entry.</span>{' '}
-                  Each paid prediction is its own entry. A single account can have multiple
-                  ranks if it has multiple paid predictions.
+                  Each prediction costs{' '}
+                  <span className="text-foreground font-semibold">
+                    ${PRICING.entryFeeCAD} {PRICING.currency}
+                  </span>{' '}
+                  and is its own entry. A single account can have multiple ranks if it has
+                  multiple paid predictions.
                 </li>
                 <li>
                   <span className="text-foreground font-semibold">
-                    Marked paid by an admin.
+                    Contact the pool organizer.
                   </span>{' '}
-                  An admin marks each prediction as paid before lock. Only paid predictions
-                  appear on the leaderboard.
+                  Reach out to arrange payment. An admin marks each prediction as paid
+                  before lock; only paid predictions appear on the leaderboard.
                 </li>
                 <li>
                   <span className="text-foreground font-semibold">Unpaid still saves.</span>{' '}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -21,6 +21,17 @@ export const SCORING = {
 } as const;
 
 /**
+ * Per-prediction entry cost. Paid out-of-band (cash / e-transfer / etc.);
+ * an admin marks each prediction as paid in `tournament_payments` before
+ * lock so it's eligible for the leaderboard. Surfaced in the home hero
+ * (HomePageContent) and the rules page so users see the price up front.
+ */
+export const PRICING = {
+  entryFeeCAD: 25,
+  currency: 'CAD',
+} as const;
+
+/**
  * Labels for the 8 ranked 3rd-place advancer slots, shown in the wizard
  * and admin UI. Rank 1 = "best" 3rd-place team, rank 8 = "8th best".
  */


### PR DESCRIPTION
## Why

Production hero on \`/\` says **'Free to play — all you need is a username.'** That's no longer accurate: each prediction costs **\$25 CAD**, paid out-of-band and admin-marked in \`tournament_payments\` before lock. Users have no way to learn the price from the site today.

This PR surfaces the cost in the two places users look (home hero + rules page), centralizes the value in a constant, and fixes the matching stale line in \`CLAUDE.md\`.

User decisions confirmed during planning:
- **Hero copy**: replace the 'Free to play' line outright.
- **Payment instructions**: show the price + a generic 'Contact the pool organizer' line. No specific channel (e-transfer / cash / Venmo) committed in user-facing copy.
- **CLAUDE.md**: update in the same PR.

## Changes

| File | Change |
|---|---|
| \`frontend/src/lib/constants.ts\` | New \`PRICING\` constant: \`{ entryFeeCAD: 25, currency: 'CAD' }\`. Single source of truth. |
| \`frontend/src/app/HomePageContent.tsx\` | Hero copy now reads '\$25 CAD per prediction — sign up free, pay per entry.' instead of 'Free to play — all you need is a username.' |
| \`frontend/src/app/rules/page.tsx\` | 'Leaderboard eligibility' card: 'Per-prediction entry' bullet now shows the price; second bullet changed from 'Marked paid by an admin' to 'Contact the pool organizer' so users know how to arrange payment. Third bullet untouched. |
| \`CLAUDE.md\` | Line 12 'no entry fees' → corrected description pointing at \`PRICING\` + \`0008_payments.sql\`. Version 3.1.0 → 3.2.0, date bumped. |

## Out of scope

- **No DB change.** \`tournament_payments\` doesn't store an amount and shouldn't — the price is a static fact about this season, not a per-row attribute.
- **No nav change.** \`/rules\` is already linked from \`Header\` and \`Footer\`.
- **No privacy-policy change.** The privacy page mentions 'payment status' without amount, which is the right framing.
- **No 'How It Works' step-2 change** on the home page — keeping the 4-step explainer focused on game mechanics.

## Checks

- \`npm test\`: **297/297 pass** (no behavior changes).
- \`npm run typecheck\`: clean.
- Scoped ESLint on the 3 TSX/TS files: clean. (Full-repo lint OOMs in my local dev env — pre-existing, will run cleanly in CI.)

## Verify after deploy

1. Visit \`/\` — hero reads '\$25 CAD per prediction — sign up free, pay per entry.' No 'Free to play'.
2. Visit \`/rules\` — 'Per-prediction entry' bullet shows the price; second bullet starts with 'Contact the pool organizer'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)