### PR TITLE
feat(predictions): Phase 1 Champions Pick with +5 bonus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-> **Version:** 3.3.0
+> **Version:** 3.3.1
 > **Last Updated:** 2026-05-21
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
@@ -99,7 +99,7 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 
 Plus flat bonuses on top: champion (M32 winner) `+15`, third-place winner (M31) `+5`. Round of 32 picks aren't scored directly — they decide R16 slots. The legacy `knockout_matches.point_value` column is still in the schema but the v2 RPCs ignore it. Max knockout points = 80 + 48 + 32 + 20 + 15 + 5 = **200**. Helper function `public.knockout_round_scores(tournament_id, stage, correct_pts, wrong_pts)` is shared by `get_leaderboard` and `get_leaderboard_rank`.
 
-**Phase 1 Champions Pick** — `+5` if `predictions.champion_team_id` matches the actual M32 winner. Independent of the bracket Final (M32) pick scoring (`+15`) — users can pick the same team for both (so a correct gut pick + correct bracket Final stacks to `+20`), or split between them. The pick is collected via a dropdown as the first wizard step, required at create time, and writable only while the tournament is in `phase1`; once `phase1_locked` (or later) it is frozen.
+**Gut Feeling Champion (Phase 1)** — `+5` if `predictions.champion_team_id` matches the actual M32 winner. Independent of the bracket Final (M32) pick scoring (`+15`) — users can pick the same team for both (so a correct gut pick + correct bracket Final stacks to `+20`), or split between them. The pick is collected via a dropdown as the final Phase 1 wizard step (after Best 3rds), required at create time, and writable only while the tournament is in `phase1`; once `phase1_locked` (or later) it is frozen.
 
 **Tiebreaker** — closest prediction to the *champion's* total goals across all 8 of their tournament matches (regulation + extra time only; no penalty-shootout goals). Stored on `tournaments.champion_total_goals` (admin-entered when the tournament ends). `predictions.total_goals` is reused with a relaxed CHECK of `between 0 and 50`.
 
@@ -149,7 +149,7 @@ Plus flat bonuses on top: champion (M32 winner) `+15`, third-place winner (M31) 
 - Each user can create as many named predictions per tournament as they like. Each prediction is independent (own picks, own tiebreaker, own payment).
 - All predictions submitted upfront before a single tournament-wide lock time (users may edit any of their predictions until lock)
 - Payment is **per prediction**: each one must be marked paid by an admin before lock to be eligible. The leaderboard shows one row per paid prediction (a user with N paid predictions occupies N rows).
-- **Phase 1 Champions Pick**: one team picked from the 48 as your tournament champion. Required at prediction-creation time, collected as the first wizard step, and locked when Phase 1 ends. Independent of the bracket Final (M32) pick — both score separately.
+- **Gut Feeling Champion** (Phase 1): one team picked from the 48 as your tournament champion. Required at prediction-creation time, collected as the final Phase 1 wizard step (after Best 3rds), and locked when Phase 1 ends. Independent of the bracket Final (M32) pick — both score separately.
 - Group stage: predict positions 1–4 for all 12 groups; only the top 2 finishers are scored (set-based 6/4/3/2/0 with a +8 exact-order bonus for Group I, the "Group of Death")
 - Knockout: predict winners R32 → Final. R32 picks decide which teams sit in your R16 slots and aren't scored directly; R16/QF/SF/Final score per advancing team with correct-side / wrong-side tiers; champion and third-place winner each get a flat bonus
 - Tiebreaker: closest prediction to the champion's total tournament goals (regulation + extra time across their 8 matches; penalty-shootout goals excluded)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
-> **Version:** 3.2.1
-> **Last Updated:** 2026-05-20
+> **Version:** 3.3.0
+> **Last Updated:** 2026-05-21
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -48,7 +48,7 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 - `profiles` — 1:1 with `auth.users`. Holds `username` (citext, unique, 3–24 chars, `[A-Za-z0-9_]`), `display_name`, `avatar_url`, `is_admin`. Auto-created via `handle_new_user` trigger; if `raw_user_meta_data.username` is missing (default for self-signup), the trigger generates `user_<8 hex chars>` with a 10-attempt collision retry. Admin-create flows still pass an explicit username.
 - `tournaments` — single active tournament enforced by partial unique index. Holds `lock_time` (single tournament-wide deadline) and `status` (`upcoming|group_stage|knockout|completed`).
 - `groups` (12: A–L), `teams` (48, FK to groups), `knockout_matches` (31, R32 → final, with `team1_source`/`team2_source` strings like `"M1"` or `"A1"`).
-- `predictions` — **many per `(user, tournament)`**, no quantity limit. Each has a unique `prediction_name` per user/tournament (case-insensitive), 1–60 chars matching `^[A-Za-z0-9 _\-.''‘’]+$`. Holds `total_goals` tiebreaker + submission timestamp.
+- `predictions` — **many per `(user, tournament)`**, no quantity limit. Each has a unique `prediction_name` per user/tournament (case-insensitive), 1–60 chars matching `^[A-Za-z0-9 _\-.''‘’]+$`. Holds `total_goals` tiebreaker, `champion_team_id` (the Phase 1 Champions Pick — nullable for legacy rows; required on new prediction creation), and submission timestamp.
 - `group_predictions` — normalized: 12 rows per prediction with `first_team_id`/`second_team_id`/`third_team_id`/`fourth_team_id`. CHECK enforces all four are distinct. PK is `(prediction_id, group_id)`.
 - `knockout_predictions` — one per `(prediction, match)` with predicted winner.
 - `tournament_payments` — one per `prediction_id` (UNIQUE). Payment is per-prediction, not per-user. Each paid prediction is its own ranked entry on the leaderboard. Has an `is_free boolean` (default `false`) that flags rows created via the referral-redeem flow rather than admin-recorded cash.
@@ -65,10 +65,10 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 
 ### RPCs (the trust boundary)
 
-- **`submit_predictions(payload jsonb)`** — single transaction. Payload includes optional `prediction_id` (omit to create, present to update) and required-on-create `prediction_name`. Users can create unlimited predictions per `(user, tournament)`; `prediction_name` uniqueness is enforced by the unique index. Raises `'predictions are locked'` (→ 403), `'prediction name taken'` (→ 409), `'prediction name required'` (→ 400), `'prediction not found'` (→ 404).
+- **`submit_predictions(payload jsonb)`** — single transaction. Payload includes optional `prediction_id` (omit to create, present to update), required-on-create `prediction_name`, and required-on-create `champion_team_id` (the Phase 1 Champions Pick — only writable while `tournament_phase = 'phase1'`). Users can create unlimited predictions per `(user, tournament)`; `prediction_name` uniqueness is enforced by the unique index. Raises `'predictions are locked'` (→ 403), `'prediction name taken'` (→ 409), `'prediction name required'` (→ 400), `'champion pick required'` (→ 400), `'prediction not found'` (→ 404).
 - **`admin_submit_predictions(p_user_id, payload)`** — same branching, no auth/lock check, scoped to the target user.
 - **`admin_set_prediction_payment(p_prediction_id, p_paid, p_paid_at)`** — replaces the old `admin_set_payment(user_id, tournament_id, …)`. Upserts `tournament_payments` keyed on `prediction_id`.
-- **`get_leaderboard(p_tournament_id, p_page, p_page_size)`** — paginated, SECURITY DEFINER. Returns one row per **paid prediction** with columns `rank, prediction_id, prediction_name, username, points, group_points, knockout_points, total_goals, total_count`. A user with N paid predictions occupies N rows.
+- **`get_leaderboard(p_tournament_id, p_page, p_page_size)`** — paginated, SECURITY DEFINER. Returns one row per **paid prediction** with columns `rank, prediction_id, prediction_name, username, points, group_points, advancer_points, knockout_points, champion_pick_points, total_goals, total_count`. A user with N paid predictions occupies N rows. `champion_pick_points` is 5 when `predictions.champion_team_id` equals the actual M32 winner, else 0; it is also folded into the `points` total used for ranking.
 - **`get_leaderboard_rank(p_tournament_id, p_user_id, p_page_size)`** — returns one row per paid prediction the user owns: `(prediction_id, prediction_name, rank, page, points)`. The frontend picks the best row for "find me".
 - **`admin_list_users(p_search, p_page, p_page_size)`** — returns `(id, username, is_admin, is_super_admin, prediction_count, paid_prediction_count, total_count)`.
 - **`redeem_referral_credit(p_prediction_id)`** — SECURITY DEFINER, caller-scoped. Locks one available `referrals` row (`FOR UPDATE SKIP LOCKED` blocks double-spend), inserts a `tournament_payments` row with `is_free = true`, marks the referral redeemed. Raises `'not your prediction'` (→ 403), `'predictions are locked'` (→ 403), `'prediction already paid'` (→ 409), `'no referral credits available'` (→ 409), `'prediction not found'` (→ 404).
@@ -99,9 +99,11 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 
 Plus flat bonuses on top: champion (M32 winner) `+15`, third-place winner (M31) `+5`. Round of 32 picks aren't scored directly — they decide R16 slots. The legacy `knockout_matches.point_value` column is still in the schema but the v2 RPCs ignore it. Max knockout points = 80 + 48 + 32 + 20 + 15 + 5 = **200**. Helper function `public.knockout_round_scores(tournament_id, stage, correct_pts, wrong_pts)` is shared by `get_leaderboard` and `get_leaderboard_rank`.
 
+**Phase 1 Champions Pick** — `+5` if `predictions.champion_team_id` matches the actual M32 winner. Independent of the bracket Final (M32) pick scoring (`+15`) — users can pick the same team for both (so a correct gut pick + correct bracket Final stacks to `+20`), or split between them. The pick is collected via a dropdown as the first wizard step, required at create time, and writable only while the tournament is in `phase1`; once `phase1_locked` (or later) it is frozen.
+
 **Tiebreaker** — closest prediction to the *champion's* total goals across all 8 of their tournament matches (regulation + extra time only; no penalty-shootout goals). Stored on `tournaments.champion_total_goals` (admin-entered when the tournament ends). `predictions.total_goals` is reused with a relaxed CHECK of `between 0 and 50`.
 
-**Grand total max: 74 + 200 = 274.**
+**Grand total max: 74 + 10 + 200 + 5 = 289.** (Group 74 + Advancers 10 + Knockout 200 + Champion Pick 5.)
 
 ## Frontend Architecture
 
@@ -147,6 +149,7 @@ Plus flat bonuses on top: champion (M32 winner) `+15`, third-place winner (M31) 
 - Each user can create as many named predictions per tournament as they like. Each prediction is independent (own picks, own tiebreaker, own payment).
 - All predictions submitted upfront before a single tournament-wide lock time (users may edit any of their predictions until lock)
 - Payment is **per prediction**: each one must be marked paid by an admin before lock to be eligible. The leaderboard shows one row per paid prediction (a user with N paid predictions occupies N rows).
+- **Phase 1 Champions Pick**: one team picked from the 48 as your tournament champion. Required at prediction-creation time, collected as the first wizard step, and locked when Phase 1 ends. Independent of the bracket Final (M32) pick — both score separately.
 - Group stage: predict positions 1–4 for all 12 groups; only the top 2 finishers are scored (set-based 6/4/3/2/0 with a +8 exact-order bonus for Group I, the "Group of Death")
 - Knockout: predict winners R32 → Final. R32 picks decide which teams sit in your R16 slots and aren't scored directly; R16/QF/SF/Final score per advancing team with correct-side / wrong-side tiers; champion and third-place winner each get a flat bonus
 - Tiebreaker: closest prediction to the champion's total tournament goals (regulation + extra time across their 8 matches; penalty-shootout goals excluded)

--- a/frontend/src/app/admin/users/[id]/predictions/[predictionId]/page.tsx
+++ b/frontend/src/app/admin/users/[id]/predictions/[predictionId]/page.tsx
@@ -22,7 +22,7 @@ export default async function AdminEditPredictionPage({
   const { data: prediction } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, total_goals, submitted_at, tournament_payments!prediction_id(paid_at)'
+      'id, prediction_name, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at)'
     )
     .eq('id', predictionId)
     .eq('user_id', id)
@@ -64,6 +64,7 @@ export default async function AdminEditPredictionPage({
     id: p.id,
     name: p.prediction_name,
     totalGoals: p.total_goals,
+    championTeamId: p.champion_team_id,
     submittedAt: p.submitted_at,
     isPaid: payment != null,
     paidAt: payment?.paid_at ?? null,

--- a/frontend/src/app/api/admin/users/[id]/predictions/[predictionId]/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/[predictionId]/route.ts
@@ -10,6 +10,7 @@ type RouteContext = {
 interface UpdatePayload {
   predictionName?: string;
   totalGoals?: number | null;
+  championTeamId?: string | null;
   submit?: boolean;
   groups?: Array<{
     groupId: string;
@@ -30,7 +31,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   const { data: prediction } = await ctx.supabase
     .from('predictions')
     .select(
-      'id, prediction_name, tournament_id, total_goals, submitted_at, tournament_payments!prediction_id(paid_at, marked_by)'
+      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at, marked_by)'
     )
     .eq('id', predictionId)
     .eq('user_id', userId)
@@ -70,6 +71,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     name: p.prediction_name,
     tournamentId: p.tournament_id,
     totalGoals: p.total_goals,
+    championTeamId: p.champion_team_id,
     submittedAt: p.submitted_at,
     isPaid: payment != null,
     paidAt: payment?.paid_at ?? null,
@@ -118,8 +120,13 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   if (!Array.isArray(body.groups) || !Array.isArray(body.knockout)) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
   }
+  const hasChampionField = Object.prototype.hasOwnProperty.call(body, 'championTeamId');
+  const championTeamId = body.championTeamId?.trim() || null;
+  if (hasChampionField && !championTeamId) {
+    return NextResponse.json({ error: 'championTeamId is required' }, { status: 400 });
+  }
 
-  const payload = {
+  const payload: Record<string, unknown> = {
     tournament_id: prediction.tournament_id,
     prediction_id: predictionId,
     prediction_name: name ?? null,
@@ -141,6 +148,9 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       team_id: a.teamId,
     })),
   };
+  if (hasChampionField) {
+    payload.champion_team_id = championTeamId;
+  }
 
   const { data, error } = await ctx.supabase.rpc('admin_submit_predictions', {
     p_user_id: userId,
@@ -153,6 +163,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     else if (msg.includes('name taken')) status = 409;
     else if (msg.includes('duplicate advancer')) status = 409;
     else if (msg.includes('advancer')) status = 400;
+    else if (msg.includes('champion pick')) status = 400;
     return NextResponse.json({ error: safeMessage(error) }, { status });
   }
   return NextResponse.json({ predictionId: data });

--- a/frontend/src/app/api/admin/users/[id]/predictions/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/__tests__/route.test.ts
@@ -58,6 +58,7 @@ describe('admin user predictions', () => {
         tournamentId: 't1',
         predictionName: 'Main',
         totalGoals: 25,
+        championTeamId: 'team-arg',
         groups: [],
         knockout: [],
       }),
@@ -67,7 +68,32 @@ describe('admin user predictions', () => {
     expect(await res.json()).toEqual({ predictionId: 'pred-id' });
     expect(supabaseMock.rpc).toHaveBeenCalledWith(
       'admin_submit_predictions',
-      expect.objectContaining({ p_user_id: 'u2' })
+      expect.objectContaining({
+        p_user_id: 'u2',
+        payload: expect.objectContaining({ champion_team_id: 'team-arg' }),
+      })
     );
+  });
+
+  it('POST returns 400 when championTeamId missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.from.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({ maybeSingle: async () => ({ data: { is_admin: true } }) }),
+      }),
+    }));
+    const res = await POST(
+      postReq({
+        tournamentId: 't1',
+        predictionName: 'Main',
+        totalGoals: 25,
+        groups: [],
+        knockout: [],
+      }),
+      { params: Promise.resolve({ id: 'u2' }) }
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/championTeamId/);
   });
 });

--- a/frontend/src/app/api/admin/users/[id]/predictions/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/route.ts
@@ -7,6 +7,7 @@ interface SubmitPayload {
   tournamentId?: string;
   predictionName?: string;
   totalGoals?: number | null;
+  championTeamId?: string | null;
   submit?: boolean;
   groups?: Array<{
     groupId: string;
@@ -42,7 +43,7 @@ export async function GET(
   const { data: predictions } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, total_goals, submitted_at, tournament_payments!prediction_id(paid_at, marked_by)'
+      'id, prediction_name, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at, marked_by)'
     )
     .eq('user_id', userId)
     .eq('tournament_id', tournament.id)
@@ -53,6 +54,7 @@ export async function GET(
     id: string;
     prediction_name: string;
     total_goals: number | null;
+    champion_team_id: string | null;
     submitted_at: string | null;
     // PostgREST returns an object (not array) when the embed resolves through
     // a unique FK — `tournament_payments.prediction_id` is unique, so it's 1:1.
@@ -72,6 +74,7 @@ export async function GET(
         id: p.id,
         name: p.prediction_name,
         totalGoals: p.total_goals,
+        championTeamId: p.champion_team_id,
         submittedAt: p.submitted_at,
         isPaid: payment != null,
         paidAt: payment?.paid_at ?? null,
@@ -107,11 +110,16 @@ export async function POST(
   if (!Array.isArray(body.groups) || !Array.isArray(body.knockout)) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
   }
+  const championTeamId = body.championTeamId?.trim() || null;
+  if (!championTeamId) {
+    return NextResponse.json({ error: 'championTeamId is required' }, { status: 400 });
+  }
 
   const payload = {
     tournament_id: body.tournamentId,
     prediction_name: name,
     total_goals: body.totalGoals,
+    champion_team_id: championTeamId,
     submit: body.submit !== false,
     groups: body.groups.map((g) => ({
       group_id: g.groupId,
@@ -140,6 +148,7 @@ export async function POST(
     if (msg.includes('name taken')) status = 409;
     else if (msg.includes('duplicate advancer')) status = 409;
     else if (msg.includes('advancer')) status = 400;
+    else if (msg.includes('champion pick')) status = 400;
     return NextResponse.json({ error: safeMessage(error) }, { status });
   }
   return NextResponse.json({ predictionId: data });

--- a/frontend/src/app/api/leaderboard/prediction/[id]/route.ts
+++ b/frontend/src/app/api/leaderboard/prediction/[id]/route.ts
@@ -8,6 +8,7 @@ interface RpcRow {
   prediction_name: string;
   username: string;
   total_goals: number | null;
+  champion_team_id: string | null;
   submitted_at: string | null;
   groups: Array<{
     group_id: string;
@@ -51,6 +52,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     name: row.prediction_name,
     username: row.username,
     totalGoals: row.total_goals,
+    championTeamId: row.champion_team_id,
     submittedAt: row.submitted_at,
     // The RPC only ever returns paid + submitted predictions, so these are
     // always true. Kept for shape-compat with BracketPreviewDialog.

--- a/frontend/src/app/api/leaderboard/route.ts
+++ b/frontend/src/app/api/leaderboard/route.ts
@@ -37,6 +37,7 @@ export async function GET(request: NextRequest) {
     group_points: number;
     advancer_points: number | string;
     knockout_points: number;
+    champion_pick_points: number;
     total_goals: number | null;
     total_count: number;
   }>;
@@ -52,6 +53,7 @@ export async function GET(request: NextRequest) {
       groupPoints: row.group_points,
       advancerPoints: Number(row.advancer_points),
       knockoutPoints: row.knockout_points,
+      championPickPoints: row.champion_pick_points ?? 0,
     })),
     total: Number(rows[0]?.total_count ?? 0),
     page,

--- a/frontend/src/app/api/predictions/[id]/route.ts
+++ b/frontend/src/app/api/predictions/[id]/route.ts
@@ -6,6 +6,7 @@ import { PREDICTION_NAME_MAX, PREDICTION_NAME_REGEX } from '@/lib/constants';
 interface UpdatePayload {
   predictionName?: string;
   totalGoals?: number | null;
+  championTeamId?: string | null;
   submit?: boolean;
   groups?: Array<{
     groupId: string;
@@ -31,7 +32,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   const { data: prediction } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, tournament_id, total_goals, submitted_at, tournament_payments!prediction_id(paid_at, is_free)'
+      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at, is_free)'
     )
     .eq('id', id)
     .maybeSingle();
@@ -72,6 +73,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     name: p.prediction_name,
     tournamentId: p.tournament_id,
     totalGoals: p.total_goals,
+    championTeamId: p.champion_team_id,
     submittedAt: p.submitted_at,
     isPaid: payment != null,
     paidAt: payment?.paid_at ?? null,
@@ -122,8 +124,13 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   if (!Array.isArray(body.groups) || !Array.isArray(body.knockout)) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
   }
+  const hasChampionField = Object.prototype.hasOwnProperty.call(body, 'championTeamId');
+  const championTeamId = body.championTeamId?.trim() || null;
+  if (hasChampionField && !championTeamId) {
+    return NextResponse.json({ error: 'championTeamId is required' }, { status: 400 });
+  }
 
-  const payload = {
+  const payload: Record<string, unknown> = {
     tournament_id: prediction.tournament_id,
     prediction_id: id,
     prediction_name: name ?? null,
@@ -145,6 +152,9 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       team_id: a.teamId,
     })),
   };
+  if (hasChampionField) {
+    payload.champion_team_id = championTeamId;
+  }
 
   const { data, error } = await supabase.rpc('submit_predictions', { payload });
   if (error) {
@@ -155,6 +165,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     else if (msg.includes('name taken')) status = 409;
     else if (msg.includes('duplicate advancer')) status = 409;
     else if (msg.includes('advancer')) status = 400;
+    else if (msg.includes('champion pick')) status = 400;
     return NextResponse.json({ error: safeMessage(error) }, { status });
   }
   return NextResponse.json({ predictionId: data });

--- a/frontend/src/app/api/predictions/__tests__/route.test.ts
+++ b/frontend/src/app/api/predictions/__tests__/route.test.ts
@@ -28,6 +28,7 @@ function basePostBody(overrides: Record<string, unknown> = {}) {
   return {
     tournamentId: 't1',
     predictionName: 'Main',
+    championTeamId: 'team-arg',
     groups: [],
     knockout: [],
     ...overrides,
@@ -122,6 +123,24 @@ describe('POST /api/predictions', () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toMatch(/0-50/);
+  });
+
+  it('returns 400 when championTeamId missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    const res = await POST(postRequest(basePostBody({ championTeamId: null })));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/championTeamId/);
+  });
+
+  it('returns 400 when rpc reports champion pick required', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'champion pick required' },
+    });
+    const res = await POST(postRequest(basePostBody()));
+    expect(res.status).toBe(400);
   });
 
   it('returns 403 when rpc reports lock', async () => {

--- a/frontend/src/app/api/predictions/route.ts
+++ b/frontend/src/app/api/predictions/route.ts
@@ -7,6 +7,7 @@ interface SubmitPayload {
   tournamentId?: string;
   predictionName?: string;
   totalGoals?: number | null;
+  championTeamId?: string | null;
   submit?: boolean;
   groups?: Array<{
     groupId: string;
@@ -39,7 +40,7 @@ export async function GET() {
   const { data: predictions } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, total_goals, submitted_at, tournament_payments!prediction_id(paid_at, is_free)'
+      'id, prediction_name, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at, is_free)'
     )
     .eq('user_id', user.id)
     .eq('tournament_id', tournament.id)
@@ -114,6 +115,7 @@ export async function GET() {
     id: string;
     prediction_name: string;
     total_goals: number | null;
+    champion_team_id: string | null;
     submitted_at: string | null;
     tournament_payments: Payment | Payment[] | null;
   };
@@ -131,6 +133,7 @@ export async function GET() {
         id: p.id,
         name: p.prediction_name,
         totalGoals: p.total_goals,
+        championTeamId: p.champion_team_id,
         submittedAt: p.submitted_at,
         isPaid: payment != null,
         paidAt: payment?.paid_at ?? null,
@@ -180,11 +183,16 @@ export async function POST(request: NextRequest) {
   if (!Array.isArray(body.groups) || !Array.isArray(body.knockout)) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
   }
+  const championTeamId = body.championTeamId?.trim() || null;
+  if (!championTeamId) {
+    return NextResponse.json({ error: 'championTeamId is required' }, { status: 400 });
+  }
 
   const payload = {
     tournament_id: body.tournamentId,
     prediction_name: name,
     total_goals: body.totalGoals,
+    champion_team_id: championTeamId,
     submit: body.submit !== false,
     groups: body.groups.map((g) => ({
       group_id: g.groupId,
@@ -211,6 +219,7 @@ export async function POST(request: NextRequest) {
     else if (msg.includes('name taken')) status = 409;
     else if (msg.includes('duplicate advancer')) status = 409;
     else if (msg.includes('advancer')) status = 400;
+    else if (msg.includes('champion pick')) status = 400;
     return NextResponse.json({ error: safeMessage(error) }, { status });
   }
 

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, ArrowRight, Clock, Save } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { PageLayout } from '@/components/layout/PageLayout';
+import { ChampionPickForm } from '@/components/predictions/ChampionPickForm';
 import { GroupStageForm } from '@/components/predictions/GroupStageForm';
 import { KnockoutBracket } from '@/components/predictions/KnockoutBracket';
 import { PredictionStepper, type StepperStep } from '@/components/predictions/PredictionStepper';
@@ -46,6 +47,7 @@ import { AdvancersForm } from '@/components/predictions/AdvancersForm';
 type PositionKey = 'first' | 'second' | 'third' | 'fourth';
 
 type Step =
+  | 'champion_pick'
   | 'groups'
   | 'best_thirds'
   | 'round_of_32'
@@ -56,9 +58,10 @@ type Step =
   | 'third_place'
   | 'tiebreaker';
 
-type TopStep = 'groups' | 'best_thirds' | 'knockout' | 'tiebreaker';
+type TopStep = 'champion_pick' | 'groups' | 'best_thirds' | 'knockout' | 'tiebreaker';
 
 const STEP_ORDER: Step[] = [
+  'champion_pick',
   'groups',
   'best_thirds',
   'round_of_32',
@@ -71,6 +74,7 @@ const STEP_ORDER: Step[] = [
 ];
 
 const STEP_LABELS: Record<Step, string> = {
+  champion_pick: 'Champion Pick',
   groups: 'Group Stage',
   best_thirds: 'Best 3rds',
   round_of_32: 'Round of 32',
@@ -100,8 +104,9 @@ const SUB_STEP_LABELS: Record<KnockoutStage, string> = {
   third_place: '3rd',
 };
 
-const TOP_STEPS: TopStep[] = ['groups', 'best_thirds', 'knockout', 'tiebreaker'];
+const TOP_STEPS: TopStep[] = ['champion_pick', 'groups', 'best_thirds', 'knockout', 'tiebreaker'];
 const TOP_STEP_LABELS: Record<TopStep, string> = {
+  champion_pick: 'Champion',
   groups: 'Group Stage',
   best_thirds: 'Best 3rds',
   knockout: 'Knockout',
@@ -113,6 +118,7 @@ function isKnockoutStage(step: Step): step is KnockoutStage {
 }
 
 function topOf(step: Step): TopStep {
+  if (step === 'champion_pick') return 'champion_pick';
   if (step === 'groups') return 'groups';
   if (step === 'best_thirds') return 'best_thirds';
   if (step === 'tiebreaker') return 'tiebreaker';
@@ -123,6 +129,7 @@ export interface InitialPrediction {
   id: string;
   name: string;
   totalGoals: number | null;
+  championTeamId: string | null;
   submittedAt: string | null;
   isPaid: boolean;
   paidAt: string | null;
@@ -143,6 +150,7 @@ interface DraftData {
   knockoutPredictions: KnockoutMatchPrediction[];
   advancerPredictions: AdvancerPrediction[];
   totalGoals: number | null;
+  championTeamId: string | null;
 }
 
 interface PredictionsPageContentProps {
@@ -322,18 +330,21 @@ export function PredictionsPageContent({
       }))
   );
   const [totalGoals, setTotalGoals] = React.useState<number | null>(initial?.totalGoals ?? null);
+  const [championTeamId, setChampionTeamId] = React.useState<string | null>(
+    initial?.championTeamId ?? null
+  );
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [isSavingProgress, setIsSavingProgress] = React.useState(false);
   const [hydrated, setHydrated] = React.useState(false);
-  const [currentStep, setCurrentStep] = React.useState<Step>('groups');
+  const [currentStep, setCurrentStep] = React.useState<Step>('champion_pick');
   const userInteractedRef = React.useRef(false);
   const initialStepSet = React.useRef(false);
   const nameRef = React.useRef<HTMLInputElement>(null);
 
   // Once we know the phase and have hydrated, jump straight to Round of 32
-  // when phase 2 is open — group + advancer picks are frozen at that point
-  // so the user's only remaining work is the knockout bracket. Runs once;
-  // later navigation is up to the user.
+  // when phase 2 is open — group + advancer + champion picks are frozen at
+  // that point so the user's only remaining work is the knockout bracket.
+  // Runs once; later navigation is up to the user.
   React.useEffect(() => {
     if (initialStepSet.current) return;
     if (!hydrated) return;
@@ -394,6 +405,7 @@ export function PredictionsPageContent({
     let advancerSeed = seedAdvancers;
     let nameSeed = initial?.name ?? '';
     let totalGoalsSeed = initial?.totalGoals ?? null;
+    let championSeed = initial?.championTeamId ?? null;
     let restoredFromDraft = false;
 
     if (isLocked) {
@@ -415,6 +427,7 @@ export function PredictionsPageContent({
         advancerSeed = draft.data.advancerPredictions ?? [];
         nameSeed = draft.data.predictionName ?? nameSeed;
         totalGoalsSeed = draft.data.totalGoals;
+        championSeed = draft.data.championTeamId ?? championSeed;
         restoredFromDraft = true;
       }
     }
@@ -423,6 +436,7 @@ export function PredictionsPageContent({
     setKnockoutPredictions(knockoutSeed);
     setAdvancerPredictions(advancerSeed);
     setTotalGoals(totalGoalsSeed);
+    setChampionTeamId(championSeed);
     setPredictionName(nameSeed);
     setHydrated(true);
 
@@ -436,6 +450,7 @@ export function PredictionsPageContent({
             setKnockoutPredictions(seedKnockout);
             setAdvancerPredictions(seedAdvancers);
             setTotalGoals(initial?.totalGoals ?? null);
+            setChampionTeamId(initial?.championTeamId ?? null);
             setPredictionName(initial?.name ?? '');
           },
         },
@@ -464,13 +479,24 @@ export function PredictionsPageContent({
   const completedAdvancers = advancerPredictions.filter((a) => !!a.teamId).length;
   const tiebreakerSlots = 1;
   const filledTiebreaker = totalGoals !== null ? 1 : 0;
+  const championSlots = 1;
+  const filledChampion = championTeamId !== null ? 1 : 0;
 
   const totalSlots =
-    totalGroupSlots + ADVANCER_COUNT + totalKnockoutMatches + tiebreakerSlots;
+    championSlots +
+    totalGroupSlots +
+    ADVANCER_COUNT +
+    totalKnockoutMatches +
+    tiebreakerSlots;
   const filledSlots =
-    filledGroupSlots + completedAdvancers + completedKnockoutMatches + filledTiebreaker;
+    filledChampion +
+    filledGroupSlots +
+    completedAdvancers +
+    completedKnockoutMatches +
+    filledTiebreaker;
   const overallPercent = totalSlots > 0 ? Math.round((filledSlots / totalSlots) * 100) : 0;
 
+  const isChampionPickComplete = championTeamId !== null;
   const isGroupsComplete = totalGroupsCount > 0 && completedGroups === totalGroupsCount;
   const isAdvancersComplete = completedAdvancers === ADVANCER_COUNT;
   const isBracketComplete =
@@ -485,7 +511,11 @@ export function PredictionsPageContent({
   // isBracketComplete is naturally false and Submit stays disabled until
   // Phase 2 opens.
   const isPredictionsComplete =
-    isGroupsComplete && isAdvancersComplete && isBracketComplete && isTiebreakerComplete;
+    isChampionPickComplete &&
+    isGroupsComplete &&
+    isAdvancersComplete &&
+    isBracketComplete &&
+    isTiebreakerComplete;
 
   const trimmedName = predictionName.trim();
   const nameError =
@@ -540,6 +570,7 @@ export function PredictionsPageContent({
   }, [matchesByStage, knockoutPredictions]);
 
   const stepStatus: Record<Step, boolean> = {
+    champion_pick: isChampionPickComplete,
     groups: isGroupsComplete,
     best_thirds: isAdvancersComplete,
     round_of_32: stageCompletion.round_of_32,
@@ -573,6 +604,8 @@ export function PredictionsPageContent({
       status = 'locked';
     } else if (value === topValue) {
       status = 'current';
+    } else if (value === 'champion_pick') {
+      status = isChampionPickComplete ? 'done' : 'upcoming';
     } else if (value === 'groups') {
       status = isGroupsComplete ? 'done' : 'upcoming';
     } else if (value === 'best_thirds') {
@@ -601,6 +634,8 @@ export function PredictionsPageContent({
         knockoutPredictions: next.knockoutPredictions ?? knockoutPredictions,
         advancerPredictions: next.advancerPredictions ?? advancerPredictions,
         totalGoals: next.totalGoals !== undefined ? next.totalGoals : totalGoals,
+        championTeamId:
+          next.championTeamId !== undefined ? next.championTeamId : championTeamId,
       });
     },
     [
@@ -612,6 +647,7 @@ export function PredictionsPageContent({
       knockoutPredictions,
       advancerPredictions,
       totalGoals,
+      championTeamId,
     ]
   );
 
@@ -650,6 +686,11 @@ export function PredictionsPageContent({
     persistDraft({ totalGoals: value });
   };
 
+  const handleChampionTeamIdChange = (value: string | null) => {
+    setChampionTeamId(value);
+    persistDraft({ championTeamId: value });
+  };
+
   const handleAdvancerRankChange = (rank: number, teamId: string | null) => {
     setAdvancerPredictions((prev) => {
       const others = prev.filter((a) => a.rank !== rank);
@@ -667,6 +708,7 @@ export function PredictionsPageContent({
 
   const handleTopChange = (value: string) => {
     if (!TOP_STEPS.includes(value as TopStep)) return;
+    if (value === 'champion_pick') return goToStep('champion_pick');
     if (value === 'groups') return goToStep('groups');
     if (value === 'best_thirds') return goToStep('best_thirds');
     if (value === 'tiebreaker') return goToStep('tiebreaker');
@@ -734,6 +776,16 @@ export function PredictionsPageContent({
       toast.error('Please complete all predictions before submitting');
       return;
     }
+    // The submit_predictions RPC requires champion_team_id whenever Phase 1
+    // writes are involved (create, or any Phase 1 edit). Guard before the
+    // network round-trip so the user lands back on the Champion Pick step
+    // instead of seeing a generic save-failed toast.
+    const willSendPhase1 = usesAdminRoute || phase === 'phase1';
+    if (willSendPhase1 && !championTeamId) {
+      toast.error('Pick a champion before saving');
+      goToStep('champion_pick');
+      return;
+    }
 
     if (markSubmitted) setIsSubmitting(true);
     else setIsSavingProgress(true);
@@ -743,7 +795,10 @@ export function PredictionsPageContent({
       // (admin_submit_predictions) has no phase guards, so send everything.
       const sendPhase1Fields = usesAdminRoute || phase === 'phase1';
       const sendPhase2Fields = usesAdminRoute || phase === 'phase2_open';
-      const body = {
+      // championTeamId is a Phase 1 field: only forward it when the RPC
+      // will accept Phase 1 writes. On a Phase 2 PATCH from a regular user
+      // we omit the key entirely so the RPC preserves the existing value.
+      const body: Record<string, unknown> = {
         tournamentId: tournament.id,
         predictionName: trimmedName,
         totalGoals: sendPhase2Fields ? totalGoals : null,
@@ -770,6 +825,9 @@ export function PredictionsPageContent({
             }))
           : [],
       };
+      if (sendPhase1Fields) {
+        body.championTeamId = championTeamId;
+      }
 
       const url =
         mode === 'edit' && predictionId
@@ -980,6 +1038,15 @@ export function PredictionsPageContent({
         />
 
         <div>
+          {currentStep === 'champion_pick' && (
+            <ChampionPickForm
+              teams={teams}
+              value={championTeamId}
+              onChange={handleChampionTeamIdChange}
+              disabled={!phase1Editable}
+            />
+          )}
+
           {currentStep === 'groups' && (
             <GroupStageForm
               groups={groups}

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -47,9 +47,9 @@ import { AdvancersForm } from '@/components/predictions/AdvancersForm';
 type PositionKey = 'first' | 'second' | 'third' | 'fourth';
 
 type Step =
-  | 'champion_pick'
   | 'groups'
   | 'best_thirds'
+  | 'champion_pick'
   | 'round_of_32'
   | 'round_of_16'
   | 'quarter_finals'
@@ -58,12 +58,12 @@ type Step =
   | 'third_place'
   | 'tiebreaker';
 
-type TopStep = 'champion_pick' | 'groups' | 'best_thirds' | 'knockout' | 'tiebreaker';
+type TopStep = 'groups' | 'best_thirds' | 'champion_pick' | 'knockout' | 'tiebreaker';
 
 const STEP_ORDER: Step[] = [
-  'champion_pick',
   'groups',
   'best_thirds',
+  'champion_pick',
   'round_of_32',
   'round_of_16',
   'quarter_finals',
@@ -74,9 +74,9 @@ const STEP_ORDER: Step[] = [
 ];
 
 const STEP_LABELS: Record<Step, string> = {
-  champion_pick: 'Champion Pick',
   groups: 'Group Stage',
   best_thirds: 'Best 3rds',
+  champion_pick: 'Gut Feeling Champion',
   round_of_32: 'Round of 32',
   round_of_16: 'Round of 16',
   quarter_finals: 'Quarter-finals',
@@ -104,11 +104,11 @@ const SUB_STEP_LABELS: Record<KnockoutStage, string> = {
   third_place: '3rd',
 };
 
-const TOP_STEPS: TopStep[] = ['champion_pick', 'groups', 'best_thirds', 'knockout', 'tiebreaker'];
+const TOP_STEPS: TopStep[] = ['groups', 'best_thirds', 'champion_pick', 'knockout', 'tiebreaker'];
 const TOP_STEP_LABELS: Record<TopStep, string> = {
-  champion_pick: 'Champion',
   groups: 'Group Stage',
   best_thirds: 'Best 3rds',
+  champion_pick: 'Gut Feeling',
   knockout: 'Knockout',
   tiebreaker: 'Tiebreaker',
 };
@@ -336,7 +336,7 @@ export function PredictionsPageContent({
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [isSavingProgress, setIsSavingProgress] = React.useState(false);
   const [hydrated, setHydrated] = React.useState(false);
-  const [currentStep, setCurrentStep] = React.useState<Step>('champion_pick');
+  const [currentStep, setCurrentStep] = React.useState<Step>('groups');
   const userInteractedRef = React.useRef(false);
   const initialStepSet = React.useRef(false);
   const nameRef = React.useRef<HTMLInputElement>(null);
@@ -912,7 +912,8 @@ export function PredictionsPageContent({
   const currentStepComplete = stepStatus[currentStep];
   const nextStepLabel = !isLastStep ? STEP_LABELS[STEP_ORDER[stepIndex + 1]] : null;
   const previousStepLabel = !isFirstStep ? STEP_LABELS[STEP_ORDER[stepIndex - 1]] : null;
-  // Bottom-nav action layout for the Best 3rds step in Phase 1:
+  // Bottom-nav action layout for the Gut Feeling Champion step in Phase 1
+  // (the final Phase-1 step):
   //   - Regular users: "Save Phase 1 Picks" only. Knockout steps are
   //     read-only in phase 1, so a Continue button would dump them on
   //     disabled screens.
@@ -921,12 +922,12 @@ export function PredictionsPageContent({
   //     regular participant gets; "Continue to Round 32" keeps the wizard
   //     flow into the knockout bracket (which they can edit thanks to
   //     phase2Editable).
-  const isPhase1BestThirds =
-    phase === 'phase1' && currentStep === 'best_thirds';
-  const showSavePhase1 = isPhase1BestThirds;
+  const isPhase1LastStep =
+    phase === 'phase1' && currentStep === 'champion_pick';
+  const showSavePhase1 = isPhase1LastStep;
   const showReviewSubmit = isLastStep;
   const showContinue =
-    !isLastStep && (!isPhase1BestThirds || isSuperAdmin);
+    !isLastStep && (!isPhase1LastStep || isSuperAdmin);
 
   // Why is the Save Phase 1 Picks button disabled? The button has four
   // silent gates (name validation, current-step completion, lock state,
@@ -941,7 +942,7 @@ export function PredictionsPageContent({
         : nameError
           ? 'Enter a prediction name above first.'
           : !currentStepComplete
-            ? 'Rank all 8 of your best 3rd-place teams above.'
+            ? 'Pick your gut-feeling champion above first.'
             : null;
 
   return (

--- a/frontend/src/app/predictions/[id]/page.tsx
+++ b/frontend/src/app/predictions/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function EditPredictionPage({ params }: PageProps) {
   const { data: prediction } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, total_goals, submitted_at, tournament_payments!prediction_id(paid_at)'
+      'id, prediction_name, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at)'
     )
     .eq('id', id)
     .eq('user_id', user.id)
@@ -66,6 +66,7 @@ export default async function EditPredictionPage({ params }: PageProps) {
     id: p.id,
     name: p.prediction_name,
     totalGoals: p.total_goals,
+    championTeamId: p.champion_team_id,
     submittedAt: p.submitted_at,
     isPaid: payment != null,
     paidAt: payment?.paid_at ?? null,

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -153,6 +153,23 @@ jest.mock('@/components/predictions/AdvancersForm', () => ({
   ),
 }));
 
+interface ChampionPickFormProps {
+  value: string | null;
+  onChange: (teamId: string | null) => void;
+}
+jest.mock('@/components/predictions/ChampionPickForm', () => ({
+  ChampionPickForm: ({ value, onChange }: ChampionPickFormProps) => (
+    <div data-testid="champion-pick-form">
+      <span data-testid="champion-value">{value ?? 'null'}</span>
+      <button
+        type="button"
+        data-testid="fill-champion"
+        onClick={() => onChange('team-arg')}
+      />
+    </div>
+  ),
+}));
+
 import { PredictionsPageContent } from '../PredictionsPageContent';
 import { DRAFT_DEBOUNCE_MS, DRAFT_VERSION } from '@/hooks/useDraftPersistence';
 
@@ -247,9 +264,20 @@ describe('PredictionsPageContent — stepper navigation', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    const continueBtn = await screen.findByRole('button', { name: /Continue to Best 3rds/ });
+    // Wizard now opens on the Phase 1 Champions Pick step; Continue is gated
+    // on that pick being filled.
+    const continueBtn = await screen.findByRole('button', { name: /Continue to Group Stage/ });
     expect(continueBtn).toBeDisabled();
 
+    await user.click(screen.getByTestId('fill-champion'));
+    expect(screen.getByRole('button', { name: /Continue to Group Stage/ })).toBeEnabled();
+
+    // Now advance through champion → groups and assert the next step's
+    // Continue is again gated on completion.
+    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
+    expect(
+      screen.getByRole('button', { name: /Continue to Best 3rds/ })
+    ).toBeDisabled();
     await user.click(screen.getByTestId('fill-all-groups'));
     expect(screen.getByRole('button', { name: /Continue to Best 3rds/ })).toBeEnabled();
   });
@@ -284,7 +312,9 @@ describe('PredictionsPageContent — stepper navigation', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    await user.click(await screen.findByTestId('fill-all-groups'));
+    await user.click(await screen.findByTestId('fill-champion'));
+    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
+    await user.click(screen.getByTestId('fill-all-groups'));
     await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
     await user.click(screen.getByTestId('fill-all-bundles'));
 
@@ -309,7 +339,9 @@ describe('PredictionsPageContent — stepper navigation', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    await user.click(await screen.findByTestId('fill-all-groups'));
+    await user.click(await screen.findByTestId('fill-champion'));
+    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
+    await user.click(screen.getByTestId('fill-all-groups'));
     await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
     await user.click(screen.getByTestId('fill-all-bundles'));
 
@@ -327,7 +359,9 @@ describe('PredictionsPageContent — stepper navigation', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    await user.click(await screen.findByTestId('fill-all-groups'));
+    await user.click(await screen.findByTestId('fill-champion'));
+    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
+    await user.click(screen.getByTestId('fill-all-groups'));
     await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
     await user.click(screen.getByTestId('fill-all-bundles'));
 
@@ -397,6 +431,10 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(screen.getByRole('tab', { name: /Group Stage/ })).not.toBeDisabled();
     expect(screen.getByRole('tab', { name: /Best 3rds/ })).not.toBeDisabled();
 
+    // Wizard now opens on the Phase 1 Champions Pick step; advance through
+    // it first so the test exercises the locked-Groups Continue.
+    await user.click(screen.getByTestId('fill-champion'));
+    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
     await user.click(screen.getByTestId('fill-all-groups'));
 
     const continueBtn = screen.getByRole('button', { name: /Continue to Best 3rds/ });
@@ -413,6 +451,9 @@ describe('PredictionsPageContent — autosave', () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     render(<PredictionsPageContent mode="create" />);
 
+    // Wizard now opens on Champion Pick; navigate to Groups before
+    // exercising the group-stage interaction this test cares about.
+    await user.click(await screen.findByRole('tab', { name: /Group Stage/ }));
     await user.click(await screen.findByTestId('fill-one-group-position'));
     expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull();
 
@@ -453,8 +494,12 @@ describe('PredictionsPageContent — autosave', () => {
     );
     configureQueries();
 
+    const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
+    // Wizard opens on Champion Pick now; switch to Group Stage so the
+    // mocked groups-filled testid is rendered.
+    await user.click(await screen.findByRole('tab', { name: /Group Stage/ }));
     // Draft has 1 group slot + 1 tiebreaker filled (total 2). Server would have 0.
     await waitFor(() => expect(screen.getByTestId('groups-filled')).toHaveTextContent('1'));
     // Progress bar reflects the combined draft state (groups + tiebreaker).
@@ -484,6 +529,7 @@ describe('PredictionsPageContent — autosave', () => {
     );
     configureQueries();
 
+    const user = userEvent.setup();
     render(
       <PredictionsPageContent
         mode="edit"
@@ -492,6 +538,7 @@ describe('PredictionsPageContent — autosave', () => {
           id: 'pred-1',
           name: 'Server',
           totalGoals: 7,
+          championTeamId: null,
           submittedAt: new Date().toISOString(),
           isPaid: false,
           paidAt: null,
@@ -501,6 +548,9 @@ describe('PredictionsPageContent — autosave', () => {
       />
     );
 
+    // Wizard opens on Champion Pick; navigate to Groups to see the mocked
+    // groups-filled testid.
+    await user.click(await screen.findByRole('tab', { name: /Group Stage/ }));
     // Server hydration → exactly 1 filled slot. Draft would have been 24.
     await waitFor(() =>
       expect(screen.getByTestId('groups-filled')).toHaveTextContent('1')
@@ -531,7 +581,11 @@ describe('PredictionsPageContent — autosave', () => {
 
   it('clears the draft after a successful submit', async () => {
     // Phase 2 open so Submit is reachable — regular users can't submit in
-    // phase 1 (Continue → R32 is replaced by Save Phase 1 Picks).
+    // phase 1 (Continue → R32 is replaced by Save Phase 1 Picks). Use a
+    // super-admin profile so the champion pick (a Phase 1 field) is still
+    // editable through the admin route — required because the wizard's
+    // completion gate now includes isChampionPickComplete.
+    mockAuthProfile = { isSuperAdmin: true };
     configureQueries({ phase: 'phase2_open' });
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
@@ -542,8 +596,12 @@ describe('PredictionsPageContent — autosave', () => {
 
     render(<PredictionsPageContent mode="create" />);
 
-    // Wizard starts at Round of 32 in phase 2; navigate to Group Stage first.
-    await user.click(await screen.findByRole('tab', { name: /Group Stage/ }));
+    // Wizard starts at Round of 32 in phase 2; navigate to Champion tab
+    // first so we can fill the Phase 1 pick (required for completion),
+    // then walk back through Group Stage → ... → Tiebreaker.
+    await user.click(await screen.findByRole('tab', { name: /Champion/ }));
+    await user.click(await screen.findByTestId('fill-champion'));
+    await user.click(screen.getByRole('tab', { name: /Group Stage/ }));
     await user.click(await screen.findByTestId('fill-all-groups'));
     await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
     await user.click(screen.getByTestId('fill-all-bundles'));

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -264,25 +264,14 @@ describe('PredictionsPageContent — stepper navigation', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    // Wizard now opens on the Phase 1 Champions Pick step; Continue is gated
-    // on that pick being filled.
-    const continueBtn = await screen.findByRole('button', { name: /Continue to Group Stage/ });
+    const continueBtn = await screen.findByRole('button', { name: /Continue to Best 3rds/ });
     expect(continueBtn).toBeDisabled();
 
-    await user.click(screen.getByTestId('fill-champion'));
-    expect(screen.getByRole('button', { name: /Continue to Group Stage/ })).toBeEnabled();
-
-    // Now advance through champion → groups and assert the next step's
-    // Continue is again gated on completion.
-    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
-    expect(
-      screen.getByRole('button', { name: /Continue to Best 3rds/ })
-    ).toBeDisabled();
     await user.click(screen.getByTestId('fill-all-groups'));
     expect(screen.getByRole('button', { name: /Continue to Best 3rds/ })).toBeEnabled();
   });
 
-  it('advances Groups → Best 3rds → Round of 32 via Continue (phase 2 open)', async () => {
+  it('advances Groups → Best 3rds → Gut Feeling Champion → Round of 32 via Continue (phase 2 open)', async () => {
     configureQueries({ phase: 'phase2_open' });
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
@@ -296,6 +285,11 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(screen.getByTestId('advancers-form')).toBeInTheDocument();
 
     await user.click(screen.getByTestId('fill-all-bundles'));
+    await user.click(
+      screen.getByRole('button', { name: /Continue to Gut Feeling Champion/ })
+    );
+    expect(screen.getByTestId('champion-pick-form')).toBeInTheDocument();
+    await user.click(screen.getByTestId('fill-champion'));
     await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
 
     // Top "Knockout" chip is now current; sub row appears with R32 selected.
@@ -307,18 +301,21 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(screen.getByRole('tab', { name: /R32/ })).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('shows Save Phase 1 Picks instead of Continue on Best 3rds in phase 1', async () => {
+  it('shows Save Phase 1 Picks on the Gut Feeling Champion step in phase 1', async () => {
     configureQueries(); // phase 1 default
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    await user.click(await screen.findByTestId('fill-champion'));
-    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
-    await user.click(screen.getByTestId('fill-all-groups'));
+    await user.click(await screen.findByTestId('fill-all-groups'));
     await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
     await user.click(screen.getByTestId('fill-all-bundles'));
+    await user.click(
+      screen.getByRole('button', { name: /Continue to Gut Feeling Champion/ })
+    );
+    await user.click(screen.getByTestId('fill-champion'));
 
-    // No "Continue to Round of 32" in phase 1.
+    // No "Continue to Round of 32" in phase 1 — knockout is locked for
+    // regular users.
     expect(
       screen.queryByRole('button', { name: /Continue to Round of 32/ })
     ).not.toBeInTheDocument();
@@ -329,7 +326,7 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(screen.getByRole('tab', { name: /Tiebreaker/ })).toBeDisabled();
   });
 
-  it('shows BOTH Save Phase 1 Picks and Continue to Round 32 for super admin on Best 3rds in phase 1', async () => {
+  it('shows BOTH Save Phase 1 Picks and Continue to Round 32 for super admin on Gut Feeling Champion in phase 1', async () => {
     // Super admins may be playing the pool themselves, so they still need
     // the Phase 1 commit action a regular user gets. They also retain the
     // "Continue to Round 32" jump because their phase2 fields are editable
@@ -339,11 +336,13 @@ describe('PredictionsPageContent — stepper navigation', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    await user.click(await screen.findByTestId('fill-champion'));
-    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
-    await user.click(screen.getByTestId('fill-all-groups'));
+    await user.click(await screen.findByTestId('fill-all-groups'));
     await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
     await user.click(screen.getByTestId('fill-all-bundles'));
+    await user.click(
+      screen.getByRole('button', { name: /Continue to Gut Feeling Champion/ })
+    );
+    await user.click(screen.getByTestId('fill-champion'));
 
     expect(screen.getByRole('button', { name: /Save Phase 1 Picks/ })).toBeInTheDocument();
     expect(
@@ -359,11 +358,13 @@ describe('PredictionsPageContent — stepper navigation', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    await user.click(await screen.findByTestId('fill-champion'));
-    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
-    await user.click(screen.getByTestId('fill-all-groups'));
+    await user.click(await screen.findByTestId('fill-all-groups'));
     await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
     await user.click(screen.getByTestId('fill-all-bundles'));
+    await user.click(
+      screen.getByRole('button', { name: /Continue to Gut Feeling Champion/ })
+    );
+    await user.click(screen.getByTestId('fill-champion'));
 
     const saveBtn = screen.getByRole('button', { name: /Save Phase 1 Picks/ });
     expect(saveBtn).toBeDisabled();
@@ -382,6 +383,10 @@ describe('PredictionsPageContent — stepper navigation', () => {
     await user.click(await screen.findByTestId('fill-all-groups'));
     await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
     await user.click(screen.getByTestId('fill-all-bundles'));
+    await user.click(
+      screen.getByRole('button', { name: /Continue to Gut Feeling Champion/ })
+    );
+    await user.click(screen.getByTestId('fill-champion'));
     await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
     // Filling all knockout matches at once satisfies every knockout sub-step.
     await user.click(screen.getByTestId('fill-all-knockout'));
@@ -431,10 +436,6 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(screen.getByRole('tab', { name: /Group Stage/ })).not.toBeDisabled();
     expect(screen.getByRole('tab', { name: /Best 3rds/ })).not.toBeDisabled();
 
-    // Wizard now opens on the Phase 1 Champions Pick step; advance through
-    // it first so the test exercises the locked-Groups Continue.
-    await user.click(screen.getByTestId('fill-champion'));
-    await user.click(screen.getByRole('button', { name: /Continue to Group Stage/ }));
     await user.click(screen.getByTestId('fill-all-groups'));
 
     const continueBtn = screen.getByRole('button', { name: /Continue to Best 3rds/ });
@@ -451,9 +452,6 @@ describe('PredictionsPageContent — autosave', () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     render(<PredictionsPageContent mode="create" />);
 
-    // Wizard now opens on Champion Pick; navigate to Groups before
-    // exercising the group-stage interaction this test cares about.
-    await user.click(await screen.findByRole('tab', { name: /Group Stage/ }));
     await user.click(await screen.findByTestId('fill-one-group-position'));
     expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull();
 
@@ -494,12 +492,8 @@ describe('PredictionsPageContent — autosave', () => {
     );
     configureQueries();
 
-    const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    // Wizard opens on Champion Pick now; switch to Group Stage so the
-    // mocked groups-filled testid is rendered.
-    await user.click(await screen.findByRole('tab', { name: /Group Stage/ }));
     // Draft has 1 group slot + 1 tiebreaker filled (total 2). Server would have 0.
     await waitFor(() => expect(screen.getByTestId('groups-filled')).toHaveTextContent('1'));
     // Progress bar reflects the combined draft state (groups + tiebreaker).
@@ -529,7 +523,6 @@ describe('PredictionsPageContent — autosave', () => {
     );
     configureQueries();
 
-    const user = userEvent.setup();
     render(
       <PredictionsPageContent
         mode="edit"
@@ -548,9 +541,6 @@ describe('PredictionsPageContent — autosave', () => {
       />
     );
 
-    // Wizard opens on Champion Pick; navigate to Groups to see the mocked
-    // groups-filled testid.
-    await user.click(await screen.findByRole('tab', { name: /Group Stage/ }));
     // Server hydration → exactly 1 filled slot. Draft would have been 24.
     await waitFor(() =>
       expect(screen.getByTestId('groups-filled')).toHaveTextContent('1')
@@ -596,15 +586,17 @@ describe('PredictionsPageContent — autosave', () => {
 
     render(<PredictionsPageContent mode="create" />);
 
-    // Wizard starts at Round of 32 in phase 2; navigate to Champion tab
-    // first so we can fill the Phase 1 pick (required for completion),
-    // then walk back through Group Stage → ... → Tiebreaker.
-    await user.click(await screen.findByRole('tab', { name: /Champion/ }));
-    await user.click(await screen.findByTestId('fill-champion'));
-    await user.click(screen.getByRole('tab', { name: /Group Stage/ }));
+    // Wizard starts at Round of 32 in phase 2; navigate back to Group
+    // Stage and walk forward through Best 3rds → Gut Feeling Champion
+    // (Phase 1 fields) → Round of 32 → … → Tiebreaker.
+    await user.click(await screen.findByRole('tab', { name: /Group Stage/ }));
     await user.click(await screen.findByTestId('fill-all-groups'));
     await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
     await user.click(screen.getByTestId('fill-all-bundles'));
+    await user.click(
+      screen.getByRole('button', { name: /Continue to Gut Feeling Champion/ })
+    );
+    await user.click(screen.getByTestId('fill-champion'));
     await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
     await user.click(screen.getByTestId('fill-all-knockout'));
     // Walk through R16 → QF → SF → Final → 3rd → Tiebreaker via Continue.

--- a/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
+++ b/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
@@ -13,6 +13,7 @@ const entries: LeaderboardEntry[] = [
     groupPoints: 90,
     advancerPoints: 0,
     knockoutPoints: 110,
+    championPickPoints: 0,
   },
   {
     rank: 2,
@@ -24,6 +25,7 @@ const entries: LeaderboardEntry[] = [
     groupPoints: 80,
     advancerPoints: 0,
     knockoutPoints: 100,
+    championPickPoints: 0,
   },
   {
     rank: 3,
@@ -35,6 +37,7 @@ const entries: LeaderboardEntry[] = [
     groupPoints: 75,
     advancerPoints: 0,
     knockoutPoints: 95,
+    championPickPoints: 0,
   },
 ];
 

--- a/frontend/src/components/predictions/ChampionPickForm.tsx
+++ b/frontend/src/components/predictions/ChampionPickForm.tsx
@@ -53,7 +53,7 @@ export function ChampionPickForm({
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold">Phase 1 Champions Pick</h3>
+        <h3 className="text-lg font-semibold">Your Gut Feeling Champion</h3>
         <Badge variant={filled ? 'default' : 'secondary'} className={cn(filled && 'bg-green-600')}>
           {filled ? (
             <>

--- a/frontend/src/components/predictions/ChampionPickForm.tsx
+++ b/frontend/src/components/predictions/ChampionPickForm.tsx
@@ -111,7 +111,14 @@ export function ChampionPickForm({
             <SelectTrigger data-testid="champion-pick-select">
               <SelectValue placeholder="Pick a team" />
             </SelectTrigger>
-            <SelectContent>
+            {/*
+              48 teams + 12 group labels make this list far too long for the
+              default popper mode (which pins the Viewport to the trigger's
+              height and forces chevron-scroll). `item-aligned` opens the
+              dropdown next to the trigger with native browser scrolling, so
+              users can wheel/touch/swipe through all 12 groups.
+            */}
+            <SelectContent position="item-aligned">
               {teamsByGroup.map(([groupLetter, groupTeams]) => (
                 <SelectGroup key={groupLetter}>
                   <SelectLabel>Group {groupLetter}</SelectLabel>

--- a/frontend/src/components/predictions/ChampionPickForm.tsx
+++ b/frontend/src/components/predictions/ChampionPickForm.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import * as React from 'react';
+import { CheckCircle2, Circle, Trophy } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { TeamFlag } from '@/components/shared/TeamFlag';
+import { SCORING } from '@/lib/constants';
+import { cn } from '@/lib/utils';
+import type { Team } from '@/types/tournament';
+
+export interface ChampionPickFormProps {
+  teams: Team[];
+  value: string | null;
+  onChange: (teamId: string | null) => void;
+  disabled?: boolean;
+}
+
+export function ChampionPickForm({
+  teams,
+  value,
+  onChange,
+  disabled = false,
+}: ChampionPickFormProps) {
+  const filled = !!value;
+  const pickedTeam = filled ? (teams.find((t) => t.id === value) ?? null) : null;
+
+  // Group all 48 teams by their group letter so the 48-item dropdown stays
+  // scannable. Groups are sorted alphabetically (A–L).
+  const teamsByGroup = React.useMemo(() => {
+    const map = new Map<string, Team[]>();
+    for (const team of teams) {
+      const list = map.get(team.group) ?? [];
+      list.push(team);
+      map.set(team.group, list);
+    }
+    for (const list of map.values()) {
+      list.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [teams]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Phase 1 Champions Pick</h3>
+        <Badge variant={filled ? 'default' : 'secondary'} className={cn(filled && 'bg-green-600')}>
+          {filled ? (
+            <>
+              <CheckCircle2 className="mr-1 h-3 w-3" />
+              Set
+            </>
+          ) : (
+            <>
+              <Circle className="mr-1 h-3 w-3" />
+              Not picked
+            </>
+          )}
+        </Badge>
+      </div>
+
+      <details className="group bg-muted/40 rounded-md border px-4 py-3 open:pb-4" open>
+        <summary className="cursor-pointer list-none text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="text-muted-foreground transition-transform group-open:rotate-90">▶</span>
+            How is this scored?
+          </span>
+        </summary>
+        <div className="text-muted-foreground mt-3 space-y-2 text-sm">
+          <p>
+            Pick one of the 48 teams as your tournament champion. This is your Phase 1
+            commitment — it locks when Phase 1 ends and cannot be changed afterward.
+          </p>
+          <p>
+            <strong>Scoring:</strong> +{SCORING.championPickBonus} bonus points if your pick
+            matches the actual champion (winner of the Final). This is independent of your
+            bracket Final pick — you can pick the same team for both, or split your bet.
+          </p>
+        </div>
+      </details>
+
+      <Card
+        className={cn(
+          'mx-auto max-w-md',
+          filled && 'border-green-500/50 bg-green-500/5 dark:bg-green-500/10'
+        )}
+        data-testid="champion-pick-card"
+      >
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Trophy className="h-4 w-4 text-amber-500" aria-hidden />
+            Your champion
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Select
+            value={value ?? ''}
+            onValueChange={(next) => onChange(next || null)}
+            disabled={disabled}
+          >
+            <SelectTrigger data-testid="champion-pick-select">
+              <SelectValue placeholder="Pick a team" />
+            </SelectTrigger>
+            <SelectContent>
+              {teamsByGroup.map(([groupLetter, groupTeams]) => (
+                <SelectGroup key={groupLetter}>
+                  <SelectLabel>Group {groupLetter}</SelectLabel>
+                  {groupTeams.map((team) => (
+                    <SelectItem key={team.id} value={team.id}>
+                      <span className="flex items-center gap-2">
+                        <TeamFlag code={team.code} />
+                        <span>{team.name}</span>
+                        <span className="text-muted-foreground text-xs">({team.code})</span>
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              ))}
+            </SelectContent>
+          </Select>
+          {pickedTeam && (
+            <p className="text-muted-foreground text-xs">
+              Your champion:{' '}
+              <span className="text-foreground font-medium">{pickedTeam.name}</span>{' '}
+              from Group {pickedTeam.group}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/predictions/__tests__/ChampionPickForm.test.tsx
+++ b/frontend/src/components/predictions/__tests__/ChampionPickForm.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { ChampionPickForm } from '../ChampionPickForm';
+import type { Team } from '@/types/tournament';
+
+const sampleTeams: Team[] = [
+  { id: 'arg', name: 'Argentina', code: 'ARG', group: 'A' },
+  { id: 'bra', name: 'Brazil', code: 'BRA', group: 'B' },
+  { id: 'fra', name: 'France', code: 'FRA', group: 'A' },
+  { id: 'ger', name: 'Germany', code: 'GER', group: 'C' },
+];
+
+describe('ChampionPickForm', () => {
+  it('renders the section heading and trigger', () => {
+    render(
+      <ChampionPickForm teams={sampleTeams} value={null} onChange={jest.fn()} />
+    );
+    expect(screen.getByText('Phase 1 Champions Pick')).toBeInTheDocument();
+    expect(screen.getByTestId('champion-pick-select')).toBeInTheDocument();
+  });
+
+  it('shows "Not picked" badge when value is null', () => {
+    render(
+      <ChampionPickForm teams={sampleTeams} value={null} onChange={jest.fn()} />
+    );
+    expect(screen.getByText('Not picked')).toBeInTheDocument();
+  });
+
+  it('shows "Set" badge and the picked team summary when value is set', () => {
+    render(
+      <ChampionPickForm teams={sampleTeams} value="arg" onChange={jest.fn()} />
+    );
+    expect(screen.getByText('Set')).toBeInTheDocument();
+    expect(screen.getByText(/Your champion:/i)).toBeInTheDocument();
+    // Argentina renders in both the Select trigger value and the summary line,
+    // so assert by count rather than uniqueness.
+    expect(screen.getAllByText('Argentina').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/from Group A/)).toBeInTheDocument();
+  });
+
+  it('disables the Select when disabled prop is true', () => {
+    render(
+      <ChampionPickForm
+        teams={sampleTeams}
+        value={null}
+        onChange={jest.fn()}
+        disabled
+      />
+    );
+    expect(screen.getByTestId('champion-pick-select')).toBeDisabled();
+  });
+});

--- a/frontend/src/components/predictions/__tests__/ChampionPickForm.test.tsx
+++ b/frontend/src/components/predictions/__tests__/ChampionPickForm.test.tsx
@@ -14,7 +14,7 @@ describe('ChampionPickForm', () => {
     render(
       <ChampionPickForm teams={sampleTeams} value={null} onChange={jest.fn()} />
     );
-    expect(screen.getByText('Phase 1 Champions Pick')).toBeInTheDocument();
+    expect(screen.getByText('Your Gut Feeling Champion')).toBeInTheDocument();
     expect(screen.getByTestId('champion-pick-select')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -80,8 +80,14 @@ const SelectContent = React.forwardRef<
       <SelectPrimitive.Viewport
         className={cn(
           'p-1',
+          // Radix popper mode ships with `h-[var(--radix-select-trigger-height)]`
+          // on the Viewport, which pins it to the trigger's height (~36px) and
+          // silently clips long lists — items past the first one cannot be
+          // scrolled into view. Drop the height so the Viewport sizes to its
+          // content and the Content's `max-h-[--radix-select-content-available-height]`
+          // + `overflow-y-auto` handles scrolling naturally.
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+            'w-full min-w-[var(--radix-select-trigger-width)]'
         )}
       >
         {children}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -80,14 +80,8 @@ const SelectContent = React.forwardRef<
       <SelectPrimitive.Viewport
         className={cn(
           'p-1',
-          // Radix popper mode ships with `h-[var(--radix-select-trigger-height)]`
-          // on the Viewport, which pins it to the trigger's height (~36px) and
-          // silently clips long lists — items past the first one cannot be
-          // scrolled into view. Drop the height so the Viewport sizes to its
-          // content and the Content's `max-h-[--radix-select-content-available-height]`
-          // + `overflow-y-auto` handles scrolling naturally.
           position === 'popper' &&
-            'w-full min-w-[var(--radix-select-trigger-width)]'
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
         )}
       >
         {children}

--- a/frontend/src/lib/__tests__/constants.test.ts
+++ b/frontend/src/lib/__tests__/constants.test.ts
@@ -18,9 +18,12 @@ describe('USERNAME_REGEX', () => {
 });
 
 describe('SCORING / TOURNAMENT_CONFIG', () => {
-  it('max total points = group + advancer + knockout', () => {
+  it('max total points = group + advancer + knockout + champion pick', () => {
     expect(
-      SCORING.maxGroupPoints + SCORING.maxAdvancerPoints + SCORING.maxKnockoutPoints
+      SCORING.maxGroupPoints +
+        SCORING.maxAdvancerPoints +
+        SCORING.maxKnockoutPoints +
+        SCORING.championPickBonus
     ).toBe(SCORING.maxTotalPoints);
   });
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -13,11 +13,14 @@ export const TOURNAMENT_CONFIG = {
 // Advancers: 8 ranked 3rd-place picks × 1.25 (set + rank) = 10 max.
 // Knockout: per-team correct-side maxes — R16 16×5 + QF 8×6 + SF 4×8 + Final 2×10 = 180 — plus
 // flat bonuses (champion 15, 3rd-place winner 5) = 200.
+// Phase 1 Champions Pick: +5 if `predictions.champion_team_id` matches the actual M32 winner
+// (independent of the bracket Final pick).
 export const SCORING = {
   maxGroupPoints: 74,
   maxAdvancerPoints: 10,
   maxKnockoutPoints: 200,
-  maxTotalPoints: 284,
+  championPickBonus: 5,
+  maxTotalPoints: 289,
 } as const;
 
 /**

--- a/frontend/src/types/tournament.ts
+++ b/frontend/src/types/tournament.ts
@@ -72,12 +72,14 @@ export interface Predictions {
   knockout: KnockoutMatchPrediction[];
   advancers: AdvancerPrediction[];
   totalGoals: number | null;
+  championTeamId: string | null;
 }
 
 export interface PredictionSummary {
   id: string;
   name: string;
   totalGoals: number | null;
+  championTeamId: string | null;
   submittedAt: string | null;
   isPaid: boolean;
   paidAt: string | null;
@@ -98,6 +100,7 @@ export interface LeaderboardEntry {
   groupPoints: number;
   advancerPoints: number;
   knockoutPoints: number;
+  championPickPoints: number;
 }
 
 export interface LeaderboardRankMatch {

--- a/supabase/migrations/0036_champion_pick.sql
+++ b/supabase/migrations/0036_champion_pick.sql
@@ -1,0 +1,864 @@
+-- Phase 1 Champions Pick.
+--
+-- Adds `predictions.champion_team_id` — a single team_id the user nominates as
+-- their tournament champion during Phase 1. Awards +5 bonus points when the
+-- pick matches the actual M32 winner (independent of the bracket Final pick).
+--
+-- The pick is treated as a Phase 1 field: it is writable only during 'phase1'
+-- (same gating as `groups` + `advancers`) and is required when creating a new
+-- prediction. Once `phase1_locked` flips, it becomes immutable.
+--
+-- Migration is purely additive — new nullable column, four `create or replace`
+-- function bodies, and one `create or replace` on `get_public_prediction` to
+-- surface the pick alongside groups/knockout/advancers. Existing prediction
+-- rows keep `champion_team_id = null` and simply score 0 bonus until the owner
+-- edits the prediction (while phase1 is still open) to add a pick.
+
+-- ========== schema ==========
+
+alter table public.predictions
+    add column if not exists champion_team_id text references public.teams(id);
+
+create index if not exists predictions_champion_team_id_idx
+    on public.predictions(champion_team_id);
+
+-- ========== submit_predictions ==========
+-- Replaces 0034 body. Adds:
+--   * v_champion_team_id extraction
+--   * required-on-create check
+--   * persist on insert + on update during phase1 only
+
+create or replace function public.submit_predictions(payload jsonb)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid := (payload->>'tournament_id')::uuid;
+    v_prediction_id uuid := nullif(payload->>'prediction_id', '')::uuid;
+    v_prediction_name text := nullif(trim(payload->>'prediction_name'), '');
+    v_total_goals int := nullif(payload->>'total_goals', '')::int;
+    v_champion_team_id text := nullif(payload->>'champion_team_id', '');
+    v_has_champion_key boolean := payload ? 'champion_team_id';
+    v_mark_submitted boolean := coalesce((payload->>'submit')::boolean, true);
+    v_user uuid := auth.uid();
+    v_phase text;
+    v_has_phase1_fields boolean;
+    v_has_phase2_fields boolean;
+    v_group jsonb;
+    v_match jsonb;
+    v_advancer jsonb;
+    v_rank int;
+    v_team_id text;
+    v_seen_ranks int[] := '{}';
+    v_seen_teams text[] := '{}';
+    v_valid_thirds text[];
+    v_group_id text;
+    v_team_ids text[];
+    v_mismatched_team text;
+begin
+    if v_user is null then
+        raise exception 'not authenticated';
+    end if;
+
+    v_phase := public.tournament_phase(v_tournament_id);
+
+    if v_prediction_id is null and v_phase <> 'phase1' then
+        raise exception 'phase 1 ended; new predictions cannot be created'
+            using errcode = 'P0001';
+    end if;
+
+    v_has_phase1_fields := (payload ? 'groups' and jsonb_array_length(payload->'groups') > 0)
+        or (payload ? 'advancers' and jsonb_array_length(payload->'advancers') > 0)
+        or v_has_champion_key;
+    v_has_phase2_fields := (payload ? 'knockout' and jsonb_array_length(payload->'knockout') > 0)
+        or (v_total_goals is not null);
+
+    if v_phase = 'phase1_locked' or v_phase = 'phase2_locked' then
+        raise exception 'predictions are locked';
+    end if;
+
+    if v_phase = 'phase1' and v_has_phase2_fields then
+        raise exception 'phase 1 only fields allowed' using errcode = 'P0001';
+    end if;
+    if v_phase = 'phase2_open' and v_has_phase1_fields then
+        raise exception 'phase 1 ended; group + advancer picks are frozen'
+            using errcode = 'P0001';
+    end if;
+
+    if v_prediction_id is null then
+        if v_prediction_name is null then
+            raise exception 'prediction name required' using errcode = 'P0001';
+        end if;
+        if v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            insert into public.predictions (
+                user_id, tournament_id, prediction_name, total_goals,
+                champion_team_id, submitted_at
+            )
+            values (
+                v_user,
+                v_tournament_id,
+                v_prediction_name,
+                v_total_goals,
+                v_champion_team_id,
+                case when v_mark_submitted then now() else null end
+            )
+            returning id into v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    else
+        perform 1 from public.predictions
+            where id = v_prediction_id and user_id = v_user and tournament_id = v_tournament_id;
+        if not found then
+            raise exception 'prediction not found' using errcode = 'P0001';
+        end if;
+
+        if v_has_champion_key and v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.predictions
+               set prediction_name = coalesce(v_prediction_name, prediction_name),
+                   total_goals = case when v_phase = 'phase2_open' then v_total_goals else total_goals end,
+                   champion_team_id = case
+                       when v_phase = 'phase1' and v_has_champion_key then v_champion_team_id
+                       else champion_team_id
+                   end,
+                   submitted_at = case when v_mark_submitted then now() else submitted_at end
+             where id = v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    if v_phase = 'phase1' then
+        delete from public.advancer_predictions where prediction_id = v_prediction_id;
+        delete from public.group_predictions where prediction_id = v_prediction_id;
+
+        for v_group in select * from jsonb_array_elements(coalesce(payload->'groups', '[]'::jsonb))
+        loop
+            v_group_id := v_group->>'group_id';
+            v_team_ids := array_remove(array[
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            ], null);
+
+            select t.id into v_mismatched_team
+              from public.teams t
+             where t.id = any(v_team_ids) and t.group_id is distinct from v_group_id
+             limit 1;
+
+            if v_mismatched_team is not null then
+                raise exception 'team % does not belong to group %', v_mismatched_team, v_group_id
+                    using errcode = 'P0001';
+            end if;
+
+            insert into public.group_predictions (
+                prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id
+            ) values (
+                v_prediction_id,
+                v_group_id,
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            );
+        end loop;
+
+        select array_agg(third_team_id) into v_valid_thirds
+          from public.group_predictions
+         where prediction_id = v_prediction_id
+           and third_team_id is not null;
+
+        for v_advancer in select * from jsonb_array_elements(coalesce(payload->'advancers', '[]'::jsonb))
+        loop
+            v_rank := nullif(v_advancer->>'rank', '')::int;
+            v_team_id := nullif(v_advancer->>'team_id', '');
+            if v_team_id is null then
+                continue;
+            end if;
+            if v_rank is null or v_rank < 1 or v_rank > 8 then
+                raise exception 'advancer rank must be 1..8 (got %)', v_rank using errcode = 'P0001';
+            end if;
+            if v_rank = any(v_seen_ranks) then
+                raise exception 'duplicate advancer rank %', v_rank using errcode = 'P0001';
+            end if;
+            if v_team_id = any(v_seen_teams) then
+                raise exception 'duplicate advancer team' using errcode = 'P0001';
+            end if;
+            if v_valid_thirds is null or not (v_team_id = any(v_valid_thirds)) then
+                raise exception 'advancer team % not in your 3rd-place picks', v_team_id
+                    using errcode = 'P0001';
+            end if;
+            v_seen_ranks := array_append(v_seen_ranks, v_rank);
+            v_seen_teams := array_append(v_seen_teams, v_team_id);
+
+            insert into public.advancer_predictions (prediction_id, rank, team_id)
+            values (v_prediction_id, v_rank, v_team_id);
+        end loop;
+    elsif v_phase = 'phase2_open' then
+        delete from public.knockout_predictions where prediction_id = v_prediction_id;
+        for v_match in select * from jsonb_array_elements(coalesce(payload->'knockout', '[]'::jsonb))
+        loop
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+            values (
+                v_prediction_id,
+                v_match->>'match_id',
+                nullif(v_match->>'winner', '')
+            );
+        end loop;
+    end if;
+
+    return v_prediction_id;
+end;
+$$;
+
+-- ========== admin_submit_predictions ==========
+
+create or replace function public.admin_submit_predictions(p_user_id uuid, payload jsonb)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid := (payload->>'tournament_id')::uuid;
+    v_prediction_id uuid := nullif(payload->>'prediction_id', '')::uuid;
+    v_prediction_name text := nullif(trim(payload->>'prediction_name'), '');
+    v_total_goals int := nullif(payload->>'total_goals', '')::int;
+    v_champion_team_id text := nullif(payload->>'champion_team_id', '');
+    v_has_champion_key boolean := payload ? 'champion_team_id';
+    v_mark_submitted boolean := coalesce((payload->>'submit')::boolean, true);
+    v_phase text;
+    v_super boolean;
+    v_group jsonb;
+    v_match jsonb;
+    v_advancer jsonb;
+    v_rank int;
+    v_team_id text;
+    v_seen_ranks int[] := '{}';
+    v_seen_teams text[] := '{}';
+    v_valid_thirds text[];
+    v_group_id text;
+    v_team_ids text[];
+    v_mismatched_team text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_user_id is null or v_tournament_id is null then
+        raise exception 'user_id and tournament_id are required' using errcode = 'P0001';
+    end if;
+
+    v_super := public.is_super_admin();
+    v_phase := public.tournament_phase(v_tournament_id);
+
+    if not v_super then
+        if v_prediction_id is null and v_phase <> 'phase1' then
+            raise exception 'phase 1 ended; new predictions cannot be created'
+                using errcode = 'P0001';
+        end if;
+        if v_phase = 'phase1_locked' or v_phase = 'phase2_locked' then
+            raise exception 'predictions are locked';
+        end if;
+    end if;
+
+    if v_prediction_id is null then
+        if v_prediction_name is null then
+            raise exception 'prediction name required' using errcode = 'P0001';
+        end if;
+        if v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            insert into public.predictions (
+                user_id, tournament_id, prediction_name, total_goals,
+                champion_team_id, submitted_at
+            )
+            values (
+                p_user_id,
+                v_tournament_id,
+                v_prediction_name,
+                v_total_goals,
+                v_champion_team_id,
+                case when v_mark_submitted then now() else null end
+            )
+            returning id into v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    else
+        perform 1 from public.predictions
+            where id = v_prediction_id and user_id = p_user_id and tournament_id = v_tournament_id;
+        if not found then
+            raise exception 'prediction not found' using errcode = 'P0001';
+        end if;
+
+        if v_has_champion_key and v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.predictions
+               set prediction_name = coalesce(v_prediction_name, prediction_name),
+                   total_goals = v_total_goals,
+                   champion_team_id = case
+                       when v_has_champion_key and (v_super or v_phase = 'phase1')
+                           then v_champion_team_id
+                       else champion_team_id
+                   end,
+                   submitted_at = case when v_mark_submitted then now() else submitted_at end
+             where id = v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    if v_super or v_phase = 'phase1' then
+        delete from public.advancer_predictions where prediction_id = v_prediction_id;
+        delete from public.group_predictions where prediction_id = v_prediction_id;
+
+        for v_group in select * from jsonb_array_elements(coalesce(payload->'groups', '[]'::jsonb))
+        loop
+            v_group_id := v_group->>'group_id';
+            v_team_ids := array_remove(array[
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            ], null);
+
+            select t.id into v_mismatched_team
+              from public.teams t
+             where t.id = any(v_team_ids) and t.group_id is distinct from v_group_id
+             limit 1;
+
+            if v_mismatched_team is not null then
+                raise exception 'team % does not belong to group %', v_mismatched_team, v_group_id
+                    using errcode = 'P0001';
+            end if;
+
+            insert into public.group_predictions (
+                prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id
+            ) values (
+                v_prediction_id,
+                v_group_id,
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            );
+        end loop;
+
+        select array_agg(third_team_id) into v_valid_thirds
+          from public.group_predictions
+         where prediction_id = v_prediction_id
+           and third_team_id is not null;
+
+        for v_advancer in select * from jsonb_array_elements(coalesce(payload->'advancers', '[]'::jsonb))
+        loop
+            v_rank := nullif(v_advancer->>'rank', '')::int;
+            v_team_id := nullif(v_advancer->>'team_id', '');
+            if v_team_id is null then
+                continue;
+            end if;
+            if v_rank is null or v_rank < 1 or v_rank > 8 then
+                raise exception 'advancer rank must be 1..8 (got %)', v_rank using errcode = 'P0001';
+            end if;
+            if v_rank = any(v_seen_ranks) then
+                raise exception 'duplicate advancer rank %', v_rank using errcode = 'P0001';
+            end if;
+            if v_team_id = any(v_seen_teams) then
+                raise exception 'duplicate advancer team' using errcode = 'P0001';
+            end if;
+            if v_valid_thirds is null or not (v_team_id = any(v_valid_thirds)) then
+                raise exception 'advancer team % not in your 3rd-place picks', v_team_id
+                    using errcode = 'P0001';
+            end if;
+            v_seen_ranks := array_append(v_seen_ranks, v_rank);
+            v_seen_teams := array_append(v_seen_teams, v_team_id);
+
+            insert into public.advancer_predictions (prediction_id, rank, team_id)
+            values (v_prediction_id, v_rank, v_team_id);
+        end loop;
+    end if;
+
+    if v_super or v_phase = 'phase2_open' then
+        delete from public.knockout_predictions where prediction_id = v_prediction_id;
+        for v_match in select * from jsonb_array_elements(coalesce(payload->'knockout', '[]'::jsonb))
+        loop
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+            values (
+                v_prediction_id,
+                v_match->>'match_id',
+                nullif(v_match->>'winner', '')
+            );
+        end loop;
+    end if;
+
+    return v_prediction_id;
+end;
+$$;
+
+grant execute on function public.admin_submit_predictions(uuid, jsonb) to authenticated;
+
+-- ========== get_leaderboard ==========
+-- Adds a `champion_pick_score` CTE that awards 5 when predictions.champion_team_id
+-- equals the M32 winner. Folded into knockout_scores (so total `points`
+-- accounts for it) and surfaced as a new output column `champion_pick_points`.
+--
+-- Postgres treats a new OUT column as a return-type change, so the function
+-- must be dropped before re-creation.
+
+drop function if exists public.get_leaderboard(uuid, int, int);
+
+create or replace function public.get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    champion_pick_points int,
+    total_goals int,
+    total_count bigint
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 8 else 6 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 4
+                    when gp.first_team_id = gs.first_team_id or gp.second_team_id = gs.second_team_id
+                        then 3
+                    when gp.first_team_id = gs.second_team_id or gp.second_team_id = gs.first_team_id
+                        then 2
+                    else 0
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 1.25
+                    when ta_team.team_id is not null then 1.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    r16_scores as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_32', 5, 3)),
+    qf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_16', 6, 3)),
+    sf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'quarter_finals', 8, 4)),
+    f_scores   as (select * from public.knockout_round_scores(p_tournament_id, 'semi_finals', 10, 5)),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 15 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M32'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 5 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M31'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M31'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id then 5
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(r16.round_points, 0)
+             + coalesce(qf.round_points, 0)
+             + coalesce(sf.round_points, 0)
+             + coalesce(fs.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join r16_scores r16 on r16.prediction_id = p.id
+        left join qf_scores qf on qf.prediction_id = p.id
+        left join sf_scores sf on sf.prediction_id = p.id
+        left join f_scores fs on fs.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            pr.username::text as username,
+            coalesce(gsc.group_points, 0) as group_points,
+            coalesce(asc_.advancer_points, 0)::numeric as advancer_points,
+            coalesce(ksc.knockout_points, 0) as knockout_points,
+            coalesce(ksc.champion_pick_points, 0) as champion_pick_points,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            p.total_goals,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        join public.profiles pr on pr.id = p.user_id
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        rank,
+        prediction_id,
+        prediction_name,
+        username,
+        points,
+        group_points,
+        advancer_points,
+        knockout_points,
+        champion_pick_points,
+        total_goals,
+        count(*) over () as total_count
+    from ranked
+    order by rank
+    offset greatest(p_page - 1, 0) * greatest(p_page_size, 1)
+    limit greatest(p_page_size, 1);
+$$;
+
+grant execute on function public.get_leaderboard(uuid, int, int) to anon, authenticated;
+
+-- ========== get_leaderboard_rank ==========
+
+create or replace function public.get_leaderboard_rank(
+    p_tournament_id uuid,
+    p_user_id uuid,
+    p_page_size int default 25
+)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    rank int,
+    page int,
+    points numeric
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 8 else 6 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 4
+                    when gp.first_team_id = gs.first_team_id or gp.second_team_id = gs.second_team_id
+                        then 3
+                    when gp.first_team_id = gs.second_team_id or gp.second_team_id = gs.first_team_id
+                        then 2
+                    else 0
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 1.25
+                    when ta_team.team_id is not null then 1.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    r16_scores as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_32', 5, 3)),
+    qf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'round_of_16', 6, 3)),
+    sf_scores  as (select * from public.knockout_round_scores(p_tournament_id, 'quarter_finals', 8, 4)),
+    f_scores   as (select * from public.knockout_round_scores(p_tournament_id, 'semi_finals', 10, 5)),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 15 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M32'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id then 5 else 0 end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M31'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M31'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id then 5
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(r16.round_points, 0)
+             + coalesce(qf.round_points, 0)
+             + coalesce(sf.round_points, 0)
+             + coalesce(fs.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join r16_scores r16 on r16.prediction_id = p.id
+        left join qf_scores qf on qf.prediction_id = p.id
+        left join sf_scores sf on sf.prediction_id = p.id
+        left join f_scores fs on fs.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            p.user_id,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        prediction_id,
+        prediction_name,
+        rank,
+        ((rank - 1) / greatest(p_page_size, 1) + 1)::int as page,
+        points
+    from ranked
+    where user_id = p_user_id
+    order by rank;
+$$;
+
+grant execute on function public.get_leaderboard_rank(uuid, uuid, int) to anon, authenticated;
+
+-- ========== get_public_prediction ==========
+-- Expose champion_team_id alongside the existing groups/knockout/advancers
+-- payload so the public bracket-detail view can render the user's pick.
+-- Adding an OUT column is a return-type change → drop first.
+
+drop function if exists public.get_public_prediction(uuid);
+
+create or replace function public.get_public_prediction(p_prediction_id uuid)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    total_goals int,
+    champion_team_id text,
+    submitted_at timestamptz,
+    groups jsonb,
+    knockout jsonb,
+    advancers jsonb
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with elig as (
+        select p.id, p.user_id, p.tournament_id, p.prediction_name, p.total_goals,
+               p.champion_team_id, p.submitted_at
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        join public.tournaments t on t.id = p.tournament_id
+        where p.id = p_prediction_id
+          and auth.uid() is not null
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and tp.paid_at <= t.lock_time
+    )
+    select
+        e.id as prediction_id,
+        e.prediction_name::text,
+        pr.username::text as username,
+        e.total_goals,
+        e.champion_team_id,
+        e.submitted_at,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'group_id', gp.group_id,
+                'first_team_id', gp.first_team_id,
+                'second_team_id', gp.second_team_id,
+                'third_team_id', gp.third_team_id,
+                'fourth_team_id', gp.fourth_team_id
+            ) order by gp.group_id)
+            from public.group_predictions gp
+            where gp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as groups,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'match_id', kp.match_id,
+                'winner_team_id', kp.winner_team_id
+            ) order by kp.match_id)
+            from public.knockout_predictions kp
+            where kp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as knockout,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'rank', ap.rank,
+                'team_id', ap.team_id
+            ) order by ap.rank)
+            from public.advancer_predictions ap
+            where ap.prediction_id = e.id),
+            '[]'::jsonb
+        ) as advancers
+    from elig e
+    join public.profiles pr on pr.id = e.user_id;
+$$;
+
+grant execute on function public.get_public_prediction(uuid) to authenticated;


### PR DESCRIPTION
## Summary
- New Phase 1 Champions Pick: one team selected from the 48 as the user's predicted tournament champion. Collected as the **first wizard step** via a grouped (A–L) shadcn Select. Required at create time, writable only during `phase1`, frozen at `phase1_locked`.
- **+5 bonus points** when `predictions.champion_team_id` equals the actual M32 winner — independent of the existing +15 bracket Final scoring (a correct gut pick + correct bracket can stack to +20). Bonus surfaces as a new `champion_pick_points` column in `get_leaderboard` and is folded into the total `points` used for ranking.
- Migration `0036_champion_pick.sql` is purely additive: nullable `champion_team_id` column (existing rows score 0 bonus until edited), index, and `create or replace` on `submit_predictions`, `admin_submit_predictions`, `get_leaderboard`, `get_leaderboard_rank`, and `get_public_prediction`. Idempotent re-runs are safe.
- CLAUDE.md bumped to **3.3.0**; Grand total max now **289** (74 group + 10 advancer + 200 knockout + 5 champion pick).

## Test plan
- [x] `npm test` — 325 / 325 pass (includes 4 new ChampionPickForm tests + extended predictions & admin route tests for the new field and the `champion pick required → 400` mapping).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean (no new warnings).
- [x] Migration applied locally against `supabase_db_wc2026`: new column + FK + index present; `get_leaderboard` returns the new `champion_pick_points` column; `get_public_prediction` returns `champion_team_id`.
- [ ] Manual UI smoke: create new prediction → first step is "Phase 1 Champions Pick" with grouped Select; Continue disabled until a team is picked; advancing through Groups → Best 3rds → Knockout → Tiebreaker still works.
- [ ] Manual UI smoke: edit existing prediction in Phase 1 → champion pick is hydrated from server; changing + saving persists.
- [ ] Manual scoring sanity: insert `knockout_results` row for `M32` with a known winner; verify predictions whose `champion_team_id` matches receive `champion_pick_points = 5` and 5 higher total.
- [ ] Admin path: `/admin/users/[id]/predictions/[predictionId]` allows editing the champion pick (super-admin bypasses lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)