### PR TITLE
feat(about): rewrite as personal "Our Story" + Charitable Donations placeholder

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,17 +1,14 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
-import { ChevronRight, ClipboardList, Trophy, UserPlus, Users } from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { ROUTES, TOURNAMENT_CONFIG } from '@/lib/constants';
+import { PRICING } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'About | World Cup 2026',
   description:
-    'About the World Cup 2026 Prediction Game — submit bracket predictions, earn points for correct picks, and climb the leaderboard.',
+    "The story behind soccer-pool.com — how a 30-year-old friend group's prediction tradition became an online pool, and how we're using it to give back.",
 };
 
 export default function AboutPage() {
@@ -22,109 +19,64 @@ export default function AboutPage() {
           About
         </Badge>
         <h1 className="mb-4 text-3xl font-bold tracking-tight md:text-5xl">
-          About the <span className="text-primary">Prediction Game</span>
+          Our <span className="text-primary">Story</span>
         </h1>
         <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
-          A friendly bracket-prediction game for the FIFA World Cup 2026. Lock in your picks
-          before kickoff, watch results roll in, and see how your bracket stacks up against
-          everyone else&apos;s.
+          Three decades of friendly arguments, predictions, and bragging rights — now with
+          a way to give back.
         </p>
       </section>
 
       <section className="py-8">
-        <h2 className="mb-8 text-center text-2xl font-bold md:text-3xl">How it works</h2>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-          <Card>
-            <CardHeader>
-              <UserPlus className="text-primary mb-2 h-8 w-8" />
-              <CardTitle>1. Create an account</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground text-sm">
-                Sign up with an email and password. We&apos;ll generate a username you can
-                change later from your account page.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <ClipboardList className="text-primary mb-2 h-8 w-8" />
-              <CardTitle>2. Submit predictions</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground text-sm">
-                Pick group standings, fill in the knockout bracket, and set your tiebreaker.
-                You can save up to five named predictions and edit any of them until lock.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <Users className="text-primary mb-2 h-8 w-8" />
-              <CardTitle>3. Results post</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground text-sm">
-                As matches finish, the admin posts the real-world results and points are
-                awarded automatically for each of your predictions.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <Trophy className="text-primary mb-2 h-8 w-8" />
-              <CardTitle>4. Climb the leaderboard</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-muted-foreground text-sm">
-                Every prediction is its own leaderboard entry. The closer you are to the
-                actual results, the higher you rank.
-              </p>
-            </CardContent>
-          </Card>
+        <h2 className="mb-8 text-center text-2xl font-bold md:text-3xl">How it started</h2>
+        <div className="text-muted-foreground mx-auto max-w-3xl space-y-4 text-base leading-relaxed">
+          <p>
+            My love for sports goes back as far as I can remember. Growing up, soccer was
+            always part of the conversation — especially during the World Cup and Euro
+            tournaments. Back in high school (over 30 years ago!) my friends and I would
+            spend hours debating which country was the best and predicting who would win it
+            all.
+          </p>
+          <p>
+            What started as friendly arguments eventually turned into a small prediction
+            pool between 10–15 friends using nothing more than pen and paper. Every two
+            years, the pool would return, and each tournament brought more people into the
+            fun. As the group grew, I moved everything into Excel to help automate the
+            scoring and keep track of everyone&rsquo;s predictions.
+          </p>
+          <p>
+            Later, while attending university, I met my friend David, who shared an
+            interest in web design and development. Together, we created soccer-pool.com to
+            make it easier for people to join pools, submit predictions, and follow their
+            scores throughout the tournament.
+          </p>
+          <p>
+            At its core, this has always been about bringing people together. The pool
+            gives everyone something extra to cheer for during the tournament — along with
+            a little friendly competition and bragging rights between friends. For me
+            personally, it has also become a great way to reconnect with people every
+            couple of years when the next tournament comes around.
+          </p>
+          <p>
+            This year, we decided to take things one step further by using the platform to
+            help support charities and causes that are meaningful to us. It&rsquo;s our way
+            of giving back while continuing to bring people together through the game we
+            all love.
+          </p>
         </div>
       </section>
 
       <section className="py-12">
-        <Card>
+        <Card className="mx-auto max-w-3xl">
           <CardHeader>
-            <CardTitle>What you predict</CardTitle>
-            <CardDescription>
-              Three layers, all submitted before a single tournament-wide lock time.
-            </CardDescription>
+            <CardTitle>Charitable Donations</CardTitle>
           </CardHeader>
           <CardContent>
-            <ul className="text-muted-foreground space-y-3 text-sm">
-              <li>
-                <span className="text-foreground font-semibold">Group stage standings.</span>{' '}
-                Rank teams 1st through 4th for all {TOURNAMENT_CONFIG.totalGroups} groups, plus
-                pick eight teams from your 3rd-place picks to be the best 3rd-place advancers.
-              </li>
-              <li>
-                <span className="text-foreground font-semibold">Knockout bracket.</span> Pick a
-                winner for every match from the Round of 32 through the final, including the
-                third-place match.
-              </li>
-              <li>
-                <span className="text-foreground font-semibold">Tiebreaker.</span> Predict the
-                total goals scored by the eventual champion across their eight tournament
-                matches (regulation + extra time only).
-              </li>
-            </ul>
-            <div className="mt-6 flex flex-wrap gap-3">
-              <Button asChild>
-                <Link href={ROUTES.rules}>
-                  Read the full rules
-                  <ChevronRight className="ml-1 h-4 w-4" />
-                </Link>
-              </Button>
-              <Button asChild variant="outline">
-                <Link href={ROUTES.register}>Create an account</Link>
-              </Button>
-            </div>
+            <p className="text-muted-foreground text-sm">
+              ${PRICING.charityPortionCAD} {PRICING.currency} from every ${PRICING.entryFeeCAD}{' '}
+              {PRICING.currency} entry is set aside for a charity announced before lock.
+              Details on this year&rsquo;s causes are coming soon.
+            </p>
           </CardContent>
         </Card>
       </section>


### PR DESCRIPTION
## Summary
- Replaces the generic "How it works" About page with a personal 5-paragraph narrative of how the pool started — over 30 years of pen-and-paper → Excel → soccer-pool.com.
- Adds a placeholder Charitable Donations card that surfaces the existing `$5/$30` entry split (`PRICING.charityPortionCAD`) and notes that this year's causes are coming soon.
- Trims now-unused imports (`Link`, `Button`, `ROUTES`, `TOURNAMENT_CONFIG`, four lucide icons) and updates `metadata.description` to match the new page intent.

## Test plan
- [ ] `npm run lint` clean (0 errors; verified locally)
- [ ] `npm run typecheck` clean (verified locally)
- [ ] Visit `/about` on the dev server and confirm:
  - [ ] Hero renders centered with "Our Story" title.
  - [ ] "How it started" section shows 5 paragraphs in a centered narrow prose column on mobile and desktop.
  - [ ] "Charitable Donations" card renders below with the $5/$30 teaser + "coming soon" line.
  - [ ] Footer/header still render via `PageLayout`.