### PR TITLE
feat(register): persistent 'Check your email' view after signup + Resend

### DIFF
--- a/frontend/src/app/register/RegisterForm.tsx
+++ b/frontend/src/app/register/RegisterForm.tsx
@@ -32,6 +32,20 @@ export function RegisterForm() {
     message: string;
   } | null>(null);
 
+  // After a successful signup that requires email confirmation, swap the
+  // form for a persistent "Check your email" view (mirrors the pattern in
+  // ForgotPasswordForm). `submittedEmail` doubles as the indicator that we
+  // are in that mode and as the address shown to the user / used by Resend.
+  const [submittedEmail, setSubmittedEmail] = React.useState<string | null>(null);
+  const [isResending, setIsResending] = React.useState(false);
+  const [resendCooldown, setResendCooldown] = React.useState(0);
+
+  React.useEffect(() => {
+    if (resendCooldown <= 0) return;
+    const id = window.setTimeout(() => setResendCooldown((s) => s - 1), 1000);
+    return () => window.clearTimeout(id);
+  }, [resendCooldown]);
+
   const emailRef = React.useRef<HTMLInputElement>(null);
   const passwordRef = React.useRef<HTMLInputElement>(null);
   const confirmPasswordRef = React.useRef<HTMLInputElement>(null);
@@ -117,8 +131,12 @@ export function RegisterForm() {
     }
 
     if (!data.session) {
+      // Email confirmation required. Keep the toast for instant feedback,
+      // but also swap the form for a persistent "Check your email" view so
+      // users can't miss the next step.
       toast.success('Account created — check your email to confirm.');
-      router.push(ROUTES.login);
+      setSubmittedEmail(email.trim());
+      setIsSubmitting(false);
       return;
     }
 
@@ -127,8 +145,86 @@ export function RegisterForm() {
     router.refresh();
   };
 
+  const handleResend = async () => {
+    if (!submittedEmail || isResending || resendCooldown > 0) return;
+    setIsResending(true);
+    const supabase = createSupabaseBrowserClient();
+    const { error } = await supabase.auth.resend({
+      type: 'signup',
+      email: submittedEmail,
+    });
+    setIsResending(false);
+    if (error) {
+      // Supabase enforces its own per-mailbox throttle; surface the message
+      // verbatim so users see "you can only request this after N seconds"
+      // rather than a generic failure.
+      toast.error(error.message);
+      return;
+    }
+    toast.success('Confirmation email resent.');
+    setResendCooldown(30);
+  };
+
+  const handleTryDifferentAddress = () => {
+    setSubmittedEmail(null);
+    setEmail('');
+    setPassword('');
+    setConfirmPassword('');
+    setTouched({ email: false, password: false, confirmPassword: false });
+    setResendCooldown(0);
+    // Focus moves on next render once the inputs are back in the DOM.
+    requestAnimationFrame(() => emailRef.current?.focus());
+  };
+
   const fieldClass = (field: FieldName) =>
     cn(showError(field) && 'border-destructive focus-visible:ring-destructive');
+
+  if (submittedEmail) {
+    return (
+      <div className="space-y-4">
+        <div role="status" aria-live="polite" className="space-y-3">
+          <p className="text-foreground text-base font-semibold">Check your email</p>
+          <p className="text-muted-foreground text-sm">
+            We sent a confirmation link to{' '}
+            <span className="text-foreground font-semibold break-all">{submittedEmail}</span>.
+            Click the link to activate your account, then sign in.
+          </p>
+          <p className="text-muted-foreground text-sm">
+            Didn&apos;t get it? Check your spam folder.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleResend}
+            disabled={isResending || resendCooldown > 0}
+            className="w-full sm:flex-1"
+          >
+            {isResending
+              ? 'Resending…'
+              : resendCooldown > 0
+                ? `Resend in ${resendCooldown}s`
+                : 'Resend confirmation email'}
+          </Button>
+          <Button asChild className="w-full sm:flex-1">
+            <Link href={ROUTES.login}>Go to sign in</Link>
+          </Button>
+        </div>
+        <p className="text-muted-foreground text-center text-sm">
+          Wrong address?{' '}
+          <button
+            type="button"
+            onClick={handleTryDifferentAddress}
+            className="text-primary hover:underline"
+          >
+            Try a different address
+          </button>
+          .
+        </p>
+      </div>
+    );
+  }
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4" noValidate>

