### PR TITLE
fix(auth): re-enable forgot-password form after "Try a different address"

### DIFF
--- a/frontend/src/app/forgot-password/ForgotPasswordForm.tsx
+++ b/frontend/src/app/forgot-password/ForgotPasswordForm.tsx
@@ -45,6 +45,7 @@ export function ForgotPasswordForm() {
         return;
       }
       setSubmitted(true);
+      setIsSubmitting(false);
     } catch {
       setServerError('Network error. Please try again.');
       setIsSubmitting(false);

--- a/frontend/src/app/forgot-password/__tests__/ForgotPasswordForm.test.tsx
+++ b/frontend/src/app/forgot-password/__tests__/ForgotPasswordForm.test.tsx
@@ -40,6 +40,24 @@ describe('ForgotPasswordForm', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(/network error/i);
   });
 
+  it('re-enables the form when returning via "Try a different address"', async () => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+    const user = userEvent.setup();
+    render(<ForgotPasswordForm />);
+
+    await user.type(screen.getByLabelText(/Email or username/i), 'alice');
+    await user.click(screen.getByRole('button', { name: /Send reset link/i }));
+
+    await screen.findByRole('status');
+    await user.click(screen.getByRole('button', { name: /Try a different address/i }));
+
+    const input = screen.getByLabelText(/Email or username/i);
+    expect(input).toBeEnabled();
+    expect(input).toHaveValue('');
+    const submitButton = screen.getByRole('button', { name: /Send reset link/i });
+    expect(submitButton).toBeEnabled();
+  });
+
   it('shows error alert when API returns non-2xx', async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 500 } as Response);
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- On `/forgot-password`, the success-path of `handleSubmit` never cleared `isSubmitting`, so clicking "Try a different address" returned the user to a form where the email input, submit button, and "Back to sign in" link were all disabled.
- Clear `setIsSubmitting(false)` alongside `setSubmitted(true)` so the form is in a clean state whichever way the user navigates back.
- Added a Testing-Library case that submits, lands on the success panel, clicks "Try a different address", and asserts the input/submit are enabled and the input is empty.

## Test plan
- [x] `npm test -- ForgotPasswordForm` (4/4 pass)
- [x] `npm run typecheck`
- [x] `npm run lint` (no new warnings)
- [ ] Manual: `npm run dev`, visit `/forgot-password`, submit any value, click "Try a different address", confirm the input, submit button, and "Back to sign in" link are all interactive.