### PR TITLE
feat(referrals): referral program with free-pick credits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,9 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 - `predictions` — **many per `(user, tournament)`**, no quantity limit. Each has a unique `prediction_name` per user/tournament (case-insensitive), 1–60 chars matching `^[A-Za-z0-9 _\-.''‘’]+$`. Holds `total_goals` tiebreaker + submission timestamp.
 - `group_predictions` — normalized: 12 rows per prediction with `first_team_id`/`second_team_id`/`third_team_id`/`fourth_team_id`. CHECK enforces all four are distinct. PK is `(prediction_id, group_id)`.
 - `knockout_predictions` — one per `(prediction, match)` with predicted winner.
-- `tournament_payments` — one per `prediction_id` (UNIQUE). Payment is per-prediction, not per-user. Each paid prediction is its own ranked entry on the leaderboard.
+- `tournament_payments` — one per `prediction_id` (UNIQUE). Payment is per-prediction, not per-user. Each paid prediction is its own ranked entry on the leaderboard. Has an `is_free boolean` (default `false`) that flags rows created via the referral-redeem flow rather than admin-recorded cash.
+- `referral_codes` — one per `user_id`, holding a unique 8-char citext code drawn from a 31-symbol unambiguous alphabet (no `0/O/1/I/L`). Kept in its own table (rather than on `profiles`) so the `profiles_select_all` policy doesn't expose codes to enumeration. Auto-populated by the `handle_new_user` trigger; backfilled for older rows in migration `0035_referrals.sql`.
+- `referrals` — one row per referred user. PK is `referee_id` (so each user can be referred only once). Holds `referrer_id`, the `referrer_code_used` snapshot, `qualified_at` (set by trigger when the referee's first non-free payment lands), `reward_redeemed_at` + `reward_prediction_id` (set when the referrer cashes the credit). DB CHECK blocks self-referral; no client writes — all mutations go through SECURITY DEFINER triggers/RPCs.
 - `group_standings`, `knockout_results` — admin-submitted truth for scoring.
 
 ### Auth + RLS
@@ -69,6 +71,11 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 - **`get_leaderboard(p_tournament_id, p_page, p_page_size)`** — paginated, SECURITY DEFINER. Returns one row per **paid prediction** with columns `rank, prediction_id, prediction_name, username, points, group_points, knockout_points, total_goals, total_count`. A user with N paid predictions occupies N rows.
 - **`get_leaderboard_rank(p_tournament_id, p_user_id, p_page_size)`** — returns one row per paid prediction the user owns: `(prediction_id, prediction_name, rank, page, points)`. The frontend picks the best row for "find me".
 - **`admin_list_users(p_search, p_page, p_page_size)`** — returns `(id, username, is_admin, is_super_admin, prediction_count, paid_prediction_count, total_count)`.
+- **`redeem_referral_credit(p_prediction_id)`** — SECURITY DEFINER, caller-scoped. Locks one available `referrals` row (`FOR UPDATE SKIP LOCKED` blocks double-spend), inserts a `tournament_payments` row with `is_free = true`, marks the referral redeemed. Raises `'not your prediction'` (→ 403), `'predictions are locked'` (→ 403), `'prediction already paid'` (→ 409), `'no referral credits available'` (→ 409), `'prediction not found'` (→ 404).
+- **`get_referral_status()`** — caller-scoped aggregates only: `(referral_code, available_credits, qualified_total, redeemed_total)`. Never exposes the referee usernames; admins use `admin_list_user_referrals` for that.
+- **`resolve_referrer_username(p_code)`** — SECURITY DEFINER, granted to `anon` + `authenticated`. Powers the pre-signup `/api/referrals/validate` "Invited by @user" affordance; returns NULL for invalid codes (no timing distinction between bad-format and unknown). Rate-limit at WAF.
+- **`admin_list_user_referrals(p_user_id)`** — moderation view; returns inbound + outbound referrals for one user.
+- **`referrals_sync_qualification()`** — trigger on `tournament_payments` AFTER INSERT/UPDATE/DELETE. Sets `referrals.qualified_at` when the referee's first non-free payment lands; clears it on delete only if the referrer has not yet redeemed the credit (redeemed credits are sticky so the referrer's leaderboard entry stays stable).
 
 ### Scoring (v2, in `migrations/0006_scoring_v2.sql`)
 
@@ -109,6 +116,7 @@ Plus flat bonuses on top: champion (M32 winner) `+15`, third-place winner (M31) 
 - `/admin/users` — admin user list (per-user predictions count + paid count).
 - `/admin/users/[id]` — list of a user's predictions with per-prediction payment toggle and edit/delete.
 - `/admin/users/[id]/predictions/new` and `/admin/users/[id]/predictions/[predictionId]` — admin editor mounted on the same wizard component (`PredictionsPageContent` accepts `apiBasePath` + `redirectAfterCreate` props).
+- `/referrals` — protected hub showing the user's referral code + share URL and the (free picks available / friends paid / credits used) tally. `/register?ref=<code>` is the deep link target.
 - `/auth/callback` — Supabase auth code exchange
 
 ### API routes (`src/app/api/*`)
@@ -167,6 +175,7 @@ App-level rate limiting isn't implemented (Cloudflare Workers' multi-instance mo
 | `/login`, `/register` (POST) | 10 requests | 1 minute | Challenge |
 | `/api/admin/users/*/password-reset` | 10 requests | 5 minutes | Block |
 | `/api/admin/*` | 100 requests | 1 minute | Block |
+| `/api/referrals/validate` | 10 requests | 1 minute | Block |
 | Site-wide | 600 requests | 1 minute | Challenge |
 
 All by client IP. The first three protect against email enumeration / mailbox flooding; the admin rules cap blast radius if an admin account is compromised; the site-wide rule absorbs basic scraping.

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -15,6 +15,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // OpenNext Cloudflare build output (see `npm run preview` / `npm run deploy`);
+    // gitignored but eslint-config-next doesn't know about it.
+    ".open-next/**",
   ]),
 ]);
 

--- a/frontend/src/app/account/AccountForm.tsx
+++ b/frontend/src/app/account/AccountForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 
@@ -10,8 +11,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { FieldError } from '@/components/ui/field-error';
+import { ReferralActivityCard } from '@/components/referrals/ReferralActivityCard';
 import { useAuthContext } from '@/providers/AuthProvider';
-import { USERNAME_REGEX } from '@/lib/constants';
+import { ROUTES, USERNAME_REGEX } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
 interface AccountFormProps {
@@ -187,6 +189,20 @@ export function AccountForm({ email, initialUsername, initialDisplayName }: Acco
           </form>
         </CardContent>
       </Card>
+
+      {/* Read-only snapshot of the user's referral activity. The share
+          link + code copy controls live on the dedicated /referrals
+          page; the link below sends users there for those. */}
+      <div className="mt-6 max-w-xl space-y-2">
+        <ReferralActivityCard />
+        <p className="text-muted-foreground text-sm">
+          Want to invite a friend?{' '}
+          <Link href={ROUTES.referrals} className="text-primary hover:underline">
+            Get your referral link
+          </Link>
+          .
+        </p>
+      </div>
     </PageLayout>
   );
 }

--- a/frontend/src/app/api/admin/users/[id]/referrals/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/referrals/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * Admin moderation: list all referral rows where this user is either the
+ * referee (one row, "inbound") or the referrer ("outbound", any number).
+ * Useful for spotting self-referral patterns or farming attempts.
+ */
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+  const { id } = await context.params;
+
+  const { data, error } = await ctx.supabase.rpc('admin_list_user_referrals', {
+    p_user_id: id,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    referrals: (data ?? []).map(
+      (r: {
+        direction: 'inbound' | 'outbound';
+        referee_id: string;
+        referee_username: string;
+        referrer_id: string;
+        referrer_username: string;
+        referrer_code_used: string;
+        created_at: string;
+        qualified_at: string | null;
+        reward_redeemed_at: string | null;
+        reward_prediction_id: string | null;
+      }) => ({
+        direction: r.direction,
+        refereeId: r.referee_id,
+        refereeUsername: r.referee_username,
+        referrerId: r.referrer_id,
+        referrerUsername: r.referrer_username,
+        referrerCodeUsed: r.referrer_code_used,
+        createdAt: r.created_at,
+        qualifiedAt: r.qualified_at,
+        rewardRedeemedAt: r.reward_redeemed_at,
+        rewardPredictionId: r.reward_prediction_id,
+      })
+    ),
+  });
+}