--- a/frontend/src/app/register/__tests__/RegisterForm.test.tsx
+++ b/frontend/src/app/register/__tests__/RegisterForm.test.tsx
@@ -1,12 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
 import { RegisterForm } from '../RegisterForm';
 
 const signUpMock = jest.fn();
+const resendMock = jest.fn();
 
 jest.mock('@/lib/supabase/client', () => ({
   createSupabaseBrowserClient: () => ({
-    auth: { signUp: signUpMock },
+    auth: { signUp: signUpMock, resend: resendMock },
   }),
 }));
 
@@ -14,9 +16,15 @@ jest.mock('sonner', () => ({
   toast: { success: jest.fn(), error: jest.fn() },
 }));
 
+const toastSuccess = toast.success as jest.Mock;
+const toastError = toast.error as jest.Mock;
+
 describe('RegisterForm', () => {
   beforeEach(() => {
     signUpMock.mockReset();
+    resendMock.mockReset();
+    toastSuccess.mockClear();
+    toastError.mockClear();
   });
 
   it('rejects an invalid email', async () => {
@@ -90,5 +98,73 @@ describe('RegisterForm', () => {
     await user.click(screen.getByRole('button', { name: /Create account/i }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(/already exists/);
+  });
+
+  it('replaces the form with a persistent "Check your email" view naming the user address', async () => {
+    signUpMock.mockResolvedValue({ data: { session: null }, error: null });
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    await user.type(screen.getByLabelText(/^Email/i), 'alice@example.com');
+    await user.type(screen.getByLabelText(/^Password/i), 'password123');
+    await user.type(screen.getByLabelText(/Confirm password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /Create account/i }));
+
+    expect(await screen.findByText(/Check your email/i)).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    // Form inputs are gone — the swap happened, not just a toast.
+    expect(screen.queryByLabelText(/^Email/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Password/i)).not.toBeInTheDocument();
+    // Resend + sign-in affordances are present.
+    expect(
+      screen.getByRole('button', { name: /Resend confirmation email/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Go to sign in/i })).toHaveAttribute(
+      'href',
+      '/login'
+    );
+    expect(toastSuccess).toHaveBeenCalledWith(
+      expect.stringMatching(/check your email/i)
+    );
+  });
+
+  it('reopens the signup form when "Try a different address" is clicked', async () => {
+    signUpMock.mockResolvedValue({ data: { session: null }, error: null });
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    await user.type(screen.getByLabelText(/^Email/i), 'alice@example.com');
+    await user.type(screen.getByLabelText(/^Password/i), 'password123');
+    await user.type(screen.getByLabelText(/Confirm password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /Create account/i }));
+
+    await user.click(screen.getByRole('button', { name: /Try a different address/i }));
+
+    const emailInput = await screen.findByLabelText(/^Email/i);
+    expect(emailInput).toBeInTheDocument();
+    expect(emailInput).toHaveValue('');
+    expect(screen.queryByText(/Check your email/i)).not.toBeInTheDocument();
+  });
+
+  it('resends the confirmation email when Resend is clicked', async () => {
+    signUpMock.mockResolvedValue({ data: { session: null }, error: null });
+    resendMock.mockResolvedValue({ error: null });
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    await user.type(screen.getByLabelText(/^Email/i), 'alice@example.com');
+    await user.type(screen.getByLabelText(/^Password/i), 'password123');
+    await user.type(screen.getByLabelText(/Confirm password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /Create account/i }));
+
+    await user.click(screen.getByRole('button', { name: /Resend confirmation email/i }));
+
+    expect(resendMock).toHaveBeenCalledWith({
+      type: 'signup',
+      email: 'alice@example.com',
+    });
+    expect(toastSuccess).toHaveBeenCalledWith(
+      expect.stringMatching(/resent/i)
+    );
   });
 });


### PR DESCRIPTION
## Why

Users have reported missing the post-signup 'check your email' notification — today it's a single sonner toast fired right before \`router.push('/login')\` (\`RegisterForm.tsx:120\`). The toast disappears in ~4s and they land on a bare \`/login\` page with no explanation. Easy to miss, especially on a slow network.

## What

Mirror the proven pattern from \`ForgotPasswordForm.tsx:54–83\` (which already does this for the reset flow): after a successful signup that requires email confirmation, swap the form for a persistent 'Check your email' view that explicitly names the address the link was sent to. URL stays on \`/register\`.

| Behaviour | Before | After |
|---|---|---|
| Visual feedback | Single ~4s toast + redirect to \`/login\` | Toast (kept) **+** persistent in-place view showing the actual email |
| Self-serve resend | None | 'Resend confirmation email' button (calls \`supabase.auth.resend\`) with 30s client cooldown |
| Wrong-email recovery | Re-register from scratch | 'Try a different address' reopens the form, fields cleared, email focused |
| Path to sign in | Already on \`/login\` | 'Go to sign in' link |

The auto-session branch (tenant with email confirmation disabled) is unchanged — still toasts and routes to \`/predictions\`. The downstream \`/auth/callback\` → \`/login?confirmed=1\` flow (with its existing 'Email confirmed' toast) is unaffected.

## Files

| File | Change |
|---|---|
| \`frontend/src/app/register/RegisterForm.tsx\` | New \`submittedEmail\` / \`isResending\` / \`resendCooldown\` state, \`handleResend\` + \`handleTryDifferentAddress\` handlers, cooldown countdown effect, early-return JSX block above the existing form. |
| \`frontend/src/app/register/__tests__/RegisterForm.test.tsx\` | Added \`resendMock\` to the supabase client mock, exposed toast mocks for assertion, and added 3 new test cases. |

## Reused patterns

- **Persistent confirmation pattern**: \`ForgotPasswordForm.tsx:54–83\`.
- **Toast wiring**: existing \`sonner\` usage in \`RegisterForm.tsx\` / \`LoginForm.tsx\`.
- **\`supabase.auth.resend\`**: built-in Supabase API, no new endpoint or RPC.

## Out of scope

- No change to \`/auth/callback\`, Supabase email templates, route handlers, or the proxy.
- No new page — keeping the user on \`/register\` mirrors \`ForgotPasswordForm\` and avoids extra navigation surface.
- **No Cloudflare WAF rate-limit rule yet** for resend. Supabase enforces its own per-mailbox throttle, and the client cooldown is a UX guard. If abuse appears, add a WAF rule similar to the existing \`/api/auth/forgot-password\` 5/min rule (CLAUDE.md → 'Production rate limits').

## Checks

- \`npm test\`: **300/300 pass** (was 297; +3 new RegisterForm tests).
- \`npm run typecheck\`: clean.
- Scoped \`eslint\` on the two changed files: clean.

## Verify after deploy

1. Submit \`/register\` with a fresh email → toast 'Account created — check your email to confirm.' fires, form is replaced by 'Check your email' card showing the typed address. URL stays \`/register\`.
2. Click 'Resend confirmation email' → toast 'Confirmation email resent.' fires, button shows \`Resend in 30s\` countdown, then re-enables.
3. Click 'Try a different address' → form reappears, email field empty and focused.
4. Click the actual confirmation link in the email → flows through \`/auth/callback\` to \`/login?confirmed=1\` and shows 'Email confirmed. Please sign in to continue.' (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)