### PR TITLE
chore(seo): block search-engine indexing site-wide

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -17,6 +17,7 @@ export const metadata: Metadata = {
   title: 'World Cup 2026 Prediction Game',
   description:
     'Submit your bracket predictions for the FIFA World Cup 2026 and compete on the leaderboard.',
+  robots: { index: false, follow: false },
   openGraph: {
     title: 'World Cup 2026 Prediction Game',
     description:

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+
+// Block all polite crawlers from the entire site. The companion
+// `robots: { index: false, follow: false }` entry on the root layout
+// metadata adds a <meta name="robots"> tag so pages already discovered
+// (e.g. via social shares) drop out of indexes too.
+//
+// This file produces /robots.txt at build time via the App Router. To
+// re-open the site to crawlers later, delete this file (and the metadata
+// entry on layout.tsx).
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', disallow: '/' },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds \`frontend/src/app/robots.ts\` so the App Router emits \`/robots.txt\` with \`User-agent: * / Disallow: /\`.
- Adds \`robots: { index: false, follow: false }\` to the root layout metadata so a \`<meta name=\"robots\">\` tag goes out on every page — covers URLs that get discovered through shares/backlinks even though robots.txt blocks crawling.

## Coverage
Only well-behaved crawlers (Google, Bing, etc.) respect this. Malicious scrapers ignore robots.txt entirely — if/when we need to block those, the right layer is Cloudflare (Bot Fight Mode or a WAF \"block all bots\" rule).

## Reverting
Delete \`robots.ts\` and remove the \`robots\` entry from \`layout.tsx\` to reopen the site to indexing.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\` (no new warnings)
- [ ] Manual after deploy: \`curl https://<site>/robots.txt\` returns the disallow rule, and \`curl https://<site>/ | grep robots\` shows the noindex meta tag.