### PR TITLE
feat(admin): breadcrumb nav on user views + default paid-at to now

### DIFF
--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { AdminNav } from '@/components/admin/AdminNav';
+import { AdminBreadcrumb } from '@/components/admin/AdminBreadcrumb';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -68,7 +69,9 @@ function PaymentRow({
   onChanged: () => void;
 }) {
   const [paidAtInput, setPaidAtInput] = React.useState(
-    prediction.paidAt ? toLocalDatetimeInput(prediction.paidAt) : ''
+    prediction.paidAt
+      ? toLocalDatetimeInput(prediction.paidAt)
+      : toLocalDatetimeInput(new Date().toISOString())
   );
   const [busy, setBusy] = React.useState(false);
 
@@ -207,11 +210,23 @@ export function AdminUserBracket({ userId }: { userId: string }) {
     }
   };
 
+  const userLabel =
+    userSummary?.displayName ||
+    userSummary?.username ||
+    userSummary?.email ||
+    'User';
+
   if (query.isLoading) {
     return (
       <PageLayout>
         <h1 className="mb-2 text-3xl font-bold">Admin</h1>
         <AdminNav />
+        <AdminBreadcrumb
+          items={[
+            { label: 'Users', href: '/admin/users' },
+            { label: 'Loading…' },
+          ]}
+        />
         <div className="space-y-4">
           <Skeleton className="h-10 w-64" />
           <Skeleton className="h-32 w-full" />
@@ -224,6 +239,12 @@ export function AdminUserBracket({ userId }: { userId: string }) {
     <PageLayout>
       <h1 className="mb-2 text-3xl font-bold">Admin</h1>
       <AdminNav />
+      <AdminBreadcrumb
+        items={[
+          { label: 'Users', href: '/admin/users' },
+          { label: userLabel },
+        ]}
+      />
 
       {userSummary && (
         <Card className="mb-4">

--- a/frontend/src/app/admin/users/[id]/predictions/[predictionId]/page.tsx
+++ b/frontend/src/app/admin/users/[id]/predictions/[predictionId]/page.tsx
@@ -6,6 +6,7 @@ import {
   PredictionsPageContent,
   type InitialPrediction,
 } from '@/app/predictions/PredictionsPageContent';
+import { AdminBreadcrumb } from '@/components/admin/AdminBreadcrumb';
 
 export const metadata: Metadata = {
   title: 'Edit Prediction | Admin',
@@ -30,7 +31,7 @@ export default async function AdminEditPredictionPage({
 
   if (!prediction) notFound();
 
-  const [groupsRes, knockoutRes, advancersRes] = await Promise.all([
+  const [groupsRes, knockoutRes, advancersRes, profileRes] = await Promise.all([
     supabase
       .from('group_predictions')
       .select('group_id, first_team_id, second_team_id, third_team_id, fourth_team_id')
@@ -43,7 +44,17 @@ export default async function AdminEditPredictionPage({
       .from('advancer_predictions')
       .select('rank, team_id')
       .eq('prediction_id', predictionId),
+    supabase
+      .from('profiles')
+      .select('username, display_name')
+      .eq('id', id)
+      .maybeSingle(),
   ]);
+
+  const userLabel =
+    (profileRes.data?.display_name as string | null) ||
+    (profileRes.data?.username as string | null) ||
+    'User';
 
   // PostgREST returns a single object (not an array) when the embedded
   // relation has a unique FK target — `tournament_payments.prediction_id`
@@ -92,6 +103,15 @@ export default async function AdminEditPredictionPage({
       initial={initial}
       apiBasePath={`/api/admin/users/${id}/predictions`}
       redirectAfterSave={`/admin/users/${id}`}
+      breadcrumb={
+        <AdminBreadcrumb
+          items={[
+            { label: 'Users', href: '/admin/users' },
+            { label: userLabel, href: `/admin/users/${id}` },
+            { label: initial.name },
+          ]}
+        />
+      }
     />
   );
 }

--- a/frontend/src/app/admin/users/[id]/predictions/new/page.tsx
+++ b/frontend/src/app/admin/users/[id]/predictions/new/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 
 import { PredictionsPageContent } from '@/app/predictions/PredictionsPageContent';
+import { AdminBreadcrumb } from '@/components/admin/AdminBreadcrumb';
+import { getServerSupabase } from '@/lib/supabase/server';
 
 export const metadata: Metadata = {
   title: 'New Prediction | Admin',
@@ -12,11 +14,32 @@ export default async function AdminNewPredictionPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const supabase = await getServerSupabase();
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('username, display_name')
+    .eq('id', id)
+    .maybeSingle();
+
+  const userLabel =
+    (profile?.display_name as string | null) ||
+    (profile?.username as string | null) ||
+    'User';
+
   return (
     <PredictionsPageContent
       mode="create"
       apiBasePath={`/api/admin/users/${id}/predictions`}
       redirectAfterSave={`/admin/users/${id}`}
+      breadcrumb={
+        <AdminBreadcrumb
+          items={[
+            { label: 'Users', href: '/admin/users' },
+            { label: userLabel, href: `/admin/users/${id}` },
+            { label: 'New prediction' },
+          ]}
+        />
+      }
     />
   );
 }

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -162,6 +162,8 @@ interface PredictionsPageContentProps {
   apiBasePath?: string;
   /** Where to navigate after a successful save. Defaults to /predictions. */
   redirectAfterSave?: string;
+  /** Optional breadcrumb rendered above the title (used by admin pages). */
+  breadcrumb?: React.ReactNode;
 }
 
 async function fetchJSON<T>(url: string): Promise<T> {
@@ -258,6 +260,7 @@ export function PredictionsPageContent({
   initial,
   apiBasePath = '/api/predictions',
   redirectAfterSave,
+  breadcrumb,
 }: PredictionsPageContentProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -912,6 +915,7 @@ export function PredictionsPageContent({
   if (isLoading || !tournament || !groups || !teams || !matches) {
     return (
       <PageLayout>
+        {breadcrumb}
         <div className="space-y-4 py-8">
           <Skeleton className="h-10 w-64" />
           <Skeleton className="h-32 w-full" />
@@ -962,6 +966,7 @@ export function PredictionsPageContent({
 
   return (
     <PageLayout>
+      {breadcrumb}
       <div className="mb-8">
         <h1 className="mb-2 text-3xl font-bold">
           {mode === 'edit' ? 'Edit Prediction' : 'New Prediction'}

--- a/frontend/src/components/admin/AdminBreadcrumb.tsx
+++ b/frontend/src/components/admin/AdminBreadcrumb.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import { ChevronRight } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export interface AdminBreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface AdminBreadcrumbProps {
+  items: AdminBreadcrumbItem[];
+  className?: string;
+}
+
+/**
+ * Lightweight breadcrumb used to escape nested Admin/User views. The last
+ * item is treated as the current page (rendered non-interactive) regardless
+ * of whether it has an href.
+ */
+export function AdminBreadcrumb({ items, className }: AdminBreadcrumbProps) {
+  if (items.length === 0) return null;
+  return (
+    <nav aria-label="Breadcrumb" className={cn('mb-4 text-sm', className)}>
+      <ol className="text-muted-foreground flex flex-wrap items-center gap-1">
+        {items.map((item, i) => {
+          const isLast = i === items.length - 1;
+          return (
+            <li key={`${item.label}-${i}`} className="flex items-center gap-1">
+              {i > 0 && <ChevronRight className="h-3.5 w-3.5" aria-hidden />}
+              {item.href && !isLast ? (
+                <Link
+                  href={item.href}
+                  className="hover:text-foreground transition-colors"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <span
+                  className={cn(isLast && 'text-foreground font-medium')}
+                  aria-current={isLast ? 'page' : undefined}
+                >
+                  {item.label}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
Two small admin/user UX improvements:

1. **Breadcrumb navigation** on the nested admin/user routes so admins can escape sub-views without using the browser back button. A new lightweight \`AdminBreadcrumb\` component renders an aria-labelled ordered list. Trail:
   - \`/admin/users/[id]\` (Manage Predictions): **Users › @user**
   - \`/admin/users/[id]/predictions/new\`: **Users › @user › New prediction**
   - \`/admin/users/[id]/predictions/[predictionId]\`: **Users › @user › ‹prediction name›**

2. **Default \"Paid at\" to now** on the Manage Predictions payment row. When a prediction has no payment yet, the datetime-local input pre-fills with the current timestamp instead of being blank — the most common action (mark paid right now) takes zero typing.

## Implementation notes
- \`PredictionsPageContent\` gains an optional \`breadcrumb?: React.ReactNode\` prop so the admin prediction pages can inject the crumb without affecting the user-facing \`/predictions/...\` routes.
- The admin prediction page wrappers do a small \`profiles.username / display_name\` lookup server-side so the middle crumb reads \"@alice\" rather than a UUID. The lookup is folded into the existing \`Promise.all\` on the edit page (one extra parallel query).
- For the new-prediction page, the lookup is one new query — acceptable cost for the UX win.
- Loading state in \`AdminUserBracket\` shows a placeholder \"Loading…\" segment so the breadcrumb doesn't pop in.

## Test plan
- [x] \`npm test\` — 338/338 pass.
- [x] \`npm run typecheck\`
- [x] \`npm run lint\` (no new warnings).
- [ ] Manual: visit /admin/users → click Manage predictions → confirm \"Users › @user\" appears and \"Users\" links back. Click Edit on a prediction → confirm full \"Users › @user › ‹name›\" trail and both intermediate links work. Confirm an unpaid prediction's \"Paid at\" input shows the current datetime.