### PR TITLE
fix(predictions): super admin sees Save Phase 1 Picks alongside Continue

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -855,6 +855,22 @@ export function PredictionsPageContent({
   const showContinue =
     !isLastStep && (!isPhase1BestThirds || isSuperAdmin);
 
+  // Why is the Save Phase 1 Picks button disabled? The button has four
+  // silent gates (name validation, current-step completion, lock state,
+  // in-flight save); without a hint the user is left guessing — especially
+  // when name validation fires before they've touched the field. Surface
+  // it as both a tooltip and a visible note.
+  const savePhase1DisabledReason: string | null =
+    isLocked
+      ? 'Predictions are locked.'
+      : isSavingProgress || isSubmitting
+        ? null
+        : nameError
+          ? 'Enter a prediction name above first.'
+          : !currentStepComplete
+            ? 'Rank all 8 of your best 3rd-place teams above.'
+            : null;
+
   return (
     <PageLayout>
       <div className="mb-8">
@@ -1001,23 +1017,37 @@ export function PredictionsPageContent({
             <ArrowLeft className="mr-2 h-4 w-4" />
             {previousStepLabel ? `Back: ${previousStepLabel}` : 'Back'}
           </Button>
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
             {showSavePhase1 && (
-              <Button
-                type="button"
-                onClick={handleSavePhase1}
-                disabled={
-                  !currentStepComplete ||
-                  isLocked ||
-                  isSavingProgress ||
-                  isSubmitting ||
-                  !!nameError
-                }
-                className="sm:w-auto"
-              >
-                {isSavingProgress ? 'Saving…' : 'Save Phase 1 Picks'}
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Button>
+              <div className="flex flex-col items-end gap-1">
+                <Button
+                  type="button"
+                  onClick={handleSavePhase1}
+                  disabled={
+                    !currentStepComplete ||
+                    isLocked ||
+                    isSavingProgress ||
+                    isSubmitting ||
+                    !!nameError
+                  }
+                  title={savePhase1DisabledReason ?? undefined}
+                  aria-describedby={
+                    savePhase1DisabledReason ? 'save-phase1-disabled-hint' : undefined
+                  }
+                  className="sm:w-auto"
+                >
+                  {isSavingProgress ? 'Saving…' : 'Save Phase 1 Picks'}
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Button>
+                {savePhase1DisabledReason && (
+                  <p
+                    id="save-phase1-disabled-hint"
+                    className="text-muted-foreground text-xs"
+                  >
+                    {savePhase1DisabledReason}
+                  </p>
+                )}
+              </div>
             )}
             {showReviewSubmit && (
               <Button

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -839,13 +839,21 @@ export function PredictionsPageContent({
   const currentStepComplete = stepStatus[currentStep];
   const nextStepLabel = !isLastStep ? STEP_LABELS[STEP_ORDER[stepIndex + 1]] : null;
   const previousStepLabel = !isFirstStep ? STEP_LABELS[STEP_ORDER[stepIndex - 1]] : null;
-  // In Phase 1, regular users have no knockout step to "Continue to" — the
-  // bracket is read-only. Replace the bottom nav with a "Save Phase 1 Picks"
-  // button on the last Phase 1 step (Best 3rds) so the user has a clear
-  // end-of-Phase-1 commit action instead of being dumped into disabled
-  // knockout screens. Super admin keeps Continue (god-mode editing).
-  const isPhase1EndStep =
-    phase === 'phase1' && !isSuperAdmin && currentStep === 'best_thirds';
+  // Bottom-nav action layout for the Best 3rds step in Phase 1:
+  //   - Regular users: "Save Phase 1 Picks" only. Knockout steps are
+  //     read-only in phase 1, so a Continue button would dump them on
+  //     disabled screens.
+  //   - Super admin (god-mode + may also be participating): BOTH buttons.
+  //     "Save Phase 1 Picks" gives them the same end-of-phase-1 commit a
+  //     regular participant gets; "Continue to Round 32" keeps the wizard
+  //     flow into the knockout bracket (which they can edit thanks to
+  //     phase2Editable).
+  const isPhase1BestThirds =
+    phase === 'phase1' && currentStep === 'best_thirds';
+  const showSavePhase1 = isPhase1BestThirds;
+  const showReviewSubmit = isLastStep;
+  const showContinue =
+    !isLastStep && (!isPhase1BestThirds || isSuperAdmin);
 
   return (
     <PageLayout>
@@ -993,43 +1001,48 @@ export function PredictionsPageContent({
             <ArrowLeft className="mr-2 h-4 w-4" />
             {previousStepLabel ? `Back: ${previousStepLabel}` : 'Back'}
           </Button>
-          {isPhase1EndStep ? (
-            <Button
-              type="button"
-              onClick={handleSavePhase1}
-              disabled={
-                !currentStepComplete ||
-                isLocked ||
-                isSavingProgress ||
-                isSubmitting ||
-                !!nameError
-              }
-              className="sm:w-auto"
-            >
-              {isSavingProgress ? 'Saving…' : 'Save Phase 1 Picks'}
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Button>
-          ) : isLastStep ? (
-            <Button
-              type="button"
-              onClick={focusSubmit}
-              disabled={!currentStepComplete}
-              className="sm:w-auto"
-            >
-              Review & submit
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Button>
-          ) : (
-            <Button
-              type="button"
-              onClick={goToNextStep}
-              disabled={!currentStepComplete || (isLocked && !bypassLockNav)}
-              className="sm:w-auto"
-            >
-              {nextStepLabel ? `Continue to ${nextStepLabel}` : 'Continue'}
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Button>
-          )}
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            {showSavePhase1 && (
+              <Button
+                type="button"
+                onClick={handleSavePhase1}
+                disabled={
+                  !currentStepComplete ||
+                  isLocked ||
+                  isSavingProgress ||
+                  isSubmitting ||
+                  !!nameError
+                }
+                className="sm:w-auto"
+              >
+                {isSavingProgress ? 'Saving…' : 'Save Phase 1 Picks'}
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Button>
+            )}
+            {showReviewSubmit && (
+              <Button
+                type="button"
+                onClick={focusSubmit}
+                disabled={!currentStepComplete}
+                className="sm:w-auto"
+              >
+                Review & submit
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Button>
+            )}
+            {showContinue && (
+              <Button
+                type="button"
+                variant={showSavePhase1 ? 'outline' : 'default'}
+                onClick={goToNextStep}
+                disabled={!currentStepComplete || (isLocked && !bypassLockNav)}
+                className="sm:w-auto"
+              >
+                {nextStepLabel ? `Continue to ${nextStepLabel}` : 'Continue'}
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Button>
+            )}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -299,6 +299,26 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(screen.getByRole('tab', { name: /Tiebreaker/ })).toBeDisabled();
   });
 
+  it('shows BOTH Save Phase 1 Picks and Continue to Round 32 for super admin on Best 3rds in phase 1', async () => {
+    // Super admins may be playing the pool themselves, so they still need
+    // the Phase 1 commit action a regular user gets. They also retain the
+    // "Continue to Round 32" jump because their phase2 fields are editable
+    // (god-mode). Both buttons must coexist on this step.
+    mockAuthProfile = { isSuperAdmin: true };
+    configureQueries(); // phase 1 default
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="create" />);
+
+    await user.click(await screen.findByTestId('fill-all-groups'));
+    await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
+    await user.click(screen.getByTestId('fill-all-bundles'));
+
+    expect(screen.getByRole('button', { name: /Save Phase 1 Picks/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Continue to Round of 32/ })
+    ).toBeInTheDocument();
+  });
+
   it('walks through every step with Continue and reaches the tiebreaker (phase 2 open)', async () => {
     configureQueries({ phase: 'phase2_open' });
     const user = userEvent.setup();

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -319,6 +319,24 @@ describe('PredictionsPageContent — stepper navigation', () => {
     ).toBeInTheDocument();
   });
 
+  it('surfaces why Save Phase 1 Picks is disabled when the prediction name is empty', async () => {
+    // 8/8 advancers ranked but the prediction-name field is still blank.
+    // The Save button must stay disabled AND explain why, since name
+    // validation is otherwise silent until the input is blurred.
+    configureQueries(); // phase 1
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="create" />);
+
+    await user.click(await screen.findByTestId('fill-all-groups'));
+    await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
+    await user.click(screen.getByTestId('fill-all-bundles'));
+
+    const saveBtn = screen.getByRole('button', { name: /Save Phase 1 Picks/ });
+    expect(saveBtn).toBeDisabled();
+    expect(saveBtn).toHaveAttribute('title', 'Enter a prediction name above first.');
+    expect(screen.getByText('Enter a prediction name above first.')).toBeInTheDocument();
+  });
+
   it('walks through every step with Continue and reaches the tiebreaker (phase 2 open)', async () => {
     configureQueries({ phase: 'phase2_open' });
     const user = userEvent.setup();


### PR DESCRIPTION
## Bug

When a **super admin** navigates to the regular user prediction route (`/predictions/new` or `/predictions/[id]`) during phase 1 and reaches the **Best 3rds** step, the bottom-nav shows **only** "Continue to Round 32" — there is no "Save Phase 1 Picks" button. A super admin who is also playing the pool therefore can't commit their phase-1 picks the way every other user can.

## Root cause

`frontend/src/app/predictions/PredictionsPageContent.tsx:847-848` gated the terminal phase-1 button on `!isSuperAdmin`:

```ts
const isPhase1EndStep =
  phase === 'phase1' && !isSuperAdmin && currentStep === 'best_thirds';
```

The accompanying comment justified it as "Super admin keeps Continue (god-mode editing)". That made sense when admins were imagined as editors only, but for an admin who is also a participant it strips the end-of-phase-1 commit action.

## Fix

Replace the single `isPhase1EndStep` flag with three independent flags and render the right-side action cluster as a flex row:

```ts
const isPhase1BestThirds = phase === 'phase1' && currentStep === 'best_thirds';
const showSavePhase1   = isPhase1BestThirds;
const showReviewSubmit = isLastStep;
const showContinue     = !isLastStep && (!isPhase1BestThirds || isSuperAdmin);
```

Resulting UX on **Best 3rds in phase 1**:

| Role           | Buttons shown                              |
|----------------|--------------------------------------------|
| Regular user   | "Save Phase 1 Picks"                       |
| Super admin    | "Save Phase 1 Picks" + "Continue to Round 32" |

"Continue" is rendered as an outline button when paired with Save so the phase-1 commit reads as the primary CTA. Super admin still has phase 2 fields editable (`phase2Editable=true` for them), so the Continue jump remains valid.

Everywhere else (other steps, phase 2 open, last step) is unchanged.

## Verification

- `npm test` → **300/300 pass** across 38 suites. New test: `shows BOTH Save Phase 1 Picks and Continue to Round 32 for super admin on Best 3rds in phase 1`.
- `npm run typecheck` → clean.
- Existing "regular user sees only Save Phase 1 Picks" test still passes — the regression boundary is locked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)