--- a/frontend/src/app/api/predictions/[id]/redeem-credit/__tests__/route.test.ts
+++ b/frontend/src/app/api/predictions/[id]/redeem-credit/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function req() {
+  return new NextRequest('http://localhost/api/predictions/p1/redeem-credit', {
+    method: 'POST',
+  });
+}
+
+describe('POST /api/predictions/[id]/redeem-credit', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(req(), ctx('p1'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with paymentId on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({ data: 'pay-1', error: null });
+    const res = await POST(req(), ctx('p1'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ paymentId: 'pay-1' });
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('redeem_referral_credit', {
+      p_prediction_id: 'p1',
+    });
+  });
+
+  it('maps "not your prediction" → 403', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'not your prediction' },
+    });
+    const res = await POST(req(), ctx('p1'));
+    expect(res.status).toBe(403);
+  });
+
+  it('maps "predictions are locked" → 403', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'predictions are locked' },
+    });
+    const res = await POST(req(), ctx('p1'));
+    expect(res.status).toBe(403);
+  });
+
+  it('maps "prediction not found" → 404', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'prediction not found' },
+    });
+    const res = await POST(req(), ctx('p1'));
+    expect(res.status).toBe(404);
+  });
+
+  it('maps "no referral credits available" → 409', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'no referral credits available' },
+    });
+    const res = await POST(req(), ctx('p1'));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('no referral credits available');
+  });
+
+  it('maps "prediction already paid" → 409', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'prediction already paid' },
+    });
+    const res = await POST(req(), ctx('p1'));
+    expect(res.status).toBe(409);
+  });
+});

--- a/frontend/src/app/api/predictions/[id]/redeem-credit/route.ts
+++ b/frontend/src/app/api/predictions/[id]/redeem-credit/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+import { safeMessage } from '@/lib/api/errors';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * Atomically claim one of the caller's available referral credits and
+ * apply it to the given (owned, unpaid, pre-lock) prediction. The RPC
+ * itself does the auth + ownership + lock + double-spend checks; we
+ * only translate its raises into HTTP status codes.
+ */
+export async function POST(_request: NextRequest, context: RouteContext) {
+  const { id } = await context.params;
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data, error } = await supabase.rpc('redeem_referral_credit', {
+    p_prediction_id: id,
+  });
+
+  if (error) {
+    const msg = error.message ?? '';
+    let status = 400;
+    if (msg.includes('not authenticated')) status = 401;
+    else if (msg.includes('not your prediction')) status = 403;
+    else if (msg.includes('predictions are locked')) status = 403;
+    else if (msg.includes('prediction not found')) status = 404;
+    else if (msg.includes('no referral credits available')) status = 409;
+    else if (msg.includes('prediction already paid')) status = 409;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+
+  return NextResponse.json({ paymentId: data });
+}

--- a/frontend/src/app/api/predictions/[id]/route.ts
+++ b/frontend/src/app/api/predictions/[id]/route.ts
@@ -31,7 +31,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   const { data: prediction } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, tournament_id, total_goals, submitted_at, tournament_payments!prediction_id(paid_at)'
+      'id, prediction_name, tournament_id, total_goals, submitted_at, tournament_payments!prediction_id(paid_at, is_free)'
     )
     .eq('id', id)
     .maybeSingle();
@@ -55,7 +55,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
       .eq('prediction_id', id),
   ]);
 
-  type Payment = { paid_at: string | null };
+  type Payment = { paid_at: string | null; is_free: boolean | null };
   type Pred = typeof prediction & {
     tournament_payments: Payment | Payment[] | null;
   };
@@ -75,6 +75,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     submittedAt: p.submitted_at,
     isPaid: payment != null,
     paidAt: payment?.paid_at ?? null,
+    isFreePaid: payment?.is_free === true,
     groups: (groupsRes.data ?? []).map((g) => ({
       groupId: g.group_id,
       first: g.first_team_id,

--- a/frontend/src/app/api/predictions/route.ts
+++ b/frontend/src/app/api/predictions/route.ts
@@ -39,7 +39,7 @@ export async function GET() {
   const { data: predictions } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, total_goals, submitted_at, tournament_payments!prediction_id(paid_at)'
+      'id, prediction_name, total_goals, submitted_at, tournament_payments!prediction_id(paid_at, is_free)'
     )
     .eq('user_id', user.id)
     .eq('tournament_id', tournament.id)
@@ -109,7 +109,7 @@ export async function GET() {
     advancersByPrediction.set(a.prediction_id, list);
   }
 
-  type Payment = { paid_at: string | null };
+  type Payment = { paid_at: string | null; is_free: boolean | null };
   type PredictionRow = {
     id: string;
     prediction_name: string;
@@ -134,6 +134,7 @@ export async function GET() {
         submittedAt: p.submitted_at,
         isPaid: payment != null,
         paidAt: payment?.paid_at ?? null,
+        isFreePaid: payment?.is_free === true,
         groups: (groupsByPrediction.get(p.id) ?? []).map((g) => ({
           groupId: g.group_id,
           first: g.first_team_id,

--- a/frontend/src/app/api/referrals/status/__tests__/route.test.ts
+++ b/frontend/src/app/api/referrals/status/__tests__/route.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+export {}; // marks this file as a module so `supabaseMock` is local-scoped
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route');
+
+describe('GET /api/referrals/status', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns zeros when the RPC returns no row', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({ data: [], error: null });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      code: null,
+      availableCredits: 0,
+      qualifiedTotal: 0,
+      redeemedTotal: 0,
+    });
+  });
+
+  it('maps the RPC row into the camelCase response', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({
+      data: [
+        {
+          referral_code: 'ABCDEFGH',
+          available_credits: 2,
+          qualified_total: 5,
+          redeemed_total: 3,
+        },
+      ],
+      error: null,
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      code: 'ABCDEFGH',
+      availableCredits: 2,
+      qualifiedTotal: 5,
+      redeemedTotal: 3,
+    });
+  });
+
+  it('returns 400 with safeMessage on DB error', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'not authenticated' },
+    });
+    const res = await GET();
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('not authenticated');
+  });
+});

--- a/frontend/src/app/api/referrals/status/route.ts
+++ b/frontend/src/app/api/referrals/status/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+import { safeMessage } from '@/lib/api/errors';
+
+/**
+ * Authenticated read of the caller's own referral state. Returns the
+ * shareable code + aggregate counts. The referee list is deliberately
+ * not exposed (use the admin moderation RPC for that).
+ */
+export async function GET() {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data, error } = await supabase.rpc('get_referral_status');
+  if (error) {
+    return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
+  }
+
+  // The RPC returns a single-row TABLE; supabase-js gives us an array.
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) {
+    return NextResponse.json({
+      code: null,
+      availableCredits: 0,
+      qualifiedTotal: 0,
+      redeemedTotal: 0,
+    });
+  }
+
+  return NextResponse.json({
+    code: row.referral_code ?? null,
+    availableCredits: row.available_credits ?? 0,
+    qualifiedTotal: row.qualified_total ?? 0,
+    redeemedTotal: row.redeemed_total ?? 0,
+  });
+}

--- a/frontend/src/app/api/referrals/validate/__tests__/route.test.ts
+++ b/frontend/src/app/api/referrals/validate/__tests__/route.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route');
+
+function get(code?: string) {
+  const url = new URL('http://localhost/api/referrals/validate');
+  if (code !== undefined) url.searchParams.set('code', code);
+  return new NextRequest(url);
+}
+
+describe('GET /api/referrals/validate', () => {
+  beforeEach(() => {
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns { valid: false } and skips the DB when code is missing', async () => {
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ valid: false });
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed codes without calling the RPC', async () => {
+    const res = await GET(get('not-a-code'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ valid: false });
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('uppercases and trims valid codes before resolving', async () => {
+    supabaseMock.rpc.mockResolvedValue({ data: 'leedium', error: null });
+    // 'AbcdJkmn' — 8 chars, all in the unambiguous alphabet after upcasing
+    // (no 0/O/1/I/L). Mixed case + surrounding whitespace exercises both
+    // the trim() and the toUpperCase() in the route.
+    const res = await GET(get('  AbcdJkmn  '));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ valid: true, referrerUsername: 'leedium' });
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('resolve_referrer_username', {
+      p_code: 'ABCDJKMN',
+    });
+  });
+
+  it('returns invalid when the RPC resolves to null', async () => {
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: null });
+    const res = await GET(get('ABCDEFGH'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ valid: false });
+  });
+
+  it('returns invalid (never 500) when the DB errors — no info leak', async () => {
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'something internal' },
+    });
+    const res = await GET(get('ABCDEFGH'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ valid: false });
+  });
+});

--- a/frontend/src/app/api/referrals/validate/route.ts
+++ b/frontend/src/app/api/referrals/validate/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+import { REFERRAL_CODE_REGEX } from '@/lib/constants';
+
+/**
+ * Public endpoint used by the /register page to resolve a referral code to
+ * a username for the "Invited by @user" affordance. We do the strict
+ * format check before hitting the DB so the WAF rate limit catches more of
+ * the noise. Anything that doesn't resolve returns `{ valid: false }` (no
+ * 404), so timing attacks can't distinguish "bad format" from "unknown
+ * code". Authenticated callers don't get special treatment — this is the
+ * pre-signup affordance.
+ *
+ * Cloudflare WAF rule for production: 10 req/min/IP, Block.
+ */
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get('code')?.trim().toUpperCase();
+  if (!code || !REFERRAL_CODE_REGEX.test(code)) {
+    return NextResponse.json({ valid: false }, { status: 200 });
+  }
+
+  const supabase = await getServerSupabase();
+  const { data, error } = await supabase.rpc('resolve_referrer_username', {
+    p_code: code,
+  });
+
+  if (error) {
+    // Don't surface DB internals to anon callers.
+    return NextResponse.json({ valid: false }, { status: 200 });
+  }
+
+  const username = typeof data === 'string' && data.length > 0 ? data : null;
+  return NextResponse.json(
+    username
+      ? { valid: true, referrerUsername: username }
+      : { valid: false },
+    { status: 200 }
+  );
+}

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, Clock, Eye, FileEdit, Plus, Trash2 } from 'lucide-react';
+import { CheckCircle2, Clock, Eye, FileEdit, Gift, Plus, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -25,7 +25,12 @@ import {
   clearDraftForPrediction,
 } from '@/hooks/useDraftPersistence';
 import { useTournamentLock } from '@/hooks/useTournamentLock';
+import {
+  REFERRAL_STATUS_QUERY_KEY,
+  useReferralStatus,
+} from '@/hooks/useReferralStatus';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
+import { ReferralCreditBanner } from '@/components/predictions/ReferralCreditBanner';
 import { ROUTES } from '@/lib/constants';
 
 interface ApiPrediction {
@@ -35,6 +40,7 @@ interface ApiPrediction {
   submittedAt: string | null;
   isPaid: boolean;
   paidAt: string | null;
+  isFreePaid: boolean;
 }
 
 interface ApiResponse {
@@ -59,6 +65,8 @@ export function PredictionsListPage() {
   const [pendingDelete, setPendingDelete] = React.useState<ApiPrediction | null>(null);
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [previewId, setPreviewId] = React.useState<string | null>(null);
+  const [redeemingId, setRedeemingId] = React.useState<string | null>(null);
+  const { status: referralStatus } = useReferralStatus();
 
   const query = useQuery<ApiResponse>({
     queryKey: ['predictions'],
@@ -79,6 +87,30 @@ export function PredictionsListPage() {
   // Late-joiner block: new predictions can only be created during phase 1.
   // Super admins bypass.
   const canCreate = phase === 'phase1' || isSuperAdmin;
+
+  const handleRedeem = async (prediction: ApiPrediction) => {
+    if (redeemingId) return;
+    setRedeemingId(prediction.id);
+    try {
+      const res = await fetch(
+        `/api/predictions/${encodeURIComponent(prediction.id)}/redeem-credit`,
+        { method: 'POST' }
+      );
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(String(body.error ?? 'Failed to redeem credit'));
+      }
+      toast.success(`Free credit applied to "${prediction.name}"`);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['predictions'] }),
+        queryClient.invalidateQueries({ queryKey: REFERRAL_STATUS_QUERY_KEY }),
+      ]);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to redeem credit');
+    } finally {
+      setRedeemingId(null);
+    }
+  };
 
   const handleDelete = async () => {
     if (!pendingDelete) return;
@@ -128,6 +160,10 @@ export function PredictionsListPage() {
         </Button>
       </div>
 
+      <div className="mb-4">
+        <ReferralCreditBanner />
+      </div>
+
       {query.isLoading ? (
         <div className="space-y-3">
           {Array.from({ length: 3 }).map((_, i) => (
@@ -162,7 +198,11 @@ export function PredictionsListPage() {
                         <FileEdit className="h-3 w-3" /> Draft
                       </Badge>
                     )}
-                    {p.isPaid ? (
+                    {p.isFreePaid ? (
+                      <Badge variant="default" className="gap-1 bg-green-600 hover:bg-green-600/90">
+                        <Gift className="h-3 w-3" /> Free pick
+                      </Badge>
+                    ) : p.isPaid ? (
                       <Badge variant="default" className="gap-1">
                         <CheckCircle2 className="h-3 w-3" /> Paid
                       </Badge>
@@ -190,6 +230,25 @@ export function PredictionsListPage() {
                       </Link>
                     </Button>
                   )}
+                  {/* Redeem a referral credit on an unpaid, pre-lock,
+                      user-owned prediction. The server RPC is the source
+                      of truth — we just hide the button when none of the
+                      preconditions hold. */}
+                  {!p.isPaid &&
+                    referralStatus.availableCredits > 0 &&
+                    (!isLocked || isSuperAdmin) && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="gap-1 border-green-600/50 text-green-700 hover:text-green-800 dark:text-green-400"
+                        onClick={() => handleRedeem(p)}
+                        disabled={redeemingId === p.id}
+                        title="Apply a free pick credit"
+                      >
+                        <Gift className="h-4 w-4" />
+                        {redeemingId === p.id ? 'Applying…' : 'Use free credit'}
+                      </Button>
+                    )}
                   <Button
                     variant="outline"
                     size="sm"

--- a/frontend/src/app/referrals/ReferralsPageContent.tsx
+++ b/frontend/src/app/referrals/ReferralsPageContent.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { Copy, Gift, Share2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useReferralStatus } from '@/hooks/useReferralStatus';
+import { ROUTES } from '@/lib/constants';
+
+/**
+ * "Refer a friend" hub. Shows the user's shareable code + URL, three-stat
+ * summary (pending invitees / credits available / credits used), and a
+ * short explainer. The shareable URL is built at render time from
+ * window.location.origin so dev/preview/prod each emit the correct host.
+ */
+export function ReferralsPageContent() {
+  const { status, isLoading } = useReferralStatus();
+  const [origin, setOrigin] = React.useState('');
+
+  React.useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setOrigin(window.location.origin);
+    }
+  }, []);
+
+  const shareUrl = status.code && origin ? `${origin}${ROUTES.register}?ref=${status.code}` : '';
+
+  const copy = async (value: string, label: string) => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(`${label} copied to clipboard`);
+    } catch {
+      toast.error('Copy failed — long-press to select');
+    }
+  };
+
+  const share = async () => {
+    if (!shareUrl) return;
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      try {
+        await navigator.share({
+          title: 'Join my WC2026 pool',
+          text: 'Join my World Cup 2026 prediction pool — use my referral link:',
+          url: shareUrl,
+        });
+        return;
+      } catch {
+        // user cancelled or share unavailable — fall through to copy
+      }
+    }
+    copy(shareUrl, 'Share link');
+  };
+
+  // The qualified-but-not-yet-redeemed bucket (= availableCredits) is what
+  // matters most. "Pending invitees" — referees who signed up but haven't
+  // paid yet — is qualifiedTotal subtracted from referee count, but we
+  // don't expose referee count for privacy, so present it as the gap
+  // between qualified and total. We don't have a total here; fall back to
+  // qualifiedTotal as the headline "referrals who paid" stat.
+  return (
+    <PageLayout>
+      <div className="mx-auto max-w-2xl py-8">
+        <div className="mb-6">
+          <h1 className="mb-2 text-3xl font-bold">Refer a friend</h1>
+          <p className="text-muted-foreground">
+            Invite a friend with your referral link. When they pay for a prediction, you
+            earn a <strong>free pick</strong> credit — redeem it on any unpaid bracket
+            from the{' '}
+            <Link href={ROUTES.predictions} className="text-primary hover:underline">
+              predictions page
+            </Link>
+            .
+          </p>
+        </div>
+
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Share2 className="h-5 w-5" />
+              Your referral link
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {isLoading ? (
+              <Skeleton className="h-10 w-full" />
+            ) : status.code ? (
+              <>
+                <div>
+                  <label className="text-muted-foreground mb-1 block text-sm">
+                    Code
+                  </label>
+                  <div className="flex gap-2">
+                    <Input
+                      readOnly
+                      value={status.code}
+                      className="font-mono uppercase tracking-widest"
+                      onFocus={(e) => e.currentTarget.select()}
+                    />
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => copy(status.code ?? '', 'Code')}
+                      title="Copy code"
+                    >
+                      <Copy className="h-4 w-4" />
+                      <span className="sr-only">Copy code</span>
+                    </Button>
+                  </div>
+                </div>
+                <div>
+                  <label className="text-muted-foreground mb-1 block text-sm">
+                    Share link
+                  </label>
+                  <div className="flex gap-2">
+                    <Input
+                      readOnly
+                      value={shareUrl}
+                      onFocus={(e) => e.currentTarget.select()}
+                    />
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => copy(shareUrl, 'Share link')}
+                      title="Copy link"
+                    >
+                      <Copy className="h-4 w-4" />
+                      <span className="sr-only">Copy link</span>
+                    </Button>
+                    <Button onClick={share} className="gap-2">
+                      <Share2 className="h-4 w-4" /> Share
+                    </Button>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                Your referral code isn&apos;t available right now. Try refreshing.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Gift className="h-5 w-5" />
+              Your referral activity
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="grid grid-cols-3 gap-4">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-20 w-full" />
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-4 text-center">
+                <Stat
+                  label="Free picks available"
+                  value={status.availableCredits}
+                  emphasis={status.availableCredits > 0}
+                />
+                <Stat label="Friends paid" value={status.qualifiedTotal} />
+                <Stat label="Credits used" value={status.redeemedTotal} />
+              </div>
+            )}
+            <p className="text-muted-foreground mt-4 text-xs">
+              Credits unlock <em>only after</em> a referred friend&apos;s payment is
+              confirmed by an admin. We don&apos;t show who used your code — only the
+              counts.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </PageLayout>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string;
+  value: number;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="rounded-md border p-3">
+      <div
+        className={
+          emphasis
+            ? 'text-2xl font-bold text-green-600 dark:text-green-400'
+            : 'text-2xl font-bold'
+        }
+      >
+        {value}
+      </div>
+      <div className="text-muted-foreground text-xs">{label}</div>
+    </div>
+  );
+}

--- a/frontend/src/app/referrals/ReferralsPageContent.tsx
+++ b/frontend/src/app/referrals/ReferralsPageContent.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { Copy, Gift, Share2 } from 'lucide-react';
+import { Copy, Share2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ReferralActivityCard } from '@/components/referrals/ReferralActivityCard';
 import { useReferralStatus } from '@/hooks/useReferralStatus';
 import { ROUTES } from '@/lib/constants';
 
@@ -147,64 +148,8 @@ export function ReferralsPageContent() {
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Gift className="h-5 w-5" />
-              Your referral activity
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <div className="grid grid-cols-3 gap-4">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-20 w-full" />
-                ))}
-              </div>
-            ) : (
-              <div className="grid grid-cols-3 gap-4 text-center">
-                <Stat
-                  label="Free picks available"
-                  value={status.availableCredits}
-                  emphasis={status.availableCredits > 0}
-                />
-                <Stat label="Friends paid" value={status.qualifiedTotal} />
-                <Stat label="Credits used" value={status.redeemedTotal} />
-              </div>
-            )}
-            <p className="text-muted-foreground mt-4 text-xs">
-              Credits unlock <em>only after</em> a referred friend&apos;s payment is
-              confirmed by an admin. We don&apos;t show who used your code — only the
-              counts.
-            </p>
-          </CardContent>
-        </Card>
+        <ReferralActivityCard />
       </div>
     </PageLayout>
-  );
-}
-
-function Stat({
-  label,
-  value,
-  emphasis = false,
-}: {
-  label: string;
-  value: number;
-  emphasis?: boolean;
-}) {
-  return (
-    <div className="rounded-md border p-3">
-      <div
-        className={
-          emphasis
-            ? 'text-2xl font-bold text-green-600 dark:text-green-400'
-            : 'text-2xl font-bold'
-        }
-      >
-        {value}
-      </div>
-      <div className="text-muted-foreground text-xs">{label}</div>
-    </div>
   );
 }

--- a/frontend/src/app/referrals/page.tsx
+++ b/frontend/src/app/referrals/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+
+import { getServerSupabase } from '@/lib/supabase/server';
+import { ROUTES } from '@/lib/constants';
+import { ReferralsPageContent } from './ReferralsPageContent';
+
+export const metadata: Metadata = {
+  title: 'Refer a friend — WC2026',
+};
+
+export default async function ReferralsPage() {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`${ROUTES.login}?next=${encodeURIComponent(ROUTES.referrals)}`);
+  }
+  return <ReferralsPageContent />;
+}

--- a/frontend/src/app/register/RegisterForm.tsx
+++ b/frontend/src/app/register/RegisterForm.tsx
@@ -10,12 +10,28 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { FieldError } from '@/components/ui/field-error';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
-import { ROUTES, EMAIL_REGEX, PASSWORD_MIN_LENGTH } from '@/lib/constants';
+import {
+  ROUTES,
+  EMAIL_REGEX,
+  PASSWORD_MIN_LENGTH,
+  REFERRAL_CODE_REGEX,
+} from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
 type FieldName = 'email' | 'password' | 'confirmPassword';
 
-export function RegisterForm() {
+interface RegisterFormProps {
+  /** Pre-filled referral code from /register?ref=…, after server-side format check. */
+  initialReferralCode?: string;
+}
+
+interface ReferralLookup {
+  status: 'idle' | 'checking' | 'valid' | 'invalid';
+  /** Referrer's username, present when status === 'valid'. */
+  referrerUsername?: string;
+}
+
+export function RegisterForm({ initialReferralCode }: RegisterFormProps = {}) {
   const router = useRouter();
   const [email, setEmail] = React.useState('');
   const [password, setPassword] = React.useState('');
@@ -40,11 +56,69 @@ export function RegisterForm() {
   const [isResending, setIsResending] = React.useState(false);
   const [resendCooldown, setResendCooldown] = React.useState(0);
 
+  // Referral code state. `referralCode` is what the user typed (or what
+  // came in via ?ref=). We validate via /api/referrals/validate after a
+  // short debounce so the user sees "Invited by @user" or "Invalid invite
+  // code" inline. An invalid code never blocks signup — the server-side
+  // trigger silently ignores codes it can't resolve.
+  const [referralCode, setReferralCode] = React.useState(initialReferralCode ?? '');
+  const [referralExpanded, setReferralExpanded] = React.useState(
+    Boolean(initialReferralCode)
+  );
+  const [referralLookup, setReferralLookup] = React.useState<ReferralLookup>({
+    status: 'idle',
+  });
+
   React.useEffect(() => {
     if (resendCooldown <= 0) return;
     const id = window.setTimeout(() => setResendCooldown((s) => s - 1), 1000);
     return () => window.clearTimeout(id);
   }, [resendCooldown]);
+
+  // Debounced referral-code lookup. Aborts in-flight requests when the
+  // user keeps typing, and only runs for codes that match the strict
+  // format (saves the API hit on every keystroke).
+  React.useEffect(() => {
+    const trimmed = referralCode.trim().toUpperCase();
+    if (!trimmed) {
+      setReferralLookup({ status: 'idle' });
+      return;
+    }
+    if (!REFERRAL_CODE_REGEX.test(trimmed)) {
+      setReferralLookup({ status: 'invalid' });
+      return;
+    }
+    setReferralLookup({ status: 'checking' });
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/referrals/validate?code=${encodeURIComponent(trimmed)}`,
+          { signal: controller.signal, cache: 'no-store' }
+        );
+        if (!res.ok) {
+          setReferralLookup({ status: 'invalid' });
+          return;
+        }
+        const json = (await res.json()) as {
+          valid: boolean;
+          referrerUsername?: string;
+        };
+        setReferralLookup(
+          json.valid
+            ? { status: 'valid', referrerUsername: json.referrerUsername }
+            : { status: 'invalid' }
+        );
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
+        setReferralLookup({ status: 'invalid' });
+      }
+    }, 350);
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [referralCode]);
 
   const emailRef = React.useRef<HTMLInputElement>(null);
   const passwordRef = React.useRef<HTMLInputElement>(null);
@@ -107,9 +181,21 @@ export function RegisterForm() {
     setIsSubmitting(true);
 
     const supabase = createSupabaseBrowserClient();
+    // Only forward a referral code we've successfully resolved — that way
+    // typos / stale links never hit the DB trigger, and we don't leak
+    // invalid codes into auth metadata. Invalid codes still proceed with
+    // signup (the trigger would silently skip anyway).
+    const trimmedRef = referralCode.trim().toUpperCase();
+    const passthroughRef =
+      referralLookup.status === 'valid' && REFERRAL_CODE_REGEX.test(trimmedRef)
+        ? trimmedRef
+        : undefined;
     const { data, error: signUpError } = await supabase.auth.signUp({
       email: email.trim(),
       password,
+      options: passthroughRef
+        ? { data: { referral_code: passthroughRef } }
+        : undefined,
     });
 
     if (signUpError) {
@@ -286,6 +372,60 @@ export function RegisterForm() {
           id="confirmPassword-error"
           message={showError('confirmPassword') || undefined}
         />
+      </div>
+      <div className="space-y-2">
+        {referralExpanded ? (
+          <>
+            <Label htmlFor="referralCode">Referral code (optional)</Label>
+            <Input
+              id="referralCode"
+              type="text"
+              autoComplete="off"
+              inputMode="text"
+              maxLength={8}
+              value={referralCode}
+              onChange={(e) =>
+                setReferralCode(e.target.value.toUpperCase().replace(/\s+/g, ''))
+              }
+              disabled={isSubmitting}
+              placeholder="e.g. ABCD1234"
+              className="font-mono uppercase tracking-widest"
+              aria-describedby="referral-status"
+            />
+            <p
+              id="referral-status"
+              className={cn(
+                'text-sm',
+                referralLookup.status === 'valid' && 'text-green-600 dark:text-green-500',
+                referralLookup.status === 'invalid' && 'text-muted-foreground',
+                referralLookup.status === 'checking' && 'text-muted-foreground'
+              )}
+              role="status"
+              aria-live="polite"
+            >
+              {referralLookup.status === 'idle' &&
+                'Enter the 8-character code shared by a friend.'}
+              {referralLookup.status === 'checking' && 'Checking…'}
+              {referralLookup.status === 'valid' && (
+                <>
+                  Invited by{' '}
+                  <span className="font-semibold">@{referralLookup.referrerUsername}</span>
+                </>
+              )}
+              {referralLookup.status === 'invalid' &&
+                "We don't recognize that code — you can still sign up without it."}
+            </p>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setReferralExpanded(true)}
+            disabled={isSubmitting}
+            className="text-primary text-sm hover:underline disabled:opacity-50"
+          >
+            Have a referral code?
+          </button>
+        )}
       </div>
       {serverError && (
         <p role="alert" className="text-destructive text-sm">

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getServerSupabase } from '@/lib/supabase/server';
 import { RegisterForm } from './RegisterForm';
-import { ROUTES } from '@/lib/constants';
+import { REFERRAL_CODE_REGEX, ROUTES } from '@/lib/constants';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -9,12 +9,25 @@ export const metadata = {
   title: 'Sign up — WC2026',
 };
 
-export default async function RegisterPage() {
+// Next.js 16 — searchParams is a Promise.
+export default async function RegisterPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string | string[] }>;
+}) {
   const supabase = await getServerSupabase();
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (user) redirect(ROUTES.predictions);
+
+  const params = await searchParams;
+  const rawRef = Array.isArray(params.ref) ? params.ref[0] : params.ref;
+  // Normalize and apply a light client-side format check so we don't echo
+  // arbitrary query strings into the form. The server RPC is the real check.
+  const normalized = rawRef?.trim().toUpperCase();
+  const initialReferralCode =
+    normalized && REFERRAL_CODE_REGEX.test(normalized) ? normalized : undefined;
 
   return (
     <PageLayout>
@@ -25,7 +38,7 @@ export default async function RegisterPage() {
             <CardDescription>Pick a username, enter your email and a password.</CardDescription>
           </CardHeader>
           <CardContent>
-            <RegisterForm />
+            <RegisterForm initialReferralCode={initialReferralCode} />
           </CardContent>
         </Card>
       </div>

--- a/frontend/src/components/layout/AuthMenu.tsx
+++ b/frontend/src/components/layout/AuthMenu.tsx
@@ -3,20 +3,24 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { LogOut, Settings, User as UserIcon } from 'lucide-react';
+import { Gift, LogOut, Settings, User as UserIcon } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useAuth } from '@/hooks/useAuth';
 import { useMounted } from '@/hooks/useMounted';
+import { useReferralStatus } from '@/hooks/useReferralStatus';
 import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils';
 
 export function AuthMenu() {
   const { user, profile, signOut } = useAuth();
   const router = useRouter();
   const mounted = useMounted();
   const [isSigningOut, setIsSigningOut] = React.useState(false);
+  const { status: referralStatus } = useReferralStatus();
+  const credits = referralStatus.availableCredits;
 
   const handleSignOut = async () => {
     setIsSigningOut(true);
@@ -73,17 +77,51 @@ export function AuthMenu() {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-2">
+        <Button variant="outline" size="sm" className="relative gap-2">
           <UserIcon className="h-4 w-4" />
           <span className="max-w-[120px] truncate">{displayName}</span>
+          {/* Unread-style indicator for available referral credits.
+              aria-hidden because the popover content surfaces the count
+              for screen readers — this dot is purely a visual hint. */}
+          {credits > 0 && (
+            <span
+              aria-hidden
+              className={cn(
+                'absolute -top-1 -right-1 inline-flex h-2.5 w-2.5 rounded-full',
+                'bg-green-500 ring-2 ring-background'
+              )}
+            />
+          )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-56">
+      <PopoverContent align="end" className="w-60">
         <div className="space-y-3">
           <div>
             <p className="text-sm font-medium">{profile?.username ?? 'Account'}</p>
             <p className="text-muted-foreground truncate text-xs">{user.email}</p>
           </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full justify-start gap-2"
+            asChild
+          >
+            <Link href={ROUTES.referrals}>
+              <Gift className="h-4 w-4" />
+              <span className="flex-1 text-left">Refer a friend</span>
+              {credits > 0 && (
+                <span
+                  className={cn(
+                    'inline-flex min-w-[1.25rem] items-center justify-center rounded-full',
+                    'bg-green-600 px-1.5 py-0.5 text-xs font-semibold text-white'
+                  )}
+                  aria-label={`${credits} free pick credits available`}
+                >
+                  {credits}
+                </span>
+              )}
+            </Link>
+          </Button>
           <Button
             variant="outline"
             size="sm"

--- a/frontend/src/components/layout/__tests__/PageLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/PageLayout.test.tsx
@@ -6,6 +6,17 @@ jest.mock('../LockStatusBanner', () => ({
   LockStatusBanner: () => null,
 }));
 
+// AuthMenu pulls in useReferralStatus (TanStack Query). Stub it so this layout
+// test doesn't need a QueryClientProvider just to render the header.
+jest.mock('@/hooks/useReferralStatus', () => ({
+  useReferralStatus: () => ({
+    status: { code: null, availableCredits: 0, qualifiedTotal: 0, redeemedTotal: 0 },
+    isLoading: false,
+    refetch: async () => ({ data: null }),
+  }),
+  REFERRAL_STATUS_QUERY_KEY: ['referralStatus'],
+}));
+
 import { PageLayout } from '../PageLayout';
 
 describe('PageLayout', () => {

--- a/frontend/src/components/predictions/ReferralCreditBanner.tsx
+++ b/frontend/src/components/predictions/ReferralCreditBanner.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { Gift, X } from 'lucide-react';
+
+import { useAuthContext } from '@/providers/AuthProvider';
+import { useReferralStatus } from '@/hooks/useReferralStatus';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils';
+
+/**
+ * Dismissible banner shown on /predictions when the signed-in user has
+ * unredeemed referral credits. Mirrors the LockStatusBanner pattern:
+ * sessionStorage-based dismissal keyed on (userId, creditCount) so a
+ * new credit arriving re-shows the banner even after the user dismissed
+ * the previous one.
+ */
+function dismissKey(userId: string, count: number): string {
+  return `wc2026:referral-banner:${userId}:${count}`;
+}
+
+export function ReferralCreditBanner() {
+  const { user } = useAuthContext();
+  const { status } = useReferralStatus();
+  const [dismissed, setDismissed] = React.useState(false);
+
+  const credits = status.availableCredits;
+  const userId = user?.id ?? null;
+
+  React.useEffect(() => {
+    if (!userId || credits <= 0 || typeof window === 'undefined') {
+      setDismissed(false);
+      return;
+    }
+    try {
+      setDismissed(
+        window.sessionStorage.getItem(dismissKey(userId, credits)) === '1'
+      );
+    } catch {
+      setDismissed(false);
+    }
+  }, [userId, credits]);
+
+  const handleDismiss = React.useCallback(() => {
+    if (!userId || typeof window === 'undefined') return;
+    try {
+      window.sessionStorage.setItem(dismissKey(userId, credits), '1');
+    } catch {
+      // best-effort
+    }
+    setDismissed(true);
+  }, [userId, credits]);
+
+  if (!userId || credits <= 0 || dismissed) return null;
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        'rounded-md border border-green-600/30 bg-green-600/10 px-4 py-3 text-sm',
+        'flex items-start gap-3 dark:border-green-500/30 dark:bg-green-500/10'
+      )}
+    >
+      <Gift className="mt-0.5 h-5 w-5 shrink-0 text-green-700 dark:text-green-400" aria-hidden />
+      <div className="flex-1">
+        <p className="font-medium text-green-900 dark:text-green-100">
+          {credits === 1
+            ? 'You earned a free pick from a referral!'
+            : `You earned ${credits} free picks from referrals!`}
+        </p>
+        <p className="text-muted-foreground mt-1">
+          Pick an unpaid bracket below and click <strong>Use free credit</strong>{' '}
+          to apply it. See your{' '}
+          <Link href={ROUTES.referrals} className="text-primary hover:underline">
+            referral status
+          </Link>{' '}
+          for details.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Dismiss notification"
+        className="text-muted-foreground -mr-1 inline-flex h-6 w-6 items-center justify-center rounded transition hover:bg-black/5 dark:hover:bg-white/10"
+      >
+        <X className="h-4 w-4" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/referrals/ReferralActivityCard.tsx
+++ b/frontend/src/components/referrals/ReferralActivityCard.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Gift } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useReferralStatus } from '@/hooks/useReferralStatus';
+
+/**
+ * Three-stat summary of the caller's referral activity. Used on both
+ * `/referrals` (alongside the share-link card) and `/account` (as a
+ * read-only snapshot). The hook is shared, so the underlying React
+ * Query cache is hit at most once per stale window across both mounts.
+ */
+export function ReferralActivityCard() {
+  const { status, isLoading } = useReferralStatus();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Gift className="h-5 w-5" />
+          Your referral activity
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="grid grid-cols-3 gap-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-20 w-full" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-3 gap-4 text-center">
+            <Stat
+              label="Free picks available"
+              value={status.availableCredits}
+              emphasis={status.availableCredits > 0}
+            />
+            <Stat label="Friends paid" value={status.qualifiedTotal} />
+            <Stat label="Credits used" value={status.redeemedTotal} />
+          </div>
+        )}
+        <p className="text-muted-foreground mt-4 text-xs">
+          Credits unlock <em>only after</em> a referred friend&apos;s payment is
+          confirmed by an admin. We don&apos;t show who used your code — only the
+          counts.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string;
+  value: number;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="rounded-md border p-3">
+      <div
+        className={
+          emphasis
+            ? 'text-2xl font-bold text-green-600 dark:text-green-400'
+            : 'text-2xl font-bold'
+        }
+      >
+        {value}
+      </div>
+      <div className="text-muted-foreground text-xs">{label}</div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useReferralStatus.ts
+++ b/frontend/src/hooks/useReferralStatus.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useAuthContext } from '@/providers/AuthProvider';
+
+export interface ReferralStatus {
+  /** Caller's own shareable code. Null for unauthenticated callers. */
+  code: string | null;
+  /** Qualified referrals not yet redeemed — drives banner + menu dot. */
+  availableCredits: number;
+  /** Lifetime count of referrals whose referee paid at least once. */
+  qualifiedTotal: number;
+  /** Lifetime count of credits the user has cashed in. */
+  redeemedTotal: number;
+}
+
+const ZERO: ReferralStatus = {
+  code: null,
+  availableCredits: 0,
+  qualifiedTotal: 0,
+  redeemedTotal: 0,
+};
+
+/**
+ * Shared client-side read of the caller's referral state. Auto-skips
+ * the fetch for signed-out users (returns zeros). Cached for 60s so
+ * the menu dot and the predictions banner don't double-fetch on every
+ * navigation. Mutations (redeem) should invalidate the
+ * ['referralStatus'] key.
+ */
+export function useReferralStatus() {
+  const { user, loading } = useAuthContext();
+  const query = useQuery<ReferralStatus>({
+    queryKey: ['referralStatus'],
+    enabled: !loading && !!user,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const res = await fetch('/api/referrals/status', { cache: 'no-store' });
+      if (!res.ok) throw new Error('Failed to load referral status');
+      return res.json();
+    },
+  });
+
+  return {
+    status: query.data ?? ZERO,
+    isLoading: query.isLoading,
+    refetch: query.refetch,
+  };
+}
+
+export const REFERRAL_STATUS_QUERY_KEY = ['referralStatus'] as const;

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -46,6 +46,11 @@ const KNOWN_ERROR_FRAGMENTS = [
   'is not a 3rd-place slot',
   'unknown r32 match',
   'all r32 3rd-place bracket slots',
+  // Referrals (migration 0035)
+  'no referral credits available',
+  'not your prediction',
+  'prediction already paid',
+  'prediction_id is required',
 ] as const;
 
 export function safeMessage(

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -66,7 +66,11 @@ export const ROUTES = {
   rules: '/rules',
   terms: '/terms',
   privacy: '/privacy',
+  referrals: '/referrals',
 } as const;
+
+/** 8 uppercase chars from a 31-symbol alphabet (no 0/O/1/I/L). */
+export const REFERRAL_CODE_REGEX = /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{8}$/;
 
 export const API_ENDPOINTS = {
   tournament: '/api/tournament',

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { env } from '@/config/env';
 
-const PROTECTED_PREFIXES = ['/predictions', '/admin', '/account'];
+const PROTECTED_PREFIXES = ['/predictions', '/admin', '/account', '/referrals'];
 
 // Using the deprecated middleware.ts name (not Next 16's proxy.ts) because
 // @opennextjs/cloudflare doesn't yet support proxy. Track:

--- a/supabase/migrations/0035_referrals.sql
+++ b/supabase/migrations/0035_referrals.sql
@@ -1,0 +1,485 @@
+-- WC2026 — Referral program
+--
+-- Every user gets an auto-generated 8-character referral code at signup
+-- (kept in a separate `referral_codes` table so codes aren't enumerable
+-- via the public `profiles_select_all` policy). Codes can be entered via
+-- /register?ref=... or a manual input. When a referred user's FIRST
+-- non-free payment lands (admin marks paid), the referrer earns one
+-- free-pick credit. The referrer redeems the credit on a chosen unpaid
+-- prediction via the `redeem_referral_credit` RPC, which inserts a
+-- `tournament_payments` row with `is_free = true`. The existing
+-- leaderboard filter (`paid_at <= lock_time`) catches it unchanged.
+--
+-- Security properties:
+--   * `referee_id` is the PK on `referrals`, so a user can only be
+--     referred once (second insert fails). DB CHECK and the trigger
+--     also block self-referral.
+--   * `qualified_at` is set only by the trigger on tournament_payments;
+--     RLS denies direct writes to `referrals` from clients. Only
+--     non-free payments (is_free = false) count toward qualification.
+--   * `redeem_referral_credit` runs the available-credit query with
+--     `FOR UPDATE SKIP LOCKED` so two concurrent redeems can never
+--     claim the same row.
+--   * Clients cannot set `is_free = true` on tournament_payments — RLS
+--     restricts writes to admins, and the redeem RPC is the only
+--     SECURITY DEFINER path that flips the flag.
+--   * `resolve_referrer_username` is SECURITY DEFINER and returns only
+--     the matching username (or NULL). It's the only way for an
+--     unauthenticated visitor to look up a code; rate-limit at the WAF.
+
+
+-- ========== referral_codes table ==========
+
+create table public.referral_codes (
+    user_id    uuid primary key references public.profiles(id) on delete cascade,
+    code       citext not null unique,
+    created_at timestamptz not null default now()
+);
+
+alter table public.referral_codes enable row level security;
+
+-- Users can read their own code; admins can read all. No client writes —
+-- the only insert path is the handle_new_user trigger (SECURITY DEFINER).
+create policy "referral_codes_select_own_or_admin"
+    on public.referral_codes for select
+    using (auth.uid() = user_id or public.is_admin());
+
+-- Grant base SELECT so PostgREST consults RLS rather than returning 401.
+grant select on public.referral_codes to authenticated;
+
+
+-- ========== referrals table ==========
+
+create table public.referrals (
+    referee_id           uuid primary key references public.profiles(id) on delete cascade,
+    referrer_id          uuid not null references public.profiles(id) on delete cascade,
+    referrer_code_used   text not null,
+    created_at           timestamptz not null default now(),
+    qualified_at         timestamptz,
+    reward_redeemed_at   timestamptz,
+    reward_prediction_id uuid references public.predictions(id) on delete set null,
+    constraint referrals_no_self_referral check (referee_id <> referrer_id),
+    constraint referrals_reward_pair check (
+        (reward_redeemed_at is null) = (reward_prediction_id is null)
+    ),
+    constraint referrals_reward_requires_qualified check (
+        reward_redeemed_at is null or qualified_at is not null
+    )
+);
+
+-- Powers credit-count lookups in get_referral_status.
+create index referrals_referrer_credits_idx
+    on public.referrals (referrer_id, qualified_at, reward_redeemed_at);
+
+alter table public.referrals enable row level security;
+
+-- Admin-only direct reads. End-users get their data via
+-- get_referral_status (aggregates) so the friend list isn't exposed.
+create policy "referrals_admin_select"
+    on public.referrals for select
+    using (public.is_admin());
+
+-- No client writes — all mutations go through SECURITY DEFINER paths.
+
+
+-- ========== tournament_payments.is_free ==========
+
+alter table public.tournament_payments
+    add column if not exists is_free boolean not null default false;
+
+-- Helpful for "list all free redemptions" admin queries.
+create index tournament_payments_is_free_idx
+    on public.tournament_payments (is_free) where is_free;
+
+
+-- ========== Code generation helper ==========
+-- 8 chars from a 31-char alphabet (no 0/O/1/I/L) → ~31^8 ≈ 8.5×10^11 codes.
+-- Function is IMMUTABLE-ish in spirit but uses random(), so VOLATILE.
+create or replace function public.generate_referral_code()
+returns text
+language plpgsql
+volatile
+set search_path = public
+as $$
+declare
+    alphabet constant text := 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+    out text := '';
+    i int;
+begin
+    for i in 1..8 loop
+        out := out || substr(alphabet, 1 + floor(random() * length(alphabet))::int, 1);
+    end loop;
+    return out;
+end;
+$$;
+
+
+-- ========== Backfill referral_codes for existing profiles ==========
+do $$
+declare
+    target uuid;
+    candidate text;
+    attempts int;
+begin
+    for target in
+        select p.id
+        from public.profiles p
+        left join public.referral_codes rc on rc.user_id = p.id
+        where rc.user_id is null
+    loop
+        attempts := 0;
+        loop
+            candidate := public.generate_referral_code();
+            begin
+                insert into public.referral_codes (user_id, code)
+                values (target, candidate);
+                exit;
+            exception when unique_violation then
+                attempts := attempts + 1;
+                if attempts >= 20 then
+                    raise exception 'could not backfill referral_code for %', target;
+                end if;
+            end;
+        end loop;
+    end loop;
+end $$;
+
+
+-- ========== handle_new_user — generate code + capture referrer ==========
+-- Replaces the version in 0015_multi_prediction_rpcs.sql. Additions:
+--   * After profile insert, generate + insert a referral_code (10-attempt
+--     collision retry, mirroring the username pattern).
+--   * If `raw_user_meta_data.referral_code` is present, resolve it to a
+--     referrer and insert a referrals row. Invalid or self-referral codes
+--     are silently ignored — we never fail signup over a bad invite link.
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    meta_username text;
+    meta_referral text;
+    candidate     text;
+    attempts      int := 0;
+    referrer_uuid uuid;
+begin
+    meta_username := nullif(trim(new.raw_user_meta_data->>'username'), '');
+    meta_referral := nullif(trim(new.raw_user_meta_data->>'referral_code'), '');
+
+    if meta_username is not null then
+        begin
+            insert into public.profiles (id, username) values (new.id, meta_username);
+        exception
+            when unique_violation then
+                raise exception 'username taken' using errcode = 'P0001';
+            when check_violation then
+                raise exception 'username invalid format' using errcode = 'P0001';
+        end;
+    else
+        loop
+            candidate := 'user_' || encode(extensions.gen_random_bytes(4), 'hex');
+            begin
+                insert into public.profiles (id, username) values (new.id, candidate);
+                exit;
+            exception when unique_violation then
+                attempts := attempts + 1;
+                if attempts >= 10 then
+                    raise exception 'could not generate unique username' using errcode = 'P0001';
+                end if;
+            end;
+        end loop;
+    end if;
+
+    -- Generate this user's own referral code (separate retry counter).
+    attempts := 0;
+    loop
+        candidate := public.generate_referral_code();
+        begin
+            insert into public.referral_codes (user_id, code) values (new.id, candidate);
+            exit;
+        exception when unique_violation then
+            attempts := attempts + 1;
+            if attempts >= 10 then
+                raise exception 'could not generate unique referral_code' using errcode = 'P0001';
+            end if;
+        end;
+    end loop;
+
+    -- Capture inbound referral if a valid, non-self code was provided.
+    if meta_referral is not null then
+        select user_id into referrer_uuid
+        from public.referral_codes
+        where code = meta_referral;
+
+        if referrer_uuid is not null and referrer_uuid <> new.id then
+            insert into public.referrals (referee_id, referrer_id, referrer_code_used)
+            values (new.id, referrer_uuid, meta_referral);
+            -- No exception handler needed: referee_id PK + check constraint
+            -- guarantee a clean insert; concurrency is single-row per new.id.
+        end if;
+    end if;
+
+    return new;
+end;
+$$;
+
+
+-- ========== Qualification trigger on tournament_payments ==========
+-- INSERT/UPDATE: if the underlying prediction belongs to a referee whose
+-- referral row is not yet qualified, set qualified_at to the payment's
+-- paid_at. Free-credit payments (is_free = true) do NOT count — only
+-- real money qualifies the referrer.
+-- DELETE: if the referee has no remaining non-free payments AND the
+-- referrer has not yet redeemed the credit, revert qualified_at to NULL
+-- so the menu/banner disappear.
+
+create or replace function public.referrals_sync_qualification()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_referee_id uuid;
+    v_remaining  int;
+begin
+    if tg_op in ('INSERT', 'UPDATE') then
+        if new.is_free then
+            return new;
+        end if;
+        select user_id into v_referee_id
+        from public.predictions where id = new.prediction_id;
+        if v_referee_id is null then
+            return new;
+        end if;
+        update public.referrals
+            set qualified_at = new.paid_at
+            where referee_id = v_referee_id
+              and qualified_at is null;
+        return new;
+    elsif tg_op = 'DELETE' then
+        if old.is_free then
+            return old;
+        end if;
+        select user_id into v_referee_id
+        from public.predictions where id = old.prediction_id;
+        if v_referee_id is null then
+            return old;
+        end if;
+        select count(*) into v_remaining
+        from public.tournament_payments tp
+        join public.predictions p on p.id = tp.prediction_id
+        where p.user_id = v_referee_id and tp.is_free = false;
+        if v_remaining = 0 then
+            update public.referrals
+                set qualified_at = null
+                where referee_id = v_referee_id
+                  and reward_redeemed_at is null;
+        end if;
+        return old;
+    end if;
+    return null;
+end;
+$$;
+
+drop trigger if exists tournament_payments_sync_referrals on public.tournament_payments;
+create trigger tournament_payments_sync_referrals
+    after insert or update or delete on public.tournament_payments
+    for each row execute function public.referrals_sync_qualification();
+
+
+-- ========== RPC: get_referral_status ==========
+-- Caller-scoped. Returns code + aggregate counts; never leaks the
+-- referee usernames (use admin_list_user_referrals for moderation).
+create or replace function public.get_referral_status()
+returns table (
+    referral_code      text,
+    available_credits  int,
+    qualified_total    int,
+    redeemed_total     int
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+begin
+    if auth.uid() is null then
+        raise exception 'not authenticated' using errcode = 'P0001';
+    end if;
+    return query
+    select
+        (select rc.code::text from public.referral_codes rc where rc.user_id = auth.uid()),
+        coalesce(sum(case when r.qualified_at is not null and r.reward_redeemed_at is null then 1 else 0 end), 0)::int,
+        coalesce(sum(case when r.qualified_at is not null then 1 else 0 end), 0)::int,
+        coalesce(sum(case when r.reward_redeemed_at is not null then 1 else 0 end), 0)::int
+    from public.referrals r
+    where r.referrer_id = auth.uid();
+end;
+$$;
+
+grant execute on function public.get_referral_status() to authenticated;
+
+
+-- ========== RPC: resolve_referrer_username ==========
+-- Powers /api/referrals/validate. Returns NULL for invalid codes.
+-- SECURITY DEFINER so anon callers (pre-signup) bypass RLS on
+-- referral_codes. Rate-limit at the Cloudflare WAF layer.
+create or replace function public.resolve_referrer_username(p_code text)
+returns text
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    select p.username::text
+    from public.referral_codes rc
+    join public.profiles p on p.id = rc.user_id
+    where rc.code = nullif(trim(p_code), '');
+$$;
+
+grant execute on function public.resolve_referrer_username(text) to anon, authenticated;
+
+
+-- ========== RPC: redeem_referral_credit ==========
+-- Atomically: lock one available referral, insert a free
+-- tournament_payments row, mark the referral redeemed.
+-- Returns the new payment's id.
+create or replace function public.redeem_referral_credit(p_prediction_id uuid)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_user           uuid := auth.uid();
+    v_prediction     public.predictions%rowtype;
+    v_existing_paid  boolean;
+    v_referral_id    uuid;
+    v_payment_id     uuid;
+    v_super_admin    boolean;
+begin
+    if v_user is null then
+        raise exception 'not authenticated' using errcode = 'P0001';
+    end if;
+    if p_prediction_id is null then
+        raise exception 'prediction_id is required' using errcode = 'P0001';
+    end if;
+
+    -- Lock the prediction row so a concurrent payment insert can't sneak
+    -- in between our existence check and the insert.
+    select * into v_prediction
+    from public.predictions
+    where id = p_prediction_id
+    for update;
+
+    if not found then
+        raise exception 'prediction not found' using errcode = 'P0001';
+    end if;
+
+    if v_prediction.user_id <> v_user then
+        raise exception 'not your prediction' using errcode = 'P0001';
+    end if;
+
+    -- Super admins can bypass lock (matches submit_predictions semantics).
+    select coalesce(is_super_admin, false) into v_super_admin
+    from public.profiles where id = v_user;
+
+    if not v_super_admin and not public.is_before_lock(v_prediction.tournament_id) then
+        raise exception 'predictions are locked' using errcode = 'P0001';
+    end if;
+
+    select exists(
+        select 1 from public.tournament_payments
+        where prediction_id = p_prediction_id
+    ) into v_existing_paid;
+
+    if v_existing_paid then
+        raise exception 'prediction already paid' using errcode = 'P0001';
+    end if;
+
+    -- Claim one available credit. FOR UPDATE SKIP LOCKED is what makes
+    -- concurrent redeems safe — each transaction picks a different row.
+    select referee_id into v_referral_id
+    from public.referrals
+    where referrer_id = v_user
+      and qualified_at is not null
+      and reward_redeemed_at is null
+    order by qualified_at
+    limit 1
+    for update skip locked;
+
+    if v_referral_id is null then
+        raise exception 'no referral credits available' using errcode = 'P0001';
+    end if;
+
+    -- Issue the free payment. marked_by = the redeemer themselves; admin
+    -- listings can distinguish via is_free.
+    insert into public.tournament_payments
+        (user_id, tournament_id, prediction_id, paid_at, marked_by, is_free)
+    values
+        (v_user, v_prediction.tournament_id, p_prediction_id, now(), v_user, true)
+    returning id into v_payment_id;
+
+    update public.referrals
+        set reward_redeemed_at = now(),
+            reward_prediction_id = p_prediction_id
+        where referee_id = v_referral_id;
+
+    return v_payment_id;
+end;
+$$;
+
+grant execute on function public.redeem_referral_credit(uuid) to authenticated;
+
+
+-- ========== RPC: admin_list_user_referrals ==========
+-- Moderation view: who did this user refer, and where are they in the
+-- qualification → redemption lifecycle? Also returns the inbound row
+-- (who referred *them*) for context.
+create or replace function public.admin_list_user_referrals(p_user_id uuid)
+returns table (
+    direction              text,
+    referee_id             uuid,
+    referee_username       text,
+    referrer_id            uuid,
+    referrer_username      text,
+    referrer_code_used     text,
+    created_at             timestamptz,
+    qualified_at           timestamptz,
+    reward_redeemed_at     timestamptz,
+    reward_prediction_id   uuid
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    return query
+    select
+        case when r.referrer_id = p_user_id then 'outbound' else 'inbound' end::text,
+        r.referee_id,
+        ree.username::text,
+        r.referrer_id,
+        rer.username::text,
+        r.referrer_code_used,
+        r.created_at,
+        r.qualified_at,
+        r.reward_redeemed_at,
+        r.reward_prediction_id
+    from public.referrals r
+    join public.profiles ree on ree.id = r.referee_id
+    join public.profiles rer on rer.id = r.referrer_id
+    where r.referrer_id = p_user_id or r.referee_id = p_user_id
+    order by r.created_at desc;
+end;
+$$;
+
+grant execute on function public.admin_list_user_referrals(uuid) to authenticated;


### PR DESCRIPTION
## Summary

Adds an end-to-end referral program:

1. Every signup gets a unique 8-char `referral_code` (auto-generated by the existing `handle_new_user` trigger).
2. Codes can be entered via `/register?ref=ABCDJKMN` or a manual input on the signup form (with debounced live "Invited by @user" validation).
3. When a referred user pays for at least one prediction (admin marks `tournament_payments` paid), the referrer earns one free-pick credit.
4. The referrer sees a dismissible banner on `/predictions` and a red dot + count on the user menu. A new `/referrals` page surfaces the code, share URL, and stats.
5. The referrer clicks **Use free credit** on any unpaid pre-lock prediction; the prediction is then tagged with a green **Free pick** badge and counts toward the leaderboard like any paid bracket.

Confirmed design choices: credits are uncapped, referrer-only reward, banner + menu dot (no toast), explicit redeem button.

## Architecture

### Data model — `supabase/migrations/0035_referrals.sql`

- `public.referral_codes (user_id PK, code citext UNIQUE)` — separate table so codes aren't enumerable via the existing public `profiles_select_all` policy.
- `public.referrals (referee_id PK, referrer_id, qualified_at, reward_redeemed_at, reward_prediction_id, …)` — PK on `referee_id` enforces "one referrer per user, forever." DB CHECK and the trigger both block self-referral.
- `tournament_payments.is_free boolean` — distinguishes referral-redeemed from admin-recorded cash payments. Leaderboard query keeps working unchanged.

### Triggers / RPCs

- **`handle_new_user`** — extended to generate the new user's own code and capture the inbound referrer if a valid, non-self code was passed in `raw_user_meta_data.referral_code`.
- **`referrals_sync_qualification`** — trigger on `tournament_payments` AFTER INSERT/UPDATE/DELETE. Sets `qualified_at` on first non-free payment; clears it on delete only if the credit isn't yet redeemed (redeemed credits are sticky so the referrer's leaderboard entry stays stable).
- **`redeem_referral_credit(p_prediction_id)`** — SECURITY DEFINER. Uses `SELECT … FOR UPDATE SKIP LOCKED` on the chosen credit row, so concurrent redeems can never claim the same one. Inserts a `tournament_payments` row with `is_free = true, marked_by = auth.uid()`.
- **`get_referral_status()`** — caller-scoped aggregates only (code + counts). Referee list is never exposed.
- **`resolve_referrer_username(p_code)`** — SECURITY DEFINER, granted to `anon` + `authenticated`. Powers `/api/referrals/validate`. Returns NULL for invalid codes (no timing distinction).
- **`admin_list_user_referrals(p_user_id)`** — moderation view (inbound + outbound referrals).

### API routes

| Route | Method |
|---|---|
| `/api/referrals/validate?code=XXX` | GET (public, rate-limit at WAF) |
| `/api/referrals/status` | GET (authenticated) |
| `/api/predictions/[id]/redeem-credit` | POST (authenticated) |
| `/api/admin/users/[id]/referrals` | GET (admin) |

Plus `/api/predictions` and `/api/predictions/[id]` GETs now include `isFreePaid` in the response.

### Frontend

- `/register` — accepts `?ref=…`, debounced inline validation, optional manual input.
- `/predictions` — new `ReferralCreditBanner` (mirrors `LockStatusBanner`), "Free pick" badge, "Use free credit" button.
- `AuthMenu` — red dot + "Refer a friend (N)" entry.
- New `/referrals` page — code, share URL with copy/Web Share API, three-stat summary card.
- New shared `useReferralStatus()` hook (React Query, 60s stale).

## Security properties

| Threat | Mitigation |
|---|---|
| Self-referral | DB CHECK `referee_id <> referrer_id` + trigger skips if `referrer.id = new.id` |
| Multiple referrers for one referee | `referee_id` PK |
| Code enumeration | 31⁸ search space + `referral_codes` not selectable by other users (RLS) + WAF rate limit on `/api/referrals/validate` |
| Client tampering with `is_free` | RLS denies writes on `tournament_payments` except admin + the redeem RPC |
| Double-spend (concurrent redeem) | `SELECT … FOR UPDATE SKIP LOCKED` on the chosen `referrals` row |
| Credit before payment | Only the trigger sets `qualified_at`, only for `is_free = false` payments |
| Farming via fake signups | Admin mark-paid is the human checkpoint; `admin_list_user_referrals` surfaces the graph for moderation |
| Privacy leak of who used your code | `get_referral_status` returns aggregates only; referee list is admin-only |
| Reversal after admin un-marks payment | DELETE trigger nulls `qualified_at` only if credit not yet redeemed |

## Verification performed

1. ✅ `supabase db reset` — migration applies clean, existing seed user got a backfilled `referral_code`.
2. ✅ End-to-end SQL smoke test (10 scenarios) covers: signup-with-ref → qualification trigger → redeem → `is_free = true` payment → `get_referral_status` aggregates → double-spend blocked → self-referral blocked → PK blocks second referrer → `resolve_referrer_username` happy + null paths.
3. ✅ `npm run typecheck` — clean.
4. ✅ `npm run lint` — 0 errors (3 pre-existing warnings).
5. ✅ `npm test` — 41 suites, 317 tests pass.

## Follow-up for ops (post-merge)

- Add the Cloudflare WAF rule for `/api/referrals/validate` (10 req/min/IP, Block) — already documented in `CLAUDE.md`.