### PR TITLE
feat(copy): bump entry to $30 CAD; add $5 charity portion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-> **Version:** 3.2.0
+> **Version:** 3.2.1
 > **Last Updated:** 2026-05-20
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 World Cup 2026 prediction game. Users register with a username/password, submit bracket predictions (group stage standings + knockout bracket + total goals tiebreaker) before a single tournament-wide lock time, and earn points based on how their predictions compare to admin-submitted real-world results. A leaderboard ranks all participants.
 
-**No blockchain, no wallets** — this is a pure web app backed by Supabase Postgres + Auth. Entry is paid out-of-band ($25 CAD per prediction; an admin marks `tournament_payments` paid before lock); see `frontend/src/lib/constants.ts` (`PRICING`) and migration `0008_payments.sql`. The earlier Solana/Anchor architecture has been removed; any references to wallets, SOL, prize pools, or `@solana/*` packages are stale.
+**No blockchain, no wallets** — this is a pure web app backed by Supabase Postgres + Auth. Entry is paid out-of-band ($30 CAD per prediction; $5 of each entry is allocated to a charity the pool organizer announces before lock; an admin marks `tournament_payments` paid before lock); see `frontend/src/lib/constants.ts` (`PRICING.entryFeeCAD` + `PRICING.charityPortionCAD`) and migration `0008_payments.sql`. The earlier Solana/Anchor architecture has been removed; any references to wallets, SOL, prize pools, or `@solana/*` packages are stale.
 
 ## Tech Stack
 

--- a/frontend/src/app/HomePageContent.tsx
+++ b/frontend/src/app/HomePageContent.tsx
@@ -89,8 +89,9 @@ export function HomePageContent() {
           </h1>
           <p className="text-muted-foreground mb-8 text-lg md:text-xl">
             Submit your bracket predictions, earn points for correct picks, and climb the
-            leaderboard. ${PRICING.entryFeeCAD} {PRICING.currency} per prediction — sign up
-            free, pay per entry.
+            leaderboard. ${PRICING.entryFeeCAD} {PRICING.currency} per prediction — $
+            {PRICING.charityPortionCAD} from each entry goes to a charity announced before
+            lock. Sign up free, pay per entry.
           </p>
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Button asChild size="lg" className="min-w-[200px]">

--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -96,6 +96,28 @@ export default function RulesPage() {
         </div>
       </section>
 
+      <section className="py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Charity contribution</CardTitle>
+            <CardDescription>Where part of every entry goes.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground text-sm">
+              <span className="text-foreground font-semibold">
+                ${PRICING.charityPortionCAD} {PRICING.currency}
+              </span>{' '}
+              from every{' '}
+              <span className="text-foreground font-semibold">
+                ${PRICING.entryFeeCAD} {PRICING.currency}
+              </span>{' '}
+              entry is set aside for charity. The pool organizer will announce the
+              chosen charity before the tournament locks.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+
       <ScoringBreakdown />
 
       <section className="py-8">

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -23,11 +23,15 @@ export const SCORING = {
 /**
  * Per-prediction entry cost. Paid out-of-band (cash / e-transfer / etc.);
  * an admin marks each prediction as paid in `tournament_payments` before
- * lock so it's eligible for the leaderboard. Surfaced in the home hero
- * (HomePageContent) and the rules page so users see the price up front.
+ * lock so it's eligible for the leaderboard. `charityPortionCAD` is the
+ * portion of each entry set aside for a charity (selected by the pool
+ * organizer before lock). Surfaced in the home hero (HomePageContent)
+ * and the rules page so users see the price and the charity split up
+ * front.
  */
 export const PRICING = {
-  entryFeeCAD: 25,
+  entryFeeCAD: 30,
+  charityPortionCAD: 5,
   currency: 'CAD',
 } as const;
 


### PR DESCRIPTION
Two corrections to PR #96: price is $30 CAD (not $25), and $5 of every entry goes to a charity the pool organizer announces before lock. Home hero + new Rules 'Charity contribution' card + CLAUDE.md updated. PRICING constant is single source of truth. 297/297 tests pass, typecheck + scoped lint clean. No DB/behavior changes.