### PR TITLE
fix(admin): refresh user list after prediction payment toggle / delete / create

### DIFF
--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -162,8 +162,17 @@ export function AdminUserBracket({ userId }: { userId: string }) {
     : null;
   const predictions = query.data?.predictions ?? [];
 
+  // After any mutation that changes a prediction's payment state or
+  // existence, invalidate BOTH the detail-page query and the user-list
+  // query — `AdminUsersList` displays `predictionCount` /
+  // `paidPredictionCount` columns that go stale otherwise (the list query
+  // key is `['admin-users']`, see AdminUsersList.tsx).
   const refresh = React.useCallback(
-    () => queryClient.invalidateQueries({ queryKey: ['admin-user-predictions', userId] }),
+    () =>
+      Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['admin-user-predictions', userId] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+      ]),
     [queryClient, userId]
   );
 

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -796,6 +796,13 @@ export function PredictionsPageContent({
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['predictions'] }),
         queryClient.invalidateQueries({ queryKey: ['prediction', newId] }),
+        // When the admin wizard saves, the user list's `predictionCount`
+        // and `paidPredictionCount` columns (`AdminUsersList`, query key
+        // `['admin-users']`) reflect counts that just changed. Mark the
+        // list stale so the next /admin/users mount refetches.
+        ...(usesAdminRoute
+          ? [queryClient.invalidateQueries({ queryKey: ['admin-users'] })]
+          : []),
       ]);
       toast.success(markSubmitted ? 'Prediction submitted' : 'Progress saved');
 


### PR DESCRIPTION
## Bugs

On `/admin/users/[id]`, admin mutations that change `predictionCount` / `paidPredictionCount` weren't refreshing the list view at `/admin/users`. Two paths affected:

1. **Payment toggle** + **delete** — `AdminUserBracket`'s shared `refresh` callback only invalidated `['admin-user-predictions', userId]`. The `['admin-users']` list cache was never marked stale.
2. **Admin "New prediction" wizard** — `PredictionsPageContent`'s save handler invalidated `['predictions']` and `['prediction', id]`, but neither covers the admin list.

In both cases, navigating back to `/admin/users` showed cached rows with the old counts.

## Fixes

### 1. `AdminUserBracket.tsx`

Have the shared `refresh` callback invalidate both keys in parallel:

```diff
 const refresh = React.useCallback(
-  () => queryClient.invalidateQueries({ queryKey: ['admin-user-predictions', userId] }),
+  () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['admin-user-predictions', userId] }),
+      queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+    ]),
   [queryClient, userId]
 );
```

Covers both call sites (`PaymentRow.onChanged` and `handleDelete`) since they share the callback.

### 2. `PredictionsPageContent.tsx`

Add `['admin-users']` to the post-save invalidation set, gated on the existing `usesAdminRoute` flag so user-mode saves are unchanged:

```diff
 await Promise.all([
   queryClient.invalidateQueries({ queryKey: ['predictions'] }),
   queryClient.invalidateQueries({ queryKey: ['prediction', newId] }),
+  ...(usesAdminRoute
+    ? [queryClient.invalidateQueries({ queryKey: ['admin-users'] })]
+    : []),
 ]);
```

The list query has no active observer while the admin is on the detail / wizard page, so this just marks it stale — the network refetch fires when they next land on `/admin/users`.

## Verification

- `npm run typecheck`: clean
- `npm test`: 301/301 pass
- `npx eslint` on both changed files: clean