### PR TITLE
fix(tournament): show real pot total to logged-out visitors via RPC

### DIFF
--- a/frontend/src/app/api/tournament/route.ts
+++ b/frontend/src/app/api/tournament/route.ts
@@ -45,34 +45,24 @@ export async function GET() {
     knockout_lock_time: string | null;
   };
 
-  // Live entry counts. Mirrors get_leaderboard's eligibility predicate
-  // (supabase/migrations/0036_champion_pick.sql:589-595): payment row with
-  // paid_at <= lock_time. totalEntries counts both cash and free-pick rows;
-  // cashPaidPredictionCount filters is_free = false so the displayed pot
-  // reflects actual money collected (not inflated by referral/loyalty
-  // redemptions).
-  const [totalEntriesRes, cashPaidRes] = await Promise.all([
-    supabase
-      .from('tournament_payments')
-      .select('prediction_id, predictions!inner(tournament_id)', {
-        count: 'exact',
-        head: true,
-      })
-      .eq('predictions.tournament_id', data.id)
-      .lte('paid_at', data.lock_time),
-    supabase
-      .from('tournament_payments')
-      .select('prediction_id, predictions!inner(tournament_id)', {
-        count: 'exact',
-        head: true,
-      })
-      .eq('predictions.tournament_id', data.id)
-      .eq('is_free', false)
-      .lte('paid_at', data.lock_time),
-  ]);
-
-  const totalEntries = totalEntriesRes.count ?? 0;
-  const cashPaidPredictionCount = cashPaidRes.count ?? 0;
+  // Live entry counts via SECURITY DEFINER RPC. A direct count against
+  // tournament_payments returns 0 for logged-out visitors because the
+  // table's RLS is own_or_admin (0016_multi_prediction_rls.sql). The
+  // RPC bypasses RLS and returns only two aggregates — safe for public
+  // display. Eligibility predicate (paid_at <= lock_time, is_free split)
+  // matches get_leaderboard.
+  const potStatsRes = await supabase.rpc('get_tournament_pot_stats', {
+    p_tournament_id: data.id,
+  });
+  if (potStatsRes.error) {
+    return NextResponse.json({ error: potStatsRes.error.message }, { status: 500 });
+  }
+  const potStats = (potStatsRes.data?.[0] ?? { total_entries: 0, cash_paid_count: 0 }) as {
+    total_entries: number;
+    cash_paid_count: number;
+  };
+  const totalEntries = potStats.total_entries;
+  const cashPaidPredictionCount = potStats.cash_paid_count;
   const potTotalCAD = cashPaidPredictionCount * PRICING.entryFeeCAD;
 
   const serverTime =

--- a/supabase/migrations/0041_tournament_pot_stats.sql
+++ b/supabase/migrations/0041_tournament_pot_stats.sql
@@ -1,0 +1,37 @@
+-- 0041_tournament_pot_stats.sql
+--
+-- Public aggregate counts for the home-page Pot Total + Total Entries
+-- displays. `tournament_payments` has an `own_or_admin` SELECT policy
+-- (see 0016_multi_prediction_rls.sql), so a logged-out visitor counting
+-- rows through the anon client sees 0 — which is why the production
+-- home page was stuck at $0 / 0 entries.
+--
+-- This RPC mirrors get_leaderboard's SECURITY DEFINER pattern: it
+-- bypasses RLS for the count, but returns only two aggregates (no
+-- per-user data) so it's safe to grant to anon + authenticated.
+--
+-- Eligibility predicate matches the route handler it replaces
+-- (frontend/src/app/api/tournament/route.ts) and get_leaderboard
+-- (0036_champion_pick.sql): `paid_at <= tournaments.lock_time`.
+
+create or replace function public.get_tournament_pot_stats(p_tournament_id uuid)
+returns table (
+    total_entries int,
+    cash_paid_count int
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    select
+        count(*)::int as total_entries,
+        count(*) filter (where tp.is_free = false)::int as cash_paid_count
+    from public.tournament_payments tp
+    join public.predictions p on p.id = tp.prediction_id
+    join public.tournaments t on t.id = p.tournament_id
+    where p.tournament_id = p_tournament_id
+      and tp.paid_at <= t.lock_time;
+$$;
+
+grant execute on function public.get_tournament_pot_stats(uuid) to anon, authenticated;


### PR DESCRIPTION
## Summary
- **Bug:** Home-page **Pot Total** and **Total Entries** were stuck at \$0 / 0 in production for logged-out visitors
- **Cause:** `/api/tournament/route.ts` counted `tournament_payments` through the cookie/anon Supabase client. The table's `own_or_admin` SELECT policy (`supabase/migrations/0016_multi_prediction_rls.sql`) hides every row when `auth.uid() IS NULL`, so `count(*)` returns 0
- **Fix:** New SECURITY DEFINER RPC `get_tournament_pot_stats(uuid)` (migration `0041_tournament_pot_stats.sql`) returns `(total_entries, cash_paid_count)` as a public aggregate. Granted to `anon` + `authenticated`, mirroring `get_leaderboard`. Eligibility predicate (`paid_at <= lock_time`, `is_free` split) is unchanged
- Route handler swaps the two raw count queries for a single RPC call

## Deploy notes
- **DB migration must be applied before the code deploy** (route handler will 500 otherwise)
- No other surfaces affected — `tournament_payments` keeps its RLS

## Test plan
- [x] `npm run lint`, `npm run typecheck`, `npm test` (338 tests) pass
- [x] Migration applied locally via `psql`; `select * from public.get_tournament_pot_stats(...)` as `postgres` returns `(4, 4)`
- [x] Same query under `set role anon;` returns `(4, 4)` (confirms RLS bypass works for the public surface)
- [x] `curl http://localhost:3000/api/tournament` (no cookie) returns `potTotalCAD: 120` (= 4 × \$30) instead of `0`