### PR TITLE
feat(predictions): group stage autofill + reset

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -41,6 +41,7 @@ import type {
   TournamentInfo,
 } from '@/types/tournament';
 import { ADVANCER_COUNT } from '@/lib/constants';
+import { autofillGroupPredictionsByFifaRanking } from '@/lib/fifaRankings';
 import { applyGroupPositionChange } from '@/lib/groupSwap';
 import { AdvancersForm } from '@/components/predictions/AdvancersForm';
 
@@ -671,6 +672,20 @@ export function PredictionsPageContent({
     });
   };
 
+  const handleAutofillGroupsByFifaRanking = () => {
+    if (!groups) return;
+    const next = autofillGroupPredictionsByFifaRanking(groups);
+    setGroupPredictions(next);
+    persistDraft({ groupPredictions: next });
+  };
+
+  const handleResetGroups = () => {
+    if (!groups) return;
+    const next = buildEmptyGroups(groups);
+    setGroupPredictions(next);
+    persistDraft({ groupPredictions: next });
+  };
+
   const handleKnockoutPredictionChange = (matchId: string, winnerId: string | null) => {
     setKnockoutPredictions((prev) => {
       const next = prev.map((prediction) =>
@@ -1053,6 +1068,8 @@ export function PredictionsPageContent({
               groups={groups}
               predictions={groupPredictions}
               onPredictionChange={handleGroupPredictionChange}
+              onAutofillByFifaRanking={handleAutofillGroupsByFifaRanking}
+              onResetGroups={handleResetGroups}
               disabled={!phase1Editable}
             />
           )}

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { CheckCircle2, Circle } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Select,
@@ -48,6 +49,16 @@ interface GroupStageFormProps {
   variant?: 'predict' | 'admin';
   /** Optional render-prop appended inside each group card (e.g., a Save row). */
   extraPerCard?: (groupId: string) => React.ReactNode;
+  /**
+   * Predict-variant only: when provided, renders an "Auto-fill by FIFA ranking"
+   * button in the header that overwrites all 12 groups with rank-ordered picks.
+   */
+  onAutofillByFifaRanking?: () => void;
+  /**
+   * Predict-variant only: when provided, renders a "Reset" button that clears
+   * every position in every group back to the unselected state.
+   */
+  onResetGroups?: () => void;
 }
 
 // Local alias for the existing internal usage.
@@ -175,8 +186,13 @@ export function GroupStageForm({
   disabled = false,
   variant = 'predict',
   extraPerCard,
+  onAutofillByFifaRanking,
+  onResetGroups,
 }: GroupStageFormProps) {
   const isAdmin = variant === 'admin';
+  const showAutofill = !isAdmin && !!onAutofillByFifaRanking && !disabled;
+  const showReset = !isAdmin && !!onResetGroups && !disabled;
+  const showActions = showAutofill || showReset;
 
   // Calculate completion stats
   const completedGroups = predictions.filter((p) => {
@@ -224,6 +240,33 @@ export function GroupStageForm({
             </p>
           </div>
         </details>
+      )}
+
+      {showActions && (
+        <div className="flex items-center justify-between gap-2">
+          {showAutofill ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={onAutofillByFifaRanking}
+            >
+              Auto-fill by FIFA ranking
+            </Button>
+          ) : (
+            <span />
+          )}
+          {showReset && (
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={onResetGroups}
+            >
+              Reset
+            </Button>
+          )}
+        </div>
       )}
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/frontend/src/lib/__tests__/fifaRankings.test.ts
+++ b/frontend/src/lib/__tests__/fifaRankings.test.ts
@@ -1,0 +1,82 @@
+import type { Group } from '@/types/tournament';
+
+import { FIFA_RANKINGS, autofillGroupPredictionsByFifaRanking } from '../fifaRankings';
+
+const makeGroup = (id: string, teams: Array<{ id: string; code: string }>): Group => ({
+  id,
+  name: `Group ${id}`,
+  teams: teams.map((t) => ({ id: t.id, name: t.id, code: t.code, group: id })),
+});
+
+describe('autofillGroupPredictionsByFifaRanking', () => {
+  it('orders top-3 by rank ascending, with leftover team in 4th', () => {
+    const rankings = { AAA: 1, BBB: 2, CCC: 3, DDD: 4 };
+    const group = makeGroup('A', [
+      { id: 'd', code: 'DDD' },
+      { id: 'b', code: 'BBB' },
+      { id: 'a', code: 'AAA' },
+      { id: 'c', code: 'CCC' },
+    ]);
+
+    const [pred] = autofillGroupPredictionsByFifaRanking([group], rankings);
+
+    expect(pred.groupId).toBe('A');
+    expect(pred.positions.first).toBe('a');
+    expect(pred.positions.second).toBe('b');
+    expect(pred.positions.third).toBe('c');
+    expect(pred.positions.fourth).toBe('d');
+  });
+
+  it('sorts teams missing from the rankings to the bottom', () => {
+    const rankings = { AAA: 5, BBB: 10 };
+    const group = makeGroup('A', [
+      { id: 'unknown1', code: 'XXX' },
+      { id: 'a', code: 'AAA' },
+      { id: 'unknown2', code: 'YYY' },
+      { id: 'b', code: 'BBB' },
+    ]);
+
+    const [pred] = autofillGroupPredictionsByFifaRanking([group], rankings);
+
+    expect(pred.positions.first).toBe('a');
+    expect(pred.positions.second).toBe('b');
+    expect([pred.positions.third, pred.positions.fourth].sort()).toEqual(
+      ['unknown1', 'unknown2'].sort(),
+    );
+  });
+
+  it('fills all four positions for every group with no null slots', () => {
+    const groups: Group[] = ['A', 'B', 'C'].map((g) =>
+      makeGroup(g, [
+        { id: `${g}-1`, code: `${g}A` },
+        { id: `${g}-2`, code: `${g}B` },
+        { id: `${g}-3`, code: `${g}C` },
+        { id: `${g}-4`, code: `${g}D` },
+      ]),
+    );
+
+    const result = autofillGroupPredictionsByFifaRanking(groups, {});
+
+    expect(result).toHaveLength(3);
+    for (const pred of result) {
+      const slots = Object.values(pred.positions);
+      expect(slots.every((v) => v !== null)).toBe(true);
+      expect(new Set(slots).size).toBe(4);
+    }
+  });
+
+  it('uses FIFA_RANKINGS by default and produces sensible top-of-group picks', () => {
+    const group = makeGroup('H', [
+      { id: 'esp', code: 'ESP' },
+      { id: 'uru', code: 'URU' },
+      { id: 'ksa', code: 'KSA' },
+      { id: 'cpv', code: 'CPV' },
+    ]);
+
+    const [pred] = autofillGroupPredictionsByFifaRanking([group]);
+
+    expect(pred.positions.first).toBe('esp');
+    expect(pred.positions.second).toBe('uru');
+    expect(FIFA_RANKINGS.ESP).toBeLessThan(FIFA_RANKINGS.URU);
+  });
+});

--- a/frontend/src/lib/fifaRankings.ts
+++ b/frontend/src/lib/fifaRankings.ts
@@ -1,0 +1,76 @@
+// Source: FIFA Men's World Ranking (https://www.fifa.com/fifa-world-ranking).
+// Hand-maintained; refresh after each official FIFA ranking publication.
+// Last updated: 2026-05.
+
+import type { Group, GroupPrediction } from '@/types/tournament';
+
+export const FIFA_RANKINGS: Record<string, number> = {
+  ESP: 1,
+  ARG: 2,
+  FRA: 3,
+  ENG: 4,
+  BRA: 5,
+  POR: 6,
+  NED: 7,
+  BEL: 8,
+  CRO: 9,
+  GER: 11,
+  MAR: 12,
+  COL: 13,
+  URU: 14,
+  USA: 15,
+  MEX: 16,
+  SUI: 17,
+  SEN: 18,
+  JPN: 19,
+  IRN: 21,
+  KOR: 22,
+  ECU: 24,
+  AUS: 25,
+  AUT: 26,
+  CAN: 28,
+  TUR: 30,
+  NOR: 32,
+  SWE: 33,
+  ALG: 36,
+  CZE: 37,
+  EGY: 38,
+  SCO: 39,
+  CIV: 40,
+  PAN: 41,
+  PAR: 45,
+  QAT: 50,
+  TUN: 51,
+  UZB: 55,
+  RSA: 58,
+  KSA: 59,
+  COD: 60,
+  CPV: 62,
+  JOR: 64,
+  IRQ: 68,
+  BIH: 75,
+  CUW: 80,
+  HAI: 85,
+  GHA: 86,
+  NZL: 88,
+};
+
+export function autofillGroupPredictionsByFifaRanking(
+  groups: Group[],
+  rankings: Record<string, number> = FIFA_RANKINGS,
+): GroupPrediction[] {
+  return groups.map((group) => {
+    const sorted = [...group.teams].sort(
+      (a, b) => (rankings[a.code] ?? Infinity) - (rankings[b.code] ?? Infinity),
+    );
+    return {
+      groupId: group.id,
+      positions: {
+        first: sorted[0]?.id ?? null,
+        second: sorted[1]?.id ?? null,
+        third: sorted[2]?.id ?? null,
+        fourth: sorted[3]?.id ?? null,
+      },
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- Add **Auto-fill by FIFA ranking** button on the Group Stage step — overwrites all 12 groups with picks ordered by current FIFA Men's Ranking (top 3 ranked teams seed 1st/2nd/3rd; the existing 4th-place auto-fill handles the leftover team).
- Add **Reset** button on the same row — clears every position in every group via the existing `buildEmptyGroups` helper.
- Rankings live in a hand-maintained constant at `frontend/src/lib/fifaRankings.ts` (no DB migration, no API change — refresh after each official FIFA publication).
- Both buttons are predict-variant only; admin standings editor is untouched.

## Test plan
- [x] `cd frontend && npm run lint` — 0 errors (3 pre-existing warnings).
- [x] `cd frontend && npm run typecheck` — clean.
- [x] `cd frontend && npm test` — 43 suites / 334 tests pass.
- [x] New unit tests in `frontend/src/lib/__tests__/fifaRankings.test.ts` cover rank-order output, missing-team fallback, all-positions-filled, and distinct-team-IDs (DB CHECK).
- [ ] Manual: `npm run dev`, sign in, `/predictions/new` → Group Stage step:
  - Click **Auto-fill by FIFA ranking** → all 12 groups flip to "Complete", `12 / 12 groups complete` badge appears, top-3 are in rank order.
  - Click **Reset** → every group returns to `0/4` with empty dropdowns; draft persists empty across reload.
  - Verify admin editor at `/admin/users/<id>/predictions/new` does **not** show either button.