### PR TITLE
fix(auth): wipe React Query cache on sign-out

### DIFF
--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import type { User } from '@supabase/supabase-js';
+import { useQueryClient } from '@tanstack/react-query';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { clearAllDrafts } from '@/hooks/useDraftPersistence';
 import type { Profile } from '@/types/tournament';
@@ -28,6 +29,7 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
   const [loading, setLoading] = React.useState(false);
 
   const supabase = React.useMemo(() => createSupabaseBrowserClient(), []);
+  const queryClient = useQueryClient();
 
   const loadProfile = React.useCallback(
     async (userId: string) => {
@@ -55,8 +57,17 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
   React.useEffect(() => {
     // Never await Supabase calls inside this callback — auth-js holds an internal
     // navigator.locks lock for the duration of the listener, and re-entering it
-    // can wedge a later signOut() (see supabase/auth-js#762).
+    // can wedge a later signOut() (see supabase/auth-js#762). queryClient.clear()
+    // and clearAllDrafts() are sync, so they're safe to call here.
     const { data: subscription } = supabase.auth.onAuthStateChange((event, session) => {
+      // SIGNED_OUT fires for both same-tab signOut() and cross-tab logouts;
+      // wiping the React Query cache here is what prevents user A's
+      // /predictions data from being served to user B if they sign in
+      // within the gcTime window (5 min by QueryProvider default). Idempotent
+      // with the explicit clear in signOut() below.
+      if (event === 'SIGNED_OUT') {
+        queryClient.clear();
+      }
       setUser(session?.user ?? null);
       if (!session?.user) {
         setProfile(null);
@@ -66,17 +77,24 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
       void loadProfile(session.user.id);
     });
     return () => subscription.subscription.unsubscribe();
-  }, [supabase, loadProfile]);
+  }, [supabase, loadProfile, queryClient]);
 
   const signOut = React.useCallback(async () => {
     setLoading(true);
     const userId = user?.id;
     await supabase.auth.signOut({ scope: 'local' });
     if (userId) clearAllDrafts(userId);
+    // Wipe the React Query cache so the next sign-in (possibly as a
+    // different user) doesn't see this user's predictions / referral
+    // status / etc. served from the still-warm gcTime cache. The
+    // SIGNED_OUT listener above does this too — keeping it here as well
+    // makes the cleanup happen even if the listener doesn't fire (e.g.
+    // the auth-js lock wedges and AuthMenu's 5s fallback fires first).
+    queryClient.clear();
     setUser(null);
     setProfile(null);
     setLoading(false);
-  }, [supabase, user]);
+  }, [supabase, user, queryClient]);
 
   const refreshProfile = React.useCallback(async () => {
     if (user) await loadProfile(user.id);

--- a/frontend/src/providers/__tests__/AuthProvider.test.tsx
+++ b/frontend/src/providers/__tests__/AuthProvider.test.tsx
@@ -1,4 +1,6 @@
+import * as React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { User } from '@supabase/supabase-js';
 import { AuthProvider, useAuthContext } from '../AuthProvider';
 
@@ -21,6 +23,14 @@ jest.mock('@/lib/supabase/client', () => ({
   }),
 }));
 
+// AuthProvider depends on useQueryClient() to wipe the cache on sign-out.
+// Use a fresh client per test so cache state can't leak across cases.
+let queryClient: QueryClient;
+
+function withProviders(ui: React.ReactNode) {
+  return <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>;
+}
+
 function Consumer() {
   const { user, profile, loading } = useAuthContext();
   return (
@@ -36,23 +46,28 @@ describe('AuthProvider', () => {
   beforeEach(() => {
     authCallback = null;
     fromMock.mockReset();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
   });
 
   it('exposes initial user and profile', () => {
     render(
-      <AuthProvider
-        initialUser={{ id: 'u1' } as User}
-        initialProfile={{
-          id: 'u1',
-          username: 'alice',
-          displayName: null,
-          avatarUrl: null,
-          isAdmin: false,
-          isSuperAdmin: false,
-        }}
-      >
-        <Consumer />
-      </AuthProvider>
+      withProviders(
+        <AuthProvider
+          initialUser={{ id: 'u1' } as User}
+          initialProfile={{
+            id: 'u1',
+            username: 'alice',
+            displayName: null,
+            avatarUrl: null,
+            isAdmin: false,
+            isSuperAdmin: false,
+          }}
+        >
+          <Consumer />
+        </AuthProvider>
+      )
     );
 
     expect(screen.getByTestId('user').textContent).toBe('u1');
@@ -60,6 +75,8 @@ describe('AuthProvider', () => {
   });
 
   it('uses default (null user) when no provider wraps consumer', () => {
+    // No QueryClientProvider needed — useAuthContext falls back to the
+    // default value when AuthProvider isn't in the tree.
     render(<Consumer />);
     expect(screen.getByTestId('user').textContent).toBe('none');
     expect(screen.getByTestId('username').textContent).toBe('none');
@@ -83,9 +100,11 @@ describe('AuthProvider', () => {
     }));
 
     render(
-      <AuthProvider initialUser={null} initialProfile={null}>
-        <Consumer />
-      </AuthProvider>
+      withProviders(
+        <AuthProvider initialUser={null} initialProfile={null}>
+          <Consumer />
+        </AuthProvider>
+      )
     );
 
     expect(screen.getByTestId('user').textContent).toBe('none');
@@ -98,5 +117,30 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('user').textContent).toBe('u2');
       expect(screen.getByTestId('username').textContent).toBe('bob');
     });
+  });
+
+  it('clears the React Query cache when SIGNED_OUT fires', async () => {
+    // Seed cache with stale data that would belong to the previous user.
+    queryClient.setQueryData(['predictions'], { stale: true });
+    queryClient.setQueryData(['referralStatus'], { code: 'OLD' });
+    expect(queryClient.getQueryData(['predictions'])).toEqual({ stale: true });
+
+    render(
+      withProviders(
+        <AuthProvider
+          initialUser={{ id: 'u1' } as User}
+          initialProfile={null}
+        >
+          <Consumer />
+        </AuthProvider>
+      )
+    );
+
+    await act(async () => {
+      authCallback?.('SIGNED_OUT', null);
+    });
+
+    expect(queryClient.getQueryData(['predictions'])).toBeUndefined();
+    expect(queryClient.getQueryData(['referralStatus'])).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Bug

Signing out and signing back in as a different user showed the previous user's data on `/predictions` (and would on `/leaderboard`'s "find me" row, `/account`'s referral activity, and the admin menu dot).

## Root cause

The `QueryProvider` uses `gcTime: 5 * 60 * 1000` (`QueryProvider.tsx:13-28`). Sign-out in `AuthProvider.signOut()` cleared the Supabase session and per-user draft localStorage but never touched the React Query cache. So user-scoped queries stayed warm:

| Query key | What it caches |
|---|---|
| `['predictions']` | Current user's prediction list |
| `['prediction', id]` | Single prediction details |
| `['referralStatus']` | User's referral code + credit counts |
| `['leaderboard-me']` | User's "find me" rank |
| `['admin-user-predictions', userId]` | Admin's view of a specific user's predictions |

When a new user signed in within the 5-min `gcTime` window, React Query returned the cached entries verbatim until `staleTime` refetched in the background.

## Fix

Call `queryClient.clear()` from two places:

1. The `onAuthStateChange` listener when `event === 'SIGNED_OUT'` — covers same-tab signOut, cross-tab logout, and any server-driven session invalidation. The existing "never await Supabase calls in this listener" rule still holds because `clear()` is synchronous.
2. The explicit `signOut()` callback — runs even if the listener doesn't fire (e.g. the auth-js `navigator.locks` wedge that `AuthMenu`'s 5-second fallback already handles by hard-redirecting to `/login`).

Both are idempotent, so being called twice in the common path is harmless.

`queryClient.clear()` was chosen over a targeted invalidation list because (a) the next sign-in just refetches whatever it needs and the shared queries (`['tournament']`, `['teams']`, etc.) are cheap, and (b) it's the only option that's safe by default — future user-scoped queries don't need to remember to opt in.

## Tests

- `AuthProvider.test.tsx` now wraps with a `QueryClientProvider` (matching the real `layout.tsx` order: `QueryProvider` > `AuthProvider`).
- New assertion: seed `['predictions']` and `['referralStatus']` with stale data, fire `SIGNED_OUT`, verify both are cleared.

## Verification

- `npm run typecheck`: clean
- `npm test`: 302/302 pass (one new test)
- `npx eslint` on both changed files: clean