### PR TITLE
fix(predictions): scroll viewport to top on step transition

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -326,7 +326,6 @@ export function PredictionsPageContent({
   const [isSavingProgress, setIsSavingProgress] = React.useState(false);
   const [hydrated, setHydrated] = React.useState(false);
   const [currentStep, setCurrentStep] = React.useState<Step>('groups');
-  const tabsContentRef = React.useRef<HTMLDivElement | null>(null);
   const userInteractedRef = React.useRef(false);
   const initialStepSet = React.useRef(false);
   const nameRef = React.useRef<HTMLInputElement>(null);
@@ -680,10 +679,19 @@ export function PredictionsPageContent({
     goToStep(value as Step);
   };
 
+  // After any step transition (top-tab, sub-tab, Continue button), scroll the
+  // viewport back to the page top. Previously this used
+  // `tabsContentRef.scrollIntoView({ block: 'start' })`, which (a) put the
+  // content wrapper at the top with the stepper above the viewport — so users
+  // landed on a new step with no indication of which step they were on — and
+  // (b) was unreliable on iOS Safari, which sometimes ignores `block: 'start'`
+  // when the target is partially in view. `window.scrollTo` is rock-solid
+  // cross-browser and lands above the progress bar + stepper so the user can
+  // immediately see what step they're on.
   React.useEffect(() => {
     if (!userInteractedRef.current) return;
     if (typeof window === 'undefined') return;
-    tabsContentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [currentStep]);
 
   const goToNextStep = () => {
@@ -971,7 +979,7 @@ export function PredictionsPageContent({
           onSubChange={topValue === 'knockout' ? handleSubChange : undefined}
         />
 
-        <div ref={tabsContentRef}>
+        <div>
           {currentStep === 'groups' && (
             <GroupStageForm
               groups={groups}


### PR DESCRIPTION
## Bug

Reported on mobile: after tapping **Continue** at the bottom of a step in the prediction wizard, the viewport stays scrolled to the bottom of the new step. User has to manually scroll back up to see the new step's content and the stepper.

## Root cause

The existing post-transition handler in `PredictionsPageContent.tsx:683-687` called:

```tsx
tabsContentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
```

…on the wrapper div around the step content. Two problems:

1. **Wrong target.** The wrapper sits *below* the progress bar + `PredictionStepper`. Scrolling its top to the viewport top puts the stepper above the viewport, so users land on the new step with no visual indication of which step they're on. (This was a UX issue even when the scroll worked.)
2. **Unreliable on iOS Safari.** Safari frequently ignores `scrollIntoView({ block: 'start' })` when the target is partially in view or inside layout-affecting parents (overflow, sticky positioning). This matches the reported "stays at the bottom" symptom.

## Fix

Swap for `window.scrollTo({ top: 0, behavior: 'smooth' })`:

```diff
 React.useEffect(() => {
   if (!userInteractedRef.current) return;
   if (typeof window === 'undefined') return;
-  tabsContentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  window.scrollTo({ top: 0, behavior: 'smooth' });
 }, [currentStep]);
```

- Rock-solid cross-browser (no `scrollIntoView` quirks)
- Lands above the progress bar + stepper so users immediately see the new active step
- `userInteractedRef` gate is preserved, so the initial mount doesn't trigger a scroll

Removed the now-unused `tabsContentRef` declaration and the corresponding `ref={}` on the wrapper div.

## Verification

- `npm run typecheck`: clean
- `npm test`: 318/318 pass
- `npx eslint` on the changed file: clean

Manual mobile verification recommended:
1. Sign in, open a long step (e.g. Groups), scroll to the bottom
2. Tap **Continue** (or a top/sub stepper tab)
3. Viewport should smooth-scroll to the top, showing the progress bar + stepper for the new step