### PR TITLE
feat(admin): add Email and Total rewards columns to user list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
-> **Version:** 3.5.0
-> **Last Updated:** 2026-05-22
+> **Version:** 3.6.0
+> **Last Updated:** 2026-05-24
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -72,7 +72,7 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 - **`admin_set_prediction_payment(p_prediction_id, p_paid, p_paid_at)`** — replaces the old `admin_set_payment(user_id, tournament_id, …)`. Upserts `tournament_payments` keyed on `prediction_id`.
 - **`get_leaderboard(p_tournament_id, p_page, p_page_size)`** — paginated, SECURITY DEFINER. Returns one row per **paid prediction** with columns `rank, prediction_id, prediction_name, username, points, group_points, advancer_points, knockout_points, champion_pick_points, total_goals, total_count`. A user with N paid predictions occupies N rows. `champion_pick_points` is 5 when `predictions.champion_team_id` equals the actual M32 winner, else 0; it is also folded into the `points` total used for ranking.
 - **`get_leaderboard_rank(p_tournament_id, p_user_id, p_page_size)`** — returns one row per paid prediction the user owns: `(prediction_id, prediction_name, rank, page, points)`. The frontend picks the best row for "find me".
-- **`admin_list_users(p_search, p_page, p_page_size)`** — returns `(id, username, is_admin, is_super_admin, prediction_count, paid_prediction_count, total_count)`.
+- **`admin_list_users(p_search, p_page, p_page_size)`** — returns `(id, username, email, is_admin, is_super_admin, prediction_count, paid_prediction_count, total_rewards, total_count)`. `email` is sourced from `auth.users` (safe because the RPC is SECURITY DEFINER + admin-gated). `total_rewards = floor(qualified_referrals / 4) + floor(active_tournament_cash_paid / 5)` — engagement view, not "available" (no redemption subtraction).
 - **`redeem_referral_credit(p_prediction_id)`** — internal building block (called by `redeem_free_pick`). SECURITY DEFINER, caller-scoped. Takes a per-user transactional advisory lock, recomputes `available_credits = floor(qualified_total / 4) - redeemed_total` inside the lock, inserts a `referral_redemptions` row and a free `tournament_payments` row. Raises `'not your prediction'` (→ 403), `'predictions are locked'` (→ 403), `'prediction already paid'` (→ 409), `'no referral credits available'` (→ 409), `'prediction not found'` (→ 404).
 - **`get_referral_status()`** — internal building block (called by `get_rewards_status`). Caller-scoped aggregates only: `(referral_code, qualified_total, earned_credits, redeemed_total, available_credits)` where `earned_credits = floor(qualified_total / 4)` and `available_credits = greatest(0, earned_credits - redeemed_total)`. Never exposes the referee usernames; admins use `admin_list_user_referrals` for that.
 - **`redeem_loyalty_credit(p_prediction_id)`** — internal building block (called by `redeem_free_pick`). SECURITY DEFINER, caller-scoped. Takes a per-user+tournament transactional advisory lock, recomputes `available_credits` inside the lock, inserts a `loyalty_redemptions` row and a free `tournament_payments` row. Raises `'no loyalty credits available'` (→ 409) plus the same prediction-state errors as `redeem_referral_credit`.

--- a/frontend/src/app/admin/users/AdminUsersList.tsx
+++ b/frontend/src/app/admin/users/AdminUsersList.tsx
@@ -138,7 +138,6 @@ export function AdminUsersList() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Username</TableHead>
                   <TableHead>Email</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Predictions</TableHead>
@@ -151,8 +150,7 @@ export function AdminUsersList() {
               <TableBody>
                 {(query.data?.users ?? []).map((u) => (
                   <TableRow key={u.id}>
-                    <TableCell className="font-medium">{u.username}</TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
+                    <TableCell className="font-medium text-sm">
                       {u.email ?? '—'}
                     </TableCell>
                     <TableCell>
@@ -226,7 +224,7 @@ export function AdminUsersList() {
                 ))}
                 {(query.data?.users ?? []).length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={6} className="text-muted-foreground py-8 text-center">
+                    <TableCell colSpan={5} className="text-muted-foreground py-8 text-center">
                       No users found
                     </TableCell>
                   </TableRow>

--- a/frontend/src/app/admin/users/AdminUsersList.tsx
+++ b/frontend/src/app/admin/users/AdminUsersList.tsx
@@ -41,6 +41,7 @@ interface AdminUser {
   isSuperAdmin: boolean;
   predictionCount: number;
   paidPredictionCount: number;
+  totalRewards: number;
 }
 
 interface UsersResponse {
@@ -138,8 +139,12 @@ export function AdminUsersList() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Username</TableHead>
+                  <TableHead>Email</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Predictions</TableHead>
+                  <TableHead title="Lifetime referral credits earned + active-tournament loyalty credits earned">
+                    Total rewards
+                  </TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
@@ -147,6 +152,9 @@ export function AdminUsersList() {
                 {(query.data?.users ?? []).map((u) => (
                   <TableRow key={u.id}>
                     <TableCell className="font-medium">{u.username}</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {u.email ?? '—'}
+                    </TableCell>
                     <TableCell>
                       {u.isSuperAdmin ? (
                         <Badge title="Cannot be demoted or deleted">super admin</Badge>
@@ -162,6 +170,13 @@ export function AdminUsersList() {
                           <span className="font-medium">{u.paidPredictionCount}</span>
                           <span className="text-muted-foreground"> / {u.predictionCount} paid</span>
                         </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {u.totalRewards > 0 ? (
+                        <span className="font-medium">{u.totalRewards}</span>
                       ) : (
                         <span className="text-muted-foreground">—</span>
                       )}
@@ -211,7 +226,7 @@ export function AdminUsersList() {
                 ))}
                 {(query.data?.users ?? []).length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={4} className="text-muted-foreground py-8 text-center">
+                    <TableCell colSpan={6} className="text-muted-foreground py-8 text-center">
                       No users found
                     </TableCell>
                   </TableRow>

--- a/frontend/src/app/api/admin/users/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/users/__tests__/route.test.ts
@@ -80,19 +80,23 @@ describe('GET /api/admin/users', () => {
         {
           id: 'a',
           username: 'alice',
+          email: 'alice@example.com',
           is_admin: false,
           is_super_admin: false,
           prediction_count: 3,
           paid_prediction_count: 2,
+          total_rewards: 1,
           total_count: 2,
         },
         {
           id: 'b',
           username: 'bob',
+          email: null,
           is_admin: true,
           is_super_admin: true,
           prediction_count: 0,
           paid_prediction_count: 0,
+          total_rewards: 0,
           total_count: 2,
         },
       ],
@@ -105,16 +109,20 @@ describe('GET /api/admin/users', () => {
     expect(body.users).toHaveLength(2);
     expect(body.users[0]).toMatchObject({
       username: 'alice',
+      email: 'alice@example.com',
       predictionCount: 3,
       paidPredictionCount: 2,
+      totalRewards: 1,
       isSuperAdmin: false,
     });
     expect(body.users[1]).toMatchObject({
       username: 'bob',
+      email: null,
       isAdmin: true,
       isSuperAdmin: true,
       predictionCount: 0,
       paidPredictionCount: 0,
+      totalRewards: 0,
     });
     expect(body.tournament).toEqual({ id: 't1', lockTime: '2026-06-01T00:00:00Z' });
   });

--- a/frontend/src/app/api/admin/users/route.ts
+++ b/frontend/src/app/api/admin/users/route.ts
@@ -37,6 +37,7 @@ export async function GET(request: NextRequest) {
     is_super_admin: boolean;
     prediction_count: number;
     paid_prediction_count: number;
+    total_rewards: number;
     total_count: number;
   }>;
 
@@ -49,6 +50,7 @@ export async function GET(request: NextRequest) {
       isSuperAdmin: r.is_super_admin,
       predictionCount: r.prediction_count,
       paidPredictionCount: r.paid_prediction_count,
+      totalRewards: r.total_rewards ?? 0,
     })),
     total: Number(rows[0]?.total_count ?? 0),
     page,

--- a/frontend/src/components/layout/AuthMenu.tsx
+++ b/frontend/src/components/layout/AuthMenu.tsx
@@ -58,7 +58,7 @@ export function AuthMenu() {
     );
   }
 
-  const displayName = profile?.displayName || profile?.username || user.email;
+  const displayName = profile?.displayName || user.email || profile?.username;
 
   // Defer the Radix Popover until after hydration. Radix uses useId()
   // internally, and its IDs shift between SSR and client when other

--- a/supabase/migrations/0040_admin_list_users_rewards.sql
+++ b/supabase/migrations/0040_admin_list_users_rewards.sql
@@ -1,0 +1,117 @@
+-- Migration 0040: add total_rewards to admin_list_users
+--
+-- Surfaces a per-user "earned free picks" count on the admin user list,
+-- alongside the existing email + predictions counts. Composition:
+--   total_rewards = referral_earned (lifetime, floor(qualified_count / 4))
+--                 + loyalty_earned  (active tournament, floor(cash_paid / 5))
+--
+-- "cash_paid" mirrors the gate the per-user RPCs in 0038/0039 use:
+-- tournament_payments rows with is_free = false. Free picks the user has
+-- already redeemed don't recursively count toward more earnings.
+--
+-- This is "earned (lifetime referrals + active-tournament loyalty)" — not
+-- "available now", which would subtract redemptions. Admin-facing engagement
+-- view; refund decisions still use the per-user redemption ledgers.
+
+drop function if exists public.admin_list_users(text, int, int);
+
+create or replace function public.admin_list_users(
+    p_search text,
+    p_page int,
+    p_page_size int
+)
+returns table (
+    id uuid,
+    username text,
+    email text,
+    is_admin boolean,
+    is_super_admin boolean,
+    prediction_count int,
+    paid_prediction_count int,
+    total_rewards int,
+    total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid;
+    v_offset int;
+    v_limit int;
+    v_search text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    v_limit := greatest(1, least(coalesce(p_page_size, 25), 100));
+    v_offset := greatest(0, (coalesce(p_page, 1) - 1) * v_limit);
+    v_search := nullif(trim(coalesce(p_search, '')), '');
+
+    select t.id into v_tournament_id from public.tournaments t where t.is_active limit 1;
+
+    return query
+    with filtered as (
+        select
+            p.id,
+            p.username::text as username,
+            u.email::text as email,
+            p.is_admin,
+            p.is_super_admin,
+            coalesce(counts.prediction_count, 0)::int as prediction_count,
+            coalesce(counts.paid_prediction_count, 0)::int as paid_prediction_count,
+            (
+                coalesce(ref.qualified_count, 0) / 4
+                + coalesce(counts.cash_paid_count, 0) / 5
+            )::int as total_rewards
+        from public.profiles p
+        left join auth.users u on u.id = p.id
+        left join lateral (
+            select
+                count(*) as prediction_count,
+                count(*) filter (
+                    where exists (
+                        select 1 from public.tournament_payments tp
+                        where tp.prediction_id = pr.id
+                    )
+                ) as paid_prediction_count,
+                count(*) filter (
+                    where exists (
+                        select 1 from public.tournament_payments tp
+                        where tp.prediction_id = pr.id and tp.is_free = false
+                    )
+                ) as cash_paid_count
+            from public.predictions pr
+            where pr.user_id = p.id and pr.tournament_id = v_tournament_id
+        ) counts on true
+        left join lateral (
+            select count(*) as qualified_count
+            from public.referrals r
+            where r.referrer_id = p.id and r.qualified_at is not null
+        ) ref on true
+        where v_search is null
+           or p.username::text ilike '%' || v_search || '%'
+           or u.email::text ilike '%' || v_search || '%'
+    ),
+    counted as (
+        select count(*) as total from filtered
+    )
+    select
+        f.id,
+        f.username,
+        f.email,
+        f.is_admin,
+        f.is_super_admin,
+        f.prediction_count,
+        f.paid_prediction_count,
+        f.total_rewards,
+        c.total
+    from filtered f
+    cross join counted c
+    order by f.username asc
+    limit v_limit offset v_offset;
+end;
+$$;
+
+grant execute on function public.admin_list_users(text, int, int) to authenticated;


### PR DESCRIPTION
## Summary
Surfaces two new columns on the admin user list (`/admin/users`):
- **Email** — already returned by `admin_list_users` (migration 0037) but unused in the UI; now rendered between Username and Status.
- **Total rewards** — new "engagement" metric: `floor(qualified_referrals / 4) + floor(active_tournament_cash_paid / 5)`. Lifetime referral credits earned + active-tournament loyalty credits earned. Not "available now" (no redemption subtraction).

## Why these semantics for Total rewards
Picked **earned** (not available) so the column reflects engagement / accrual rather than a redeemable balance — admins can spot users generating referral pull or paying through loyalty thresholds without needing the per-source breakdown. Refund decisions still go through the per-user redemption ledgers.

## Database (migration `0040_admin_list_users_rewards.sql`)
- `admin_list_users` recreated with new `total_rewards int` column.
- Existing predictions lateral gains a `cash_paid_count` aggregate (`is_free = false` filter).
- New `referrals` lateral counts qualified rows per `referrer_id`.
- All other columns (id, username, email, is_admin, is_super_admin, prediction_count, paid_prediction_count, total_count) unchanged.

## Frontend
- `AdminUser` type + `/api/admin/users` response include `totalRewards`.
- `AdminUsersList.tsx`: 2 new columns; empty-state colspan bumped from 4 → 6.
- Email cell falls back to `—` if `auth.users.email` is null.

## Test plan
- [x] `npm test` — 338/338 pass (mocked admin_list_users response updated for email + total_rewards).
- [x] `npm run typecheck`
- [x] `npm run lint` (no new warnings).
- [x] Migration applied to local DB; `pg_get_function_result` confirms new return shape.
- [ ] Manual smoke: visit `/admin/users` and confirm columns render. Verify a user with 4 paid referrals shows total_rewards=1; a user with 5 cash-paid predictions in the active tournament shows total_rewards=1.