### PR TITLE
feat(admin): show user email in admin user views

### DIFF
--- a/frontend/src/app/admin/users/AdminUsersList.tsx
+++ b/frontend/src/app/admin/users/AdminUsersList.tsx
@@ -36,6 +36,7 @@ import { EMAIL_REGEX, PASSWORD_MIN_LENGTH, USERNAME_REGEX } from '@/lib/constant
 interface AdminUser {
   id: string;
   username: string;
+  email: string | null;
   isAdmin: boolean;
   isSuperAdmin: boolean;
   predictionCount: number;
@@ -483,6 +484,20 @@ function EditUserDialog({
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="edit-email">Email</Label>
+            <Input
+              id="edit-email"
+              type="email"
+              value={target?.email ?? ''}
+              readOnly
+              disabled
+              placeholder={target?.email ? undefined : 'Unavailable'}
+            />
+            <p className="text-muted-foreground text-xs">
+              Email is managed through Supabase Auth and can&apos;t be changed here.
+            </p>
+          </div>
           <div className="space-y-1">
             <Label htmlFor="edit-username">Username</Label>
             <Input

--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -33,8 +33,16 @@ interface AdminPrediction {
   markedBy: string | null;
 }
 
+interface AdminUserSummary {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+  email: string | null;
+}
+
 interface AdminPredictionsResponse {
   tournament: { id: string; lockTime: string };
+  user?: AdminUserSummary;
   predictions: AdminPrediction[];
 }
 
@@ -160,6 +168,7 @@ export function AdminUserBracket({ userId }: { userId: string }) {
   const lockTime = query.data?.tournament.lockTime
     ? new Date(query.data.tournament.lockTime)
     : null;
+  const userSummary = query.data?.user ?? null;
   const predictions = query.data?.predictions ?? [];
 
   // After any mutation that changes a prediction's payment state or
@@ -215,6 +224,27 @@ export function AdminUserBracket({ userId }: { userId: string }) {
     <PageLayout>
       <h1 className="mb-2 text-3xl font-bold">Admin</h1>
       <AdminNav />
+
+      {userSummary && (
+        <Card className="mb-4">
+          <CardContent className="grid gap-3 p-4 sm:grid-cols-2">
+            <div>
+              <p className="text-muted-foreground text-xs uppercase tracking-wide">
+                Username
+              </p>
+              <p className="text-sm font-medium">{userSummary.username ?? '—'}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs uppercase tracking-wide">Email</p>
+              <p className="text-sm font-medium break-all">
+                {userSummary.email ?? (
+                  <span className="text-muted-foreground">Unavailable</span>
+                )}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-semibold">User predictions</h2>

--- a/frontend/src/app/api/admin/users/[id]/predictions/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { createAdminSupabaseClient } from '@/lib/supabase/admin';
 import { safeMessage } from '@/lib/api/errors';
 import { PREDICTION_NAME_MAX, PREDICTION_NAME_REGEX } from '@/lib/constants';
 
@@ -40,6 +41,21 @@ export async function GET(
     return NextResponse.json({ error: 'No active tournament' }, { status: 404 });
   }
 
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('username, display_name')
+    .eq('id', userId)
+    .maybeSingle();
+
+  let email: string | null = null;
+  try {
+    const admin = createAdminSupabaseClient();
+    const { data: authUser } = await admin.auth.admin.getUserById(userId);
+    email = authUser.user?.email ?? null;
+  } catch {
+    // Service role unavailable (e.g. in tests); email simply omitted.
+  }
+
   const { data: predictions } = await supabase
     .from('predictions')
     .select(
@@ -68,6 +84,12 @@ export async function GET(
 
   return NextResponse.json({
     tournament: { id: tournament.id, lockTime: tournament.lock_time },
+    user: {
+      id: userId,
+      username: (profile?.username as string | undefined) ?? null,
+      displayName: (profile?.display_name as string | null | undefined) ?? null,
+      email,
+    },
     predictions: ((predictions ?? []) as Pred[]).map((p) => {
       const payment = unwrapPayment(p.tournament_payments);
       return {

--- a/frontend/src/app/api/admin/users/route.ts
+++ b/frontend/src/app/api/admin/users/route.ts
@@ -32,6 +32,7 @@ export async function GET(request: NextRequest) {
   const rows = (usersResult.data ?? []) as Array<{
     id: string;
     username: string;
+    email: string | null;
     is_admin: boolean;
     is_super_admin: boolean;
     prediction_count: number;
@@ -43,6 +44,7 @@ export async function GET(request: NextRequest) {
     users: rows.map((r) => ({
       id: r.id,
       username: r.username,
+      email: r.email ?? null,
       isAdmin: r.is_admin,
       isSuperAdmin: r.is_super_admin,
       predictionCount: r.prediction_count,

--- a/supabase/migrations/0037_admin_list_users_email.sql
+++ b/supabase/migrations/0037_admin_list_users_email.sql
@@ -1,0 +1,92 @@
+-- Migration 0037: include email in admin_list_users
+--
+-- The admin user list and edit dialog need to show the user's email
+-- (read-only). `auth.users.email` isn't reachable from a normal client,
+-- but admin_list_users is SECURITY DEFINER and already gated on is_admin(),
+-- so it can safely return the column.
+
+drop function if exists public.admin_list_users(text, int, int);
+
+create or replace function public.admin_list_users(
+    p_search text,
+    p_page int,
+    p_page_size int
+)
+returns table (
+    id uuid,
+    username text,
+    email text,
+    is_admin boolean,
+    is_super_admin boolean,
+    prediction_count int,
+    paid_prediction_count int,
+    total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid;
+    v_offset int;
+    v_limit int;
+    v_search text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    v_limit := greatest(1, least(coalesce(p_page_size, 25), 100));
+    v_offset := greatest(0, (coalesce(p_page, 1) - 1) * v_limit);
+    v_search := nullif(trim(coalesce(p_search, '')), '');
+
+    select t.id into v_tournament_id from public.tournaments t where t.is_active limit 1;
+
+    return query
+    with filtered as (
+        select
+            p.id,
+            p.username::text as username,
+            u.email::text as email,
+            p.is_admin,
+            p.is_super_admin,
+            coalesce(counts.prediction_count, 0)::int as prediction_count,
+            coalesce(counts.paid_prediction_count, 0)::int as paid_prediction_count
+        from public.profiles p
+        left join auth.users u on u.id = p.id
+        left join lateral (
+            select
+                count(*) as prediction_count,
+                count(*) filter (
+                    where exists (
+                        select 1 from public.tournament_payments tp
+                        where tp.prediction_id = pr.id
+                    )
+                ) as paid_prediction_count
+            from public.predictions pr
+            where pr.user_id = p.id and pr.tournament_id = v_tournament_id
+        ) counts on true
+        where v_search is null
+           or p.username::text ilike '%' || v_search || '%'
+           or u.email::text ilike '%' || v_search || '%'
+    ),
+    counted as (
+        select count(*) as total from filtered
+    )
+    select
+        f.id,
+        f.username,
+        f.email,
+        f.is_admin,
+        f.is_super_admin,
+        f.prediction_count,
+        f.paid_prediction_count,
+        c.total
+    from filtered f
+    cross join counted c
+    order by f.username asc
+    limit v_limit offset v_offset;
+end;
+$$;
+
+grant execute on function public.admin_list_users(text, int, int) to authenticated;


### PR DESCRIPTION
## Summary
- Surfaces `auth.users.email` (read-only) in the admin Edit user dialog and the manage-predictions page so admins can identify accounts without leaving the app.
- New migration `0037_admin_list_users_email.sql` extends `admin_list_users` to return `email` (and match the search filter on it); the RPC is already SECURITY DEFINER + `is_admin()`-gated so this stays admin-only.
- `/api/admin/users/[id]/predictions` GET now also returns a `user: { username, displayName, email }` block (email looked up via the service-role client; gracefully `null` if unavailable).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (325 tests pass)
- [ ] Apply `0037` to the target Supabase project before deploy (`supabase migration up`).
- [ ] In the admin UI, open `/admin/users`, click **Edit** on a user — verify the email is shown in a disabled input with the "managed by Supabase Auth" hint.
- [ ] Open `/admin/users/[id]` — verify the username + email summary card renders above the predictions list.
- [ ] Confirm the search box on `/admin/users` now also matches on email substrings.