### PR TITLE
chore(gitignore): ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ vite.config.ts.timestamp-*
 .claude/settings.local.json
 .claude/projects/
 .claude/sessions/
+.claude/scheduled_tasks.lock
 
 # Supabase CLI local state
 supabase/.branches/


### PR DESCRIPTION
## Summary
- Adds `.claude/scheduled_tasks.lock` to `.gitignore` (next to the existing `.claude/*` local-state entries).
- The file is a runtime lock created by Claude Code's scheduled-tasks feature — not intended to be tracked.

## Test plan
- [ ] After this lands, `git status` from a clean checkout shows no `.claude/scheduled_tasks.lock` even when the file is present locally.