### PR TITLE
feat(brand,marketing): rebrand to soccer-pool 2026 + Pot Total + Donations card

### DIFF
--- a/frontend/src/app/HomePageContent.tsx
+++ b/frontend/src/app/HomePageContent.tsx
@@ -3,10 +3,19 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
-import { Clock, Trophy, Users, UserPlus, Target, Award, ChevronRight } from 'lucide-react';
+import {
+  ChevronRight,
+  Clock,
+  CircleDollarSign,
+  Target,
+  Trophy,
+  Users,
+  UserPlus,
+  Award,
+} from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
-import { ScoringBreakdown } from '@/components/marketing/ScoringBreakdown';
+import { DonationsToCharity } from '@/components/marketing/DonationsToCharity';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -21,7 +30,15 @@ interface TournamentResponse {
   status: TournamentInfo['status'];
   lockTime: string;
   totalEntries: number;
+  cashPaidPredictionCount: number;
+  potTotalCAD: number;
 }
+
+const POT_FORMATTER = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+  maximumFractionDigits: 0,
+});
 
 function formatTimeRemaining(lockTime: Date): string {
   const now = new Date();
@@ -109,7 +126,7 @@ export function HomePageContent() {
 
       <section className="py-12">
         <h2 className="mb-8 text-center text-2xl font-bold md:text-3xl">Tournament Overview</h2>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <Card>
             <CardHeader className="pb-2">
               <CardDescription className="flex items-center gap-2">
@@ -141,6 +158,24 @@ export function HomePageContent() {
               ) : (
                 <p className="text-2xl font-bold">
                   {(tournament?.totalEntries ?? 0).toLocaleString()}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription className="flex items-center gap-2">
+                <CircleDollarSign className="h-4 w-4" />
+                Pot Total
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {query.isLoading ? (
+                <Skeleton className="h-8 w-24" />
+              ) : (
+                <p className="text-2xl font-bold">
+                  {POT_FORMATTER.format(tournament?.potTotalCAD ?? 0)}
                 </p>
               )}
             </CardContent>
@@ -233,7 +268,7 @@ export function HomePageContent() {
         </div>
       </section>
 
-      <ScoringBreakdown />
+      <DonationsToCharity />
 
       <section className="py-12">
         <Card className="bg-primary/5 border-primary/20">

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { AdminDashboard } from './AdminDashboard';
 
 export const metadata: Metadata = {
-  title: 'Admin Dashboard | WC2026',
+  title: 'Admin Dashboard | soccer-pool 2026',
 };
 
 export default function AdminPage() {

--- a/frontend/src/app/api/tournament/route.ts
+++ b/frontend/src/app/api/tournament/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getServerSupabase } from '@/lib/supabase/server';
+import { PRICING } from '@/lib/constants';
 
 export async function GET() {
   const supabase = await getServerSupabase();
@@ -7,7 +8,7 @@ export async function GET() {
     supabase
       .from('tournaments')
       .select(
-        'id, slug, name, status, lock_time, total_entries, champion_total_goals, knockout_unlocked, knockout_lock_time'
+        'id, slug, name, status, lock_time, champion_total_goals, knockout_unlocked, knockout_lock_time'
       )
       .eq('is_active', true)
       .maybeSingle(),
@@ -39,11 +40,40 @@ export async function GET() {
     name: string;
     status: string;
     lock_time: string;
-    total_entries: number;
     champion_total_goals: number | null;
     knockout_unlocked: boolean;
     knockout_lock_time: string | null;
   };
+
+  // Live entry counts. Mirrors get_leaderboard's eligibility predicate
+  // (supabase/migrations/0036_champion_pick.sql:589-595): payment row with
+  // paid_at <= lock_time. totalEntries counts both cash and free-pick rows;
+  // cashPaidPredictionCount filters is_free = false so the displayed pot
+  // reflects actual money collected (not inflated by referral/loyalty
+  // redemptions).
+  const [totalEntriesRes, cashPaidRes] = await Promise.all([
+    supabase
+      .from('tournament_payments')
+      .select('prediction_id, predictions!inner(tournament_id)', {
+        count: 'exact',
+        head: true,
+      })
+      .eq('predictions.tournament_id', data.id)
+      .lte('paid_at', data.lock_time),
+    supabase
+      .from('tournament_payments')
+      .select('prediction_id, predictions!inner(tournament_id)', {
+        count: 'exact',
+        head: true,
+      })
+      .eq('predictions.tournament_id', data.id)
+      .eq('is_free', false)
+      .lte('paid_at', data.lock_time),
+  ]);
+
+  const totalEntries = totalEntriesRes.count ?? 0;
+  const cashPaidPredictionCount = cashPaidRes.count ?? 0;
+  const potTotalCAD = cashPaidPredictionCount * PRICING.entryFeeCAD;
 
   const serverTime =
     typeof serverTimeRes.data === 'string'
@@ -74,7 +104,9 @@ export async function GET() {
     knockoutUnlocked: data.knockout_unlocked,
     advancersSet,
     phase,
-    totalEntries: data.total_entries,
+    totalEntries,
+    cashPaidPredictionCount,
+    potTotalCAD,
     championTotalGoals: data.champion_total_goals,
     serverTime,
   });

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -6,7 +6,7 @@ import { PageLayout } from '@/components/layout/PageLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 export const metadata = {
-  title: 'Forgot password — WC2026',
+  title: 'Forgot password — soccer-pool 2026',
 };
 
 export default async function ForgotPasswordPage() {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -6,7 +6,7 @@ import { PageLayout } from '@/components/layout/PageLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 export const metadata = {
-  title: 'Sign in — WC2026',
+  title: 'Sign in — soccer-pool 2026',
 };
 
 export default async function LoginPage({

--- a/frontend/src/app/referrals/ReferralsPageContent.tsx
+++ b/frontend/src/app/referrals/ReferralsPageContent.tsx
@@ -48,7 +48,7 @@ export function ReferralsPageContent() {
     if (typeof navigator !== 'undefined' && navigator.share) {
       try {
         await navigator.share({
-          title: 'Join my WC2026 pool',
+          title: 'Join my soccer-pool 2026',
           text: 'Join my World Cup 2026 prediction pool — use my referral link:',
           url: shareUrl,
         });

--- a/frontend/src/app/referrals/page.tsx
+++ b/frontend/src/app/referrals/page.tsx
@@ -6,7 +6,7 @@ import { ROUTES } from '@/lib/constants';
 import { ReferralsPageContent } from './ReferralsPageContent';
 
 export const metadata: Metadata = {
-  title: 'Refer a friend — WC2026',
+  title: 'Refer a friend — soccer-pool 2026',
 };
 
 export default async function ReferralsPage() {

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -6,7 +6,7 @@ import { PageLayout } from '@/components/layout/PageLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 export const metadata = {
-  title: 'Sign up — WC2026',
+  title: 'Sign up — soccer-pool 2026',
 };
 
 // Next.js 16 — searchParams is a Promise.

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -5,7 +5,7 @@ import { PageLayout } from '@/components/layout/PageLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 export const metadata = {
-  title: 'Reset password — WC2026',
+  title: 'Reset password — soccer-pool 2026',
 };
 
 export default async function ResetPasswordPage() {

--- a/frontend/src/app/rewards/page.tsx
+++ b/frontend/src/app/rewards/page.tsx
@@ -6,7 +6,7 @@ import { ROUTES } from '@/lib/constants';
 import { RewardsPageContent } from './RewardsPageContent';
 
 export const metadata: Metadata = {
-  title: 'Rewards — WC2026',
+  title: 'Rewards — soccer-pool 2026',
 };
 
 export default async function RewardsPage() {

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -6,7 +6,7 @@ import { ROUTES } from '@/lib/constants';
 
 const footerLinks = [
   { label: 'About', href: ROUTES.about },
-  { label: 'Rules', href: ROUTES.rules },
+  { label: 'Rules & Scoring', href: ROUTES.rules },
   { label: 'Terms', href: ROUTES.terms },
   { label: 'Privacy', href: ROUTES.privacy },
 ];
@@ -19,7 +19,7 @@ export function Footer() {
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="flex flex-col items-center gap-6 sm:flex-row sm:justify-between">
           <div className="flex flex-col items-center sm:items-start">
-            <span className="text-foreground text-lg font-semibold">WC2026 Prediction Game</span>
+            <span className="text-foreground text-lg font-semibold">soccer-pool 2026</span>
             <span className="text-muted-foreground text-sm">
               Bracket predictions for the FIFA World Cup 2026
             </span>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import { Menu } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ROUTES } from '@/lib/constants';
 import { AuthMenu } from '@/components/layout/AuthMenu';
+import { HeaderPotTotal } from '@/components/layout/HeaderPotTotal';
 import { ThemeToggle } from '@/components/shared/ThemeToggle';
 import { useAuthContext } from '@/providers/AuthProvider';
 import { useMounted } from '@/hooks/useMounted';
@@ -24,7 +25,7 @@ const baseNavLinks = [
   { label: 'Home', href: ROUTES.home },
   { label: 'Predictions', href: ROUTES.predictions },
   { label: 'Leaderboard', href: ROUTES.leaderboard },
-  { label: 'Rules', href: ROUTES.rules },
+  { label: 'Rules & Scoring', href: ROUTES.rules },
   { label: 'About', href: ROUTES.about },
 ];
 
@@ -47,7 +48,7 @@ export function Header() {
     <header className="border-border bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 w-full border-b backdrop-blur">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href={ROUTES.home} className="flex items-center space-x-2">
-          <span className="text-foreground text-xl font-bold">WC2026</span>
+          <span className="text-foreground text-xl font-bold">soccer-pool 2026</span>
         </Link>
 
         <NavigationMenu className="hidden md:flex">
@@ -71,6 +72,7 @@ export function Header() {
         </NavigationMenu>
 
         <div className="hidden items-center gap-4 md:flex">
+          <HeaderPotTotal />
           <ThemeToggle />
           <AuthMenu />
         </div>
@@ -91,6 +93,7 @@ export function Header() {
                 <SheetHeader>
                   <SheetTitle>Navigation</SheetTitle>
                 </SheetHeader>
+                <HeaderPotTotal className="mt-4" />
                 <nav className="mt-6 flex flex-col space-y-4">
                   {navLinks.map((link) => (
                     <Link

--- a/frontend/src/components/layout/HeaderPotTotal.tsx
+++ b/frontend/src/components/layout/HeaderPotTotal.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { CircleDollarSign } from 'lucide-react';
+
+import { useAuthContext } from '@/providers/AuthProvider';
+
+interface TournamentSlice {
+  potTotalCAD: number;
+}
+
+const POT_FORMATTER = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+  maximumFractionDigits: 0,
+});
+
+/**
+ * Small inline badge showing the live pot total in the Header. Visible only
+ * to authenticated users. Shares the ['tournament'] React Query cache key
+ * with HomePageContent, so it doesn't trigger an extra request when both
+ * are mounted on /.
+ */
+export function HeaderPotTotal({
+  className,
+}: {
+  className?: string;
+}) {
+  const { user, loading } = useAuthContext();
+  const query = useQuery<TournamentSlice>({
+    queryKey: ['tournament'],
+    enabled: !loading && !!user,
+    queryFn: async () => {
+      const res = await fetch('/api/tournament');
+      if (!res.ok) throw new Error('Failed to fetch tournament');
+      return res.json();
+    },
+  });
+
+  if (!user || !query.data) return null;
+
+  return (
+    <div
+      className={`text-muted-foreground flex items-center gap-1.5 text-sm font-medium ${className ?? ''}`}
+      aria-label={`Pot total ${POT_FORMATTER.format(query.data.potTotalCAD)}`}
+    >
+      <CircleDollarSign className="h-4 w-4" aria-hidden />
+      <span className="text-foreground">
+        Pot {POT_FORMATTER.format(query.data.potTotalCAD)}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/__tests__/Footer.test.tsx
+++ b/frontend/src/components/layout/__tests__/Footer.test.tsx
@@ -11,7 +11,7 @@ describe('Footer', () => {
     it('should render branding text', () => {
       render(<Footer />);
 
-      expect(screen.getByText('WC2026 Prediction Game')).toBeInTheDocument();
+      expect(screen.getByText('soccer-pool 2026')).toBeInTheDocument();
       expect(screen.getByText('Bracket predictions for the FIFA World Cup 2026')).toBeInTheDocument();
     });
 
@@ -37,7 +37,7 @@ describe('Footer', () => {
     it('should render Rules link', () => {
       render(<Footer />);
 
-      const rulesLink = screen.getByRole('link', { name: 'Rules' });
+      const rulesLink = screen.getByRole('link', { name: 'Rules & Scoring' });
       expect(rulesLink).toBeInTheDocument();
       expect(rulesLink).toHaveAttribute('href', '/rules');
     });

--- a/frontend/src/components/layout/__tests__/PageLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/PageLayout.test.tsx
@@ -13,13 +13,18 @@ jest.mock('@/hooks/useRewardsStatus', () => ({
     status: {
       referralCode: null,
       totalAvailable: 0,
-      referral: { available: 0, qualifiedTotal: 0, redeemedTotal: 0 },
+      referral: { available: 0, qualifiedTotal: 0, earned: 0, redeemedTotal: 0 },
       loyalty: { available: 0, earned: 0, redeemed: 0, cashPaid: 0 },
     },
     isLoading: false,
     refetch: async () => ({ data: null }),
   }),
   REWARDS_STATUS_QUERY_KEY: ['rewardsStatus'],
+}));
+
+// HeaderPotTotal also calls useQuery — stub it out for the same reason.
+jest.mock('../HeaderPotTotal', () => ({
+  HeaderPotTotal: () => null,
 }));
 
 import { PageLayout } from '../PageLayout';

--- a/frontend/src/components/marketing/DonationsToCharity.tsx
+++ b/frontend/src/components/marketing/DonationsToCharity.tsx
@@ -1,0 +1,33 @@
+import { HeartHandshake } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PRICING } from '@/lib/constants';
+
+export function DonationsToCharity() {
+  return (
+    <section className="py-12">
+      <h2 className="mb-8 text-center text-2xl font-bold md:text-3xl">
+        Donations to Charity
+      </h2>
+      <Card className="mx-auto max-w-3xl">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <HeartHandshake className="h-5 w-5" />
+            ${PRICING.charityPortionCAD} {PRICING.currency} from every entry
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-3 text-sm">
+          <p>
+            Each prediction sets aside ${PRICING.charityPortionCAD}{' '}
+            {PRICING.currency} for a charity the pool organizer announces before
+            lock.
+          </p>
+          <p>
+            Final partner, running total, and impact updates will be published
+            here. Stay tuned.
+          </p>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- **Rebrand**: visible \"WC2026\" → \"soccer-pool 2026\" in the Header, Footer, all page \`<title>\` metadata, and the Web Share API title used when a user shares their referral link. Internal strings (Zustand devtools key, source comments, repo path) untouched.
- **Nav rename**: \"Rules\" → \"Rules & Scoring\" in both Header and Footer nav lists (the \`/rules\` page already hosts the ScoringBreakdown component, so the label is now descriptive).
- **Homepage swap**: \`ScoringBreakdown\` removed from the Homepage; new \`DonationsToCharity\` placeholder card takes its place. \`/rules\` still mounts ScoringBreakdown unchanged.
- **Pot Total**: \`/api/tournament\` derives entry counts live (the legacy \`tournaments.total_entries\` column was never updated by any migration, so the Homepage card was reading 0). New \`cashPaidPredictionCount\` (is_free = false, paid_at ≤ lock_time) and \`potTotalCAD\` are exposed. Homepage renders a new Pot Total card in the Tournament Overview grid (now 4-up); Header shows an inline pot-total badge for authenticated users on desktop and at the top of the mobile sheet.

## Pot Total semantics
Cash-only: \`Pot = count(paid where is_free = false) × $30\`. Referral/loyalty redemptions count as leaderboard entries but don't inflate the pot — reflects actual cash collected. Confirmed with user before implementation.

## Notes
- The Header and Homepage share the \`['tournament']\` React Query key so the badge doesn't trigger an extra fetch when both are mounted on \`/\`.
- PageLayout test gained a mock for HeaderPotTotal (matching the existing pattern for useRewardsStatus) since useQuery without QueryClientProvider would otherwise break the unit test.

## Test plan
- [x] \`npm test\` — 338/338 pass (updated Footer test for new brand string + Rules & Scoring link, added HeaderPotTotal mock in PageLayout test).
- [x] \`npm run typecheck\`
- [x] \`npm run lint\` — no new warnings.
- [ ] Manual: visit \`/\` logged out → see new brand, Rules & Scoring nav, Pot Total card; log in → see Pot Total badge in header; open the mobile sheet → see badge at top. Visit \`/rules\` → ScoringBreakdown still renders. Pay 3 cash predictions + redeem 1 free pick → totalEntries=4, Pot Total=\$90.