### PR TITLE
feat(predictions): remove the 5-prediction-per-user cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 - `profiles` — 1:1 with `auth.users`. Holds `username` (citext, unique, 3–24 chars, `[A-Za-z0-9_]`), `display_name`, `avatar_url`, `is_admin`. Auto-created via `handle_new_user` trigger; if `raw_user_meta_data.username` is missing (default for self-signup), the trigger generates `user_<8 hex chars>` with a 10-attempt collision retry. Admin-create flows still pass an explicit username.
 - `tournaments` — single active tournament enforced by partial unique index. Holds `lock_time` (single tournament-wide deadline) and `status` (`upcoming|group_stage|knockout|completed`).
 - `groups` (12: A–L), `teams` (48, FK to groups), `knockout_matches` (31, R32 → final, with `team1_source`/`team2_source` strings like `"M1"` or `"A1"`).
-- `predictions` — **many per `(user, tournament)`**, capped at 5. Each has a unique `prediction_name` per user/tournament (case-insensitive), 1–60 chars matching `^[A-Za-z0-9 _\-.''‘’]+$`. Holds `total_goals` tiebreaker + submission timestamp.
+- `predictions` — **many per `(user, tournament)`**, no quantity limit. Each has a unique `prediction_name` per user/tournament (case-insensitive), 1–60 chars matching `^[A-Za-z0-9 _\-.''‘’]+$`. Holds `total_goals` tiebreaker + submission timestamp.
 - `group_predictions` — normalized: 12 rows per prediction with `first_team_id`/`second_team_id`/`third_team_id`/`fourth_team_id`. CHECK enforces all four are distinct. PK is `(prediction_id, group_id)`.
 - `knockout_predictions` — one per `(prediction, match)` with predicted winner.
 - `tournament_payments` — one per `prediction_id` (UNIQUE). Payment is per-prediction, not per-user. Each paid prediction is its own ranked entry on the leaderboard.
@@ -63,7 +63,7 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 
 ### RPCs (the trust boundary)
 
-- **`submit_predictions(payload jsonb)`** — single transaction. Payload includes optional `prediction_id` (omit to create, present to update) and required-on-create `prediction_name`. Cap of 5 per `(user, tournament)` is enforced under `pg_advisory_xact_lock(hashtext(user || ':' || tournament))` to close the count-then-insert race. Raises `'predictions are locked'` (→ 403), `'prediction limit reached'` (→ 409), `'prediction name taken'` (→ 409), `'prediction name required'` (→ 400), `'prediction not found'` (→ 404).
+- **`submit_predictions(payload jsonb)`** — single transaction. Payload includes optional `prediction_id` (omit to create, present to update) and required-on-create `prediction_name`. Users can create unlimited predictions per `(user, tournament)`; `prediction_name` uniqueness is enforced by the unique index. Raises `'predictions are locked'` (→ 403), `'prediction name taken'` (→ 409), `'prediction name required'` (→ 400), `'prediction not found'` (→ 404).
 - **`admin_submit_predictions(p_user_id, payload)`** — same branching, no auth/lock check, scoped to the target user.
 - **`admin_set_prediction_payment(p_prediction_id, p_paid, p_paid_at)`** — replaces the old `admin_set_payment(user_id, tournament_id, …)`. Upserts `tournament_payments` keyed on `prediction_id`.
 - **`get_leaderboard(p_tournament_id, p_page, p_page_size)`** — paginated, SECURITY DEFINER. Returns one row per **paid prediction** with columns `rank, prediction_id, prediction_name, username, points, group_points, knockout_points, total_goals, total_count`. A user with N paid predictions occupies N rows.
@@ -102,7 +102,7 @@ Plus flat bonuses on top: champion (M32 winner) `+15`, third-place winner (M31) 
 
 - `/` — landing page
 - `/login`, `/register` — Supabase email auth (server-redirected if already signed in)
-- `/predictions` — protected list/hub: shows the user's predictions for the active tournament + a "New prediction" button (hidden when at the cap of 5 or when locked).
+- `/predictions` — protected list/hub: shows the user's predictions for the active tournament + a "New prediction" button (hidden when locked).
 - `/predictions/new` — wizard in create mode; on submit, redirects to `/predictions/[id]`.
 - `/predictions/[id]` — wizard in edit mode; server-fetches the prediction and passes as `initial` prop.
 - `/leaderboard` — public; uses `/api/leaderboard` and `/api/leaderboard/me`
@@ -136,7 +136,7 @@ Plus flat bonuses on top: champion (M32 winner) `+15`, third-place winner (M31) 
 ## Game Mechanics
 
 - 48 teams, 12 groups (A–L, 4 teams each), 104 total matches
-- Each user can create up to **5 named predictions** per tournament. Each prediction is independent (own picks, own tiebreaker, own payment).
+- Each user can create as many named predictions per tournament as they like. Each prediction is independent (own picks, own tiebreaker, own payment).
 - All predictions submitted upfront before a single tournament-wide lock time (users may edit any of their predictions until lock)
 - Payment is **per prediction**: each one must be marked paid by an admin before lock to be eligible. The leaderboard shows one row per paid prediction (a user with N paid predictions occupies N rows).
 - Group stage: predict positions 1–4 for all 12 groups; only the top 2 finishers are scored (set-based 6/4/3/2/0 with a +8 exact-order bonus for Group I, the "Group of Death")

--- a/frontend/src/app/api/admin/users/[id]/predictions/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/route.ts
@@ -137,7 +137,7 @@ export async function POST(
   if (error) {
     const msg = error.message ?? '';
     let status = 400;
-    if (msg.includes('limit reached') || msg.includes('name taken')) status = 409;
+    if (msg.includes('name taken')) status = 409;
     else if (msg.includes('duplicate advancer')) status = 409;
     else if (msg.includes('advancer')) status = 400;
     return NextResponse.json({ error: safeMessage(error) }, { status });

--- a/frontend/src/app/api/predictions/__tests__/route.test.ts
+++ b/frontend/src/app/api/predictions/__tests__/route.test.ts
@@ -85,7 +85,6 @@ describe('GET /api/predictions', () => {
     const body = await res.json();
     expect(body).toMatchObject({
       tournament: { id: 't1' },
-      cap: 5,
       predictions: [],
     });
   });
@@ -133,16 +132,6 @@ describe('POST /api/predictions', () => {
     });
     const res = await POST(postRequest(basePostBody()));
     expect(res.status).toBe(403);
-  });
-
-  it('returns 409 when rpc reports limit reached', async () => {
-    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
-    supabaseMock.rpc.mockResolvedValue({
-      data: null,
-      error: { message: 'prediction limit reached' },
-    });
-    const res = await POST(postRequest(basePostBody()));
-    expect(res.status).toBe(409);
   });
 
   it('returns 409 when rpc reports name taken', async () => {

--- a/frontend/src/app/api/predictions/route.ts
+++ b/frontend/src/app/api/predictions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerSupabase } from '@/lib/supabase/server';
 import { safeMessage } from '@/lib/api/errors';
-import { PREDICTION_CAP, PREDICTION_NAME_MAX, PREDICTION_NAME_REGEX } from '@/lib/constants';
+import { PREDICTION_NAME_MAX, PREDICTION_NAME_REGEX } from '@/lib/constants';
 
 interface SubmitPayload {
   tournamentId?: string;
@@ -120,7 +120,6 @@ export async function GET() {
 
   return NextResponse.json({
     tournament: { id: tournament.id, lockTime: tournament.lock_time },
-    cap: PREDICTION_CAP,
     predictions: ((predictions ?? []) as PredictionRow[]).map((p) => {
       const raw = p.tournament_payments;
       const payment: Payment | null = !raw
@@ -208,7 +207,7 @@ export async function POST(request: NextRequest) {
     const msg = error.message ?? '';
     let status = 400;
     if (msg.includes('locked')) status = 403;
-    else if (msg.includes('limit reached') || msg.includes('name taken')) status = 409;
+    else if (msg.includes('name taken')) status = 409;
     else if (msg.includes('duplicate advancer')) status = 409;
     else if (msg.includes('advancer')) status = 400;
     return NextResponse.json({ error: safeMessage(error) }, { status });

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/hooks/useDraftPersistence';
 import { useTournamentLock } from '@/hooks/useTournamentLock';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
-import { PREDICTION_CAP, ROUTES } from '@/lib/constants';
+import { ROUTES } from '@/lib/constants';
 
 interface ApiPrediction {
   id: string;
@@ -39,7 +39,6 @@ interface ApiPrediction {
 
 interface ApiResponse {
   tournament: { id: string; lockTime: string };
-  cap: number;
   predictions: ApiPrediction[];
 }
 
@@ -77,11 +76,9 @@ export function PredictionsListPage() {
     phase === 'phase2_locked' || (phase === 'phase1_locked' && advancersSet);
 
   const predictions = query.data?.predictions ?? [];
-  const cap = query.data?.cap ?? PREDICTION_CAP;
-  const atCap = predictions.length >= cap;
   // Late-joiner block: new predictions can only be created during phase 1.
   // Super admins bypass.
-  const canCreate = !atCap && (phase === 'phase1' || isSuperAdmin);
+  const canCreate = phase === 'phase1' || isSuperAdmin;
 
   const handleDelete = async () => {
     if (!pendingDelete) return;
@@ -113,7 +110,7 @@ export function PredictionsListPage() {
         <div>
           <h1 className="mb-2 text-3xl font-bold">Your Predictions</h1>
           <p className="text-muted-foreground">
-            Create up to {cap} brackets. Each paid bracket is ranked separately on the leaderboard.
+            Create as many brackets as you like. Each paid bracket is ranked separately on the leaderboard.
           </p>
         </div>
         <Button asChild disabled={!canCreate} size="lg">
@@ -123,11 +120,7 @@ export function PredictionsListPage() {
             }
             aria-disabled={!canCreate}
             title={
-              isLocked && !isSuperAdmin
-                ? 'Predictions are locked'
-                : atCap
-                  ? `You've reached the cap of ${cap}`
-                  : undefined
+              isLocked && !isSuperAdmin ? 'Predictions are locked' : undefined
             }
           >
             <Plus className="mr-2 h-4 w-4" /> New prediction

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -783,9 +783,6 @@ export function PredictionsPageContent({
           nameRef.current?.focus();
           throw new Error('Pick a different prediction name.');
         }
-        if (msg.includes('limit reached')) {
-          throw new Error('You have reached the prediction limit.');
-        }
         throw new Error(msg);
       }
 

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -26,7 +26,6 @@ const KNOWN_ERROR_FRAGMENTS = [
   'all four teams must be distinct',
   'does not belong to group',
   'winner and loser must differ',
-  'prediction limit reached',
   'prediction name required',
   'prediction name taken',
   'prediction not found',

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -89,4 +89,3 @@ export const PASSWORD_MIN_LENGTH = 8;
 
 export const PREDICTION_NAME_REGEX = /^[A-Za-z0-9 _\-.''‘’]+$/;
 export const PREDICTION_NAME_MAX = 60;
-export const PREDICTION_CAP = 5;

--- a/supabase/migrations/0034_remove_prediction_cap.sql
+++ b/supabase/migrations/0034_remove_prediction_cap.sql
@@ -1,0 +1,366 @@
+-- Remove the 5-prediction-per-(user, tournament) cap.
+--
+-- Replaces submit_predictions and admin_submit_predictions from 0027 with
+-- bodies identical except:
+--   * no pg_advisory_xact_lock (it only existed to close the count-then-insert
+--     race for the cap check),
+--   * no count(*) + 'prediction limit reached' check,
+--   * v_existing_count declaration removed.
+--
+-- Per-prediction prediction_name uniqueness is still enforced by the existing
+-- unique index, so users still can't create duplicate names; they can simply
+-- create as many distinct named predictions as they want.
+
+-- ========== submit_predictions ==========
+
+create or replace function public.submit_predictions(payload jsonb)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid := (payload->>'tournament_id')::uuid;
+    v_prediction_id uuid := nullif(payload->>'prediction_id', '')::uuid;
+    v_prediction_name text := nullif(trim(payload->>'prediction_name'), '');
+    v_total_goals int := nullif(payload->>'total_goals', '')::int;
+    v_mark_submitted boolean := coalesce((payload->>'submit')::boolean, true);
+    v_user uuid := auth.uid();
+    v_phase text;
+    v_has_phase1_fields boolean;
+    v_has_phase2_fields boolean;
+    v_group jsonb;
+    v_match jsonb;
+    v_advancer jsonb;
+    v_rank int;
+    v_team_id text;
+    v_seen_ranks int[] := '{}';
+    v_seen_teams text[] := '{}';
+    v_valid_thirds text[];
+    v_group_id text;
+    v_team_ids text[];
+    v_mismatched_team text;
+begin
+    if v_user is null then
+        raise exception 'not authenticated';
+    end if;
+
+    v_phase := public.tournament_phase(v_tournament_id);
+
+    if v_prediction_id is null and v_phase <> 'phase1' then
+        raise exception 'phase 1 ended; new predictions cannot be created'
+            using errcode = 'P0001';
+    end if;
+
+    v_has_phase1_fields := (payload ? 'groups' and jsonb_array_length(payload->'groups') > 0)
+        or (payload ? 'advancers' and jsonb_array_length(payload->'advancers') > 0);
+    v_has_phase2_fields := (payload ? 'knockout' and jsonb_array_length(payload->'knockout') > 0)
+        or (v_total_goals is not null);
+
+    if v_phase = 'phase1_locked' or v_phase = 'phase2_locked' then
+        raise exception 'predictions are locked';
+    end if;
+
+    if v_phase = 'phase1' and v_has_phase2_fields then
+        raise exception 'phase 1 only fields allowed' using errcode = 'P0001';
+    end if;
+    if v_phase = 'phase2_open' and v_has_phase1_fields then
+        raise exception 'phase 1 ended; group + advancer picks are frozen'
+            using errcode = 'P0001';
+    end if;
+
+    if v_prediction_id is null then
+        if v_prediction_name is null then
+            raise exception 'prediction name required' using errcode = 'P0001';
+        end if;
+
+        begin
+            insert into public.predictions (user_id, tournament_id, prediction_name, total_goals, submitted_at)
+            values (
+                v_user,
+                v_tournament_id,
+                v_prediction_name,
+                v_total_goals,
+                case when v_mark_submitted then now() else null end
+            )
+            returning id into v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    else
+        perform 1 from public.predictions
+            where id = v_prediction_id and user_id = v_user and tournament_id = v_tournament_id;
+        if not found then
+            raise exception 'prediction not found' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.predictions
+               set prediction_name = coalesce(v_prediction_name, prediction_name),
+                   total_goals = case when v_phase = 'phase2_open' then v_total_goals else total_goals end,
+                   submitted_at = case when v_mark_submitted then now() else submitted_at end
+             where id = v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    if v_phase = 'phase1' then
+        delete from public.advancer_predictions where prediction_id = v_prediction_id;
+        delete from public.group_predictions where prediction_id = v_prediction_id;
+
+        for v_group in select * from jsonb_array_elements(coalesce(payload->'groups', '[]'::jsonb))
+        loop
+            v_group_id := v_group->>'group_id';
+            v_team_ids := array_remove(array[
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            ], null);
+
+            select t.id into v_mismatched_team
+              from public.teams t
+             where t.id = any(v_team_ids) and t.group_id is distinct from v_group_id
+             limit 1;
+
+            if v_mismatched_team is not null then
+                raise exception 'team % does not belong to group %', v_mismatched_team, v_group_id
+                    using errcode = 'P0001';
+            end if;
+
+            insert into public.group_predictions (
+                prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id
+            ) values (
+                v_prediction_id,
+                v_group_id,
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            );
+        end loop;
+
+        select array_agg(third_team_id) into v_valid_thirds
+          from public.group_predictions
+         where prediction_id = v_prediction_id
+           and third_team_id is not null;
+
+        for v_advancer in select * from jsonb_array_elements(coalesce(payload->'advancers', '[]'::jsonb))
+        loop
+            v_rank := nullif(v_advancer->>'rank', '')::int;
+            v_team_id := nullif(v_advancer->>'team_id', '');
+            if v_team_id is null then
+                continue;
+            end if;
+            if v_rank is null or v_rank < 1 or v_rank > 8 then
+                raise exception 'advancer rank must be 1..8 (got %)', v_rank using errcode = 'P0001';
+            end if;
+            if v_rank = any(v_seen_ranks) then
+                raise exception 'duplicate advancer rank %', v_rank using errcode = 'P0001';
+            end if;
+            if v_team_id = any(v_seen_teams) then
+                raise exception 'duplicate advancer team' using errcode = 'P0001';
+            end if;
+            if v_valid_thirds is null or not (v_team_id = any(v_valid_thirds)) then
+                raise exception 'advancer team % not in your 3rd-place picks', v_team_id
+                    using errcode = 'P0001';
+            end if;
+            v_seen_ranks := array_append(v_seen_ranks, v_rank);
+            v_seen_teams := array_append(v_seen_teams, v_team_id);
+
+            insert into public.advancer_predictions (prediction_id, rank, team_id)
+            values (v_prediction_id, v_rank, v_team_id);
+        end loop;
+    elsif v_phase = 'phase2_open' then
+        delete from public.knockout_predictions where prediction_id = v_prediction_id;
+        for v_match in select * from jsonb_array_elements(coalesce(payload->'knockout', '[]'::jsonb))
+        loop
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+            values (
+                v_prediction_id,
+                v_match->>'match_id',
+                nullif(v_match->>'winner', '')
+            );
+        end loop;
+    end if;
+
+    return v_prediction_id;
+end;
+$$;
+
+-- ========== admin_submit_predictions ==========
+
+create or replace function public.admin_submit_predictions(p_user_id uuid, payload jsonb)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid := (payload->>'tournament_id')::uuid;
+    v_prediction_id uuid := nullif(payload->>'prediction_id', '')::uuid;
+    v_prediction_name text := nullif(trim(payload->>'prediction_name'), '');
+    v_total_goals int := nullif(payload->>'total_goals', '')::int;
+    v_mark_submitted boolean := coalesce((payload->>'submit')::boolean, true);
+    v_phase text;
+    v_super boolean;
+    v_group jsonb;
+    v_match jsonb;
+    v_advancer jsonb;
+    v_rank int;
+    v_team_id text;
+    v_seen_ranks int[] := '{}';
+    v_seen_teams text[] := '{}';
+    v_valid_thirds text[];
+    v_group_id text;
+    v_team_ids text[];
+    v_mismatched_team text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_user_id is null or v_tournament_id is null then
+        raise exception 'user_id and tournament_id are required' using errcode = 'P0001';
+    end if;
+
+    v_super := public.is_super_admin();
+    v_phase := public.tournament_phase(v_tournament_id);
+
+    if not v_super then
+        if v_prediction_id is null and v_phase <> 'phase1' then
+            raise exception 'phase 1 ended; new predictions cannot be created'
+                using errcode = 'P0001';
+        end if;
+        if v_phase = 'phase1_locked' or v_phase = 'phase2_locked' then
+            raise exception 'predictions are locked';
+        end if;
+    end if;
+
+    if v_prediction_id is null then
+        if v_prediction_name is null then
+            raise exception 'prediction name required' using errcode = 'P0001';
+        end if;
+
+        begin
+            insert into public.predictions (user_id, tournament_id, prediction_name, total_goals, submitted_at)
+            values (
+                p_user_id,
+                v_tournament_id,
+                v_prediction_name,
+                v_total_goals,
+                case when v_mark_submitted then now() else null end
+            )
+            returning id into v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    else
+        perform 1 from public.predictions
+            where id = v_prediction_id and user_id = p_user_id and tournament_id = v_tournament_id;
+        if not found then
+            raise exception 'prediction not found' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.predictions
+               set prediction_name = coalesce(v_prediction_name, prediction_name),
+                   total_goals = v_total_goals,
+                   submitted_at = case when v_mark_submitted then now() else submitted_at end
+             where id = v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    if v_super or v_phase = 'phase1' then
+        delete from public.advancer_predictions where prediction_id = v_prediction_id;
+        delete from public.group_predictions where prediction_id = v_prediction_id;
+
+        for v_group in select * from jsonb_array_elements(coalesce(payload->'groups', '[]'::jsonb))
+        loop
+            v_group_id := v_group->>'group_id';
+            v_team_ids := array_remove(array[
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            ], null);
+
+            select t.id into v_mismatched_team
+              from public.teams t
+             where t.id = any(v_team_ids) and t.group_id is distinct from v_group_id
+             limit 1;
+
+            if v_mismatched_team is not null then
+                raise exception 'team % does not belong to group %', v_mismatched_team, v_group_id
+                    using errcode = 'P0001';
+            end if;
+
+            insert into public.group_predictions (
+                prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id
+            ) values (
+                v_prediction_id,
+                v_group_id,
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            );
+        end loop;
+
+        select array_agg(third_team_id) into v_valid_thirds
+          from public.group_predictions
+         where prediction_id = v_prediction_id
+           and third_team_id is not null;
+
+        for v_advancer in select * from jsonb_array_elements(coalesce(payload->'advancers', '[]'::jsonb))
+        loop
+            v_rank := nullif(v_advancer->>'rank', '')::int;
+            v_team_id := nullif(v_advancer->>'team_id', '');
+            if v_team_id is null then
+                continue;
+            end if;
+            if v_rank is null or v_rank < 1 or v_rank > 8 then
+                raise exception 'advancer rank must be 1..8 (got %)', v_rank using errcode = 'P0001';
+            end if;
+            if v_rank = any(v_seen_ranks) then
+                raise exception 'duplicate advancer rank %', v_rank using errcode = 'P0001';
+            end if;
+            if v_team_id = any(v_seen_teams) then
+                raise exception 'duplicate advancer team' using errcode = 'P0001';
+            end if;
+            if v_valid_thirds is null or not (v_team_id = any(v_valid_thirds)) then
+                raise exception 'advancer team % not in your 3rd-place picks', v_team_id
+                    using errcode = 'P0001';
+            end if;
+            v_seen_ranks := array_append(v_seen_ranks, v_rank);
+            v_seen_teams := array_append(v_seen_teams, v_team_id);
+
+            insert into public.advancer_predictions (prediction_id, rank, team_id)
+            values (v_prediction_id, v_rank, v_team_id);
+        end loop;
+    end if;
+
+    if v_super or v_phase = 'phase2_open' then
+        delete from public.knockout_predictions where prediction_id = v_prediction_id;
+        for v_match in select * from jsonb_array_elements(coalesce(payload->'knockout', '[]'::jsonb))
+        loop
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+            values (
+                v_prediction_id,
+                v_match->>'match_id',
+                nullif(v_match->>'winner', '')
+            );
+        end loop;
+    end if;
+
+    return v_prediction_id;
+end;
+$$;
+
+grant execute on function public.admin_submit_predictions(uuid, jsonb) to authenticated;


### PR DESCRIPTION
Removes the 5-named-predictions-per-(user, tournament) cap. Users can create as many predictions as they want. Per-prediction `prediction_name` uniqueness (existing unique index) still prevents duplicates, and the per-paid-prediction leaderboard model is unchanged.

## What changed

### Database
- **`supabase/migrations/0034_remove_prediction_cap.sql`** — `create or replace` for `submit_predictions` and `admin_submit_predictions`. Drops the `select count(*) … if v_existing_count >= 5 then raise exception 'prediction limit reached'` block in both RPCs and removes the `pg_advisory_xact_lock` that only existed to close the count-then-insert race. Everything else (phase gating, name-required, unique-violation handling, group/knockout/advancer writes) is byte-for-byte identical to `0027_advancers_rpcs.sql`.

### Frontend
- `frontend/src/lib/constants.ts` — delete `PREDICTION_CAP = 5`.
- `frontend/src/app/api/predictions/route.ts` — drop `cap` from the GET response and the `'limit reached'` branch from the POST error mapper.
- `frontend/src/app/api/admin/users/[id]/predictions/route.ts` — same `'limit reached'` cleanup.
- `frontend/src/app/predictions/PredictionsListPage.tsx` — remove `atCap` gate and tooltip; new subtitle: *"Create as many brackets as you like."*
- `frontend/src/app/predictions/PredictionsPageContent.tsx` — drop the wizard's `'limit reached'` error branch.
- `frontend/src/lib/api/errors.ts` — remove `'prediction limit reached'` from the safe-error whitelist (RPC no longer raises it).

### Tests + docs
- `frontend/src/app/api/predictions/__tests__/route.test.ts` — drop the `cap: 5` assertion and the 409-on-limit-reached test.
- `CLAUDE.md` — scrub the four cap references (line 51, 66, 105, 139).

## Verification

- `npm test` → 299/299 pass across 38 suites.
- `npm run typecheck` → clean.
- Touched files lint clean (the full-repo lint run hits a pre-existing ESLint formatter OOM unrelated to this PR — happens regardless of these changes).

## What's NOT changing

- Older migrations (0015, 0017, 0018, 0021, 0022, 0027) still contain the old `>= 5` check — migrations are append-only, only the latest `create or replace` in 0034 matters at runtime.
- `prediction_name` uniqueness — unchanged.
- Payment / leaderboard / scoring — all unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)