### PR TITLE
docs(rules): document Gut Feeling Champion scoring

### DIFF
--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -52,6 +52,13 @@ export default function RulesPage() {
                   tournament-wide lock time.
                 </li>
                 <li>
+                  <span className="text-foreground font-semibold">Gut Feeling Champion.</span>{' '}
+                  Phase 1 ends with a single &ldquo;gut-feeling&rdquo; pick — one team you call
+                  to win the whole thing. It&apos;s required to submit, locked once Phase 1
+                  closes, and scored independently of your bracket Final pick (so both can
+                  pay out). See <span className="font-semibold">Scoring Breakdown</span> below.
+                </li>
+                <li>
                   <span className="text-foreground font-semibold">
                     Independently scored.
                   </span>{' '}

--- a/frontend/src/components/marketing/ScoringBreakdown.tsx
+++ b/frontend/src/components/marketing/ScoringBreakdown.tsx
@@ -1,4 +1,4 @@
-import { Trophy, Users, Target } from 'lucide-react';
+import { Sparkles, Target, Trophy, Users } from 'lucide-react';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { SCORING, TOURNAMENT_CONFIG } from '@/lib/constants';
@@ -168,6 +168,58 @@ export function ScoringBreakdown() {
               <div className="flex items-center justify-between font-semibold">
                 <span>Maximum Advancer Points</span>
                 <span className="text-primary">{SCORING.maxAdvancerPoints} pts</span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles className="text-primary h-5 w-5" />
+            Gut Feeling Champion
+            <span className="bg-muted text-muted-foreground ml-2 rounded-full px-2 py-0.5 text-xs font-medium">
+              Phase 1
+            </span>
+          </CardTitle>
+          <CardDescription>
+            Lock in one team — from any of the {TOURNAMENT_CONFIG.totalTeams} — as your tournament
+            champion before Phase 1 closes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Your pick wins the World Cup Final</span>
+              <span className="font-semibold whitespace-nowrap">
+                +{SCORING.championPickBonus} pts
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Anything else</span>
+              <span className="font-semibold">+0 pts</span>
+            </div>
+            <div className="bg-muted/50 rounded-md p-3 text-xs">
+              <span className="font-semibold">Independent of your bracket.</span>{' '}
+              <span className="text-muted-foreground">
+                This is a separate gut-feeling call from your bracket Final pick. If both end up
+                right, you get the full <span className="font-semibold">+15</span> bracket champion
+                bonus <span className="italic">and</span> the{' '}
+                <span className="font-semibold">+{SCORING.championPickBonus}</span> gut bonus.
+              </span>
+            </div>
+            <div className="bg-muted/50 rounded-md p-3 text-xs">
+              <span className="font-semibold">Locked at Phase 1.</span>{' '}
+              <span className="text-muted-foreground">
+                Required to submit a prediction. Once Phase 1 ends, the pick is frozen — no
+                changes even if your bracket Final pick is still editable.
+              </span>
+            </div>
+            <div className="border-t pt-3">
+              <div className="flex items-center justify-between font-semibold">
+                <span>Maximum Champion Pick Points</span>
+                <span className="text-primary">+{SCORING.championPickBonus} pts</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Surfaces the Phase 1 Gut Feeling Champion in the public **/rules** page so players actually see the new option before submitting.

- **ScoringBreakdown** — new card between Best 3rds and the Tiebreaker total summary covering: +5 if the pick wins the Final, independence from the bracket Final pick (correct gut + correct bracket stacks to +20 total champion-related bonus), and the Phase 1 lock.
- **/rules → How predictions work** — new bullet describing the pick is required at submit, locked at end of Phase 1, and scored separately.

## Test plan
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean (no new warnings).
- [x] `npm test` — 325 / 325 pass.
- [ ] Manual: visit `/rules` and confirm the new card renders between Best 3rds and the Maximum Total Points summary, and the bullet is in the right place under "How predictions work".

🤖 Generated with [Claude Code](https://claude.com/claude-code)