### PR TITLE
feat(leaderboard): show email instead of username for admin viewers

### DIFF
--- a/frontend/src/app/api/leaderboard/__tests__/route.test.ts
+++ b/frontend/src/app/api/leaderboard/__tests__/route.test.ts
@@ -6,6 +6,9 @@ import { NextRequest } from 'next/server';
 const supabaseMock = {
   from: jest.fn(),
   rpc: jest.fn(),
+  auth: {
+    getUser: jest.fn(),
+  },
 };
 
 jest.mock('@/lib/supabase/server', () => ({
@@ -19,10 +22,27 @@ function req(qs = '') {
   return new NextRequest(`http://localhost:3000/api/leaderboard${qs}`);
 }
 
+function mockTournamentLookup() {
+  return {
+    select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: 't1' } }) }) }),
+  };
+}
+
+function mockProfileLookup(isAdmin: boolean) {
+  return {
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  };
+}
+
 describe('GET /api/leaderboard', () => {
   beforeEach(() => {
     supabaseMock.from.mockReset();
     supabaseMock.rpc.mockReset();
+    supabaseMock.auth.getUser.mockReset();
+    // Default: anonymous caller
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
   });
 
   it('returns empty list when no active tournament', async () => {
@@ -34,10 +54,8 @@ describe('GET /api/leaderboard', () => {
     expect(await res.json()).toEqual({ entries: [], total: 0, page: 1, pageSize: 25 });
   });
 
-  it('shapes the RPC result into paginated entries', async () => {
-    supabaseMock.from.mockImplementation(() => ({
-      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: 't1' } }) }) }),
-    }));
+  it('shapes the RPC result into paginated entries (anon caller, no email)', async () => {
+    supabaseMock.from.mockImplementation(mockTournamentLookup);
     supabaseMock.rpc.mockResolvedValue({
       data: [
         {
@@ -72,12 +90,15 @@ describe('GET /api/leaderboard', () => {
       groupPoints: 60,
       knockoutPoints: 40,
     });
+    expect(body.entries[0].email).toBeUndefined();
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'get_leaderboard',
+      expect.objectContaining({ p_tournament_id: 't1' })
+    );
   });
 
   it('clamps page and pageSize', async () => {
-    supabaseMock.from.mockImplementation(() => ({
-      select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: 't1' } }) }) }),
-    }));
+    supabaseMock.from.mockImplementation(mockTournamentLookup);
     supabaseMock.rpc.mockResolvedValue({ data: [], error: null });
     await GET(req('?page=-5&pageSize=9999'));
     expect(supabaseMock.rpc).toHaveBeenCalledWith('get_leaderboard', {
@@ -85,5 +106,69 @@ describe('GET /api/leaderboard', () => {
       p_page: 1,
       p_page_size: 100,
     });
+  });
+
+  it('uses get_leaderboard (no email) for an authenticated non-admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    let callIdx = 0;
+    supabaseMock.from.mockImplementation(() => {
+      const handler = callIdx === 0 ? mockTournamentLookup() : mockProfileLookup(false);
+      callIdx += 1;
+      return handler;
+    });
+    supabaseMock.rpc.mockResolvedValue({
+      data: [
+        {
+          rank: 1,
+          username: 'alice',
+          email: 'alice@example.com',
+          points: 100,
+          group_points: 60,
+          knockout_points: 40,
+          total_count: 1,
+        },
+      ],
+      error: null,
+    });
+    const res = await GET(req());
+    const body = await res.json();
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'get_leaderboard',
+      expect.objectContaining({ p_tournament_id: 't1' })
+    );
+    // Even if the mock leaked an email, the non-admin response must not include it.
+    expect(body.entries[0].email).toBeUndefined();
+  });
+
+  it('uses admin_get_leaderboard and exposes email when caller is admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin1' } } });
+    let callIdx = 0;
+    supabaseMock.from.mockImplementation(() => {
+      const handler = callIdx === 0 ? mockTournamentLookup() : mockProfileLookup(true);
+      callIdx += 1;
+      return handler;
+    });
+    supabaseMock.rpc.mockResolvedValue({
+      data: [
+        {
+          rank: 1,
+          username: 'alice',
+          email: 'alice@example.com',
+          points: 100,
+          group_points: 60,
+          knockout_points: 40,
+          total_count: 1,
+        },
+      ],
+      error: null,
+    });
+    const res = await GET(req());
+    const body = await res.json();
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'admin_get_leaderboard',
+      expect.objectContaining({ p_tournament_id: 't1' })
+    );
+    expect(body.entries[0].email).toBe('alice@example.com');
+    expect(body.entries[0].username).toBe('alice');
   });
 });

--- a/frontend/src/app/api/leaderboard/route.ts
+++ b/frontend/src/app/api/leaderboard/route.ts
@@ -18,7 +18,24 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ entries: [], total: 0, page, pageSize });
   }
 
-  const { data, error } = await supabase.rpc('get_leaderboard', {
+  // Branch on admin status: admins get a wrapper RPC that also returns
+  // email per entry; everyone else gets the public RPC (no email field).
+  // We check is_admin via profiles since the user's session is already
+  // attached to the cookie client; admin_get_leaderboard double-checks
+  // is_admin() at the DB level so the API can't be tricked.
+  const { data: authData } = await supabase.auth.getUser();
+  let isAdmin = false;
+  if (authData.user) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('is_admin')
+      .eq('id', authData.user.id)
+      .maybeSingle();
+    isAdmin = profile?.is_admin === true;
+  }
+
+  const rpcName = isAdmin ? 'admin_get_leaderboard' : 'get_leaderboard';
+  const { data, error } = await supabase.rpc(rpcName, {
     p_tournament_id: tournament.id,
     p_page: page,
     p_page_size: pageSize,
@@ -33,6 +50,7 @@ export async function GET(request: NextRequest) {
     prediction_id: string;
     prediction_name: string;
     username: string;
+    email?: string | null;
     points: number | string;
     group_points: number;
     advancer_points: number | string;
@@ -48,6 +66,7 @@ export async function GET(request: NextRequest) {
       predictionId: row.prediction_id,
       predictionName: row.prediction_name,
       username: row.username,
+      ...(isAdmin && row.email ? { email: row.email } : {}),
       points: Number(row.points),
       change: 0,
       groupPoints: row.group_points,

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -132,7 +132,9 @@ export function LeaderboardTable({
                         <span className="text-muted-foreground ml-2 text-xs">(You)</span>
                       )}
                     </span>
-                    <span className="text-muted-foreground text-xs">{entry.username}</span>
+                    <span className="text-muted-foreground text-xs">
+                      {entry.email ?? entry.username}
+                    </span>
                   </div>
                 </TableCell>
                 <TableCell className="text-right">

--- a/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
+++ b/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
@@ -66,4 +66,13 @@ describe('LeaderboardTable', () => {
     expect(screen.getByText('2nd')).toBeInTheDocument();
     expect(screen.getByText('3rd')).toBeInTheDocument();
   });
+
+  it('renders email in place of username when present (admin view)', () => {
+    const adminEntries: LeaderboardEntry[] = [
+      { ...entries[0], email: 'alice@example.com' },
+    ];
+    render(<LeaderboardTable entries={adminEntries} />);
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/types/tournament.ts
+++ b/frontend/src/types/tournament.ts
@@ -95,6 +95,12 @@ export interface LeaderboardEntry {
   predictionId: string;
   predictionName: string;
   username: string;
+  /**
+   * Owner's email. Present only when the caller is an admin (the API
+   * route swaps in admin_get_leaderboard for admin sessions). Public
+   * /api/leaderboard responses omit this field entirely.
+   */
+  email?: string;
   points: number;
   change: number;
   groupPoints: number;

--- a/supabase/migrations/0042_admin_get_leaderboard.sql
+++ b/supabase/migrations/0042_admin_get_leaderboard.sql
@@ -1,0 +1,62 @@
+-- 0042_admin_get_leaderboard.sql
+--
+-- Admin-only variant of get_leaderboard that also returns each entry's
+-- email (from auth.users). Mirrors the admin_list_users pattern from
+-- 0037_admin_list_users_email.sql: SECURITY DEFINER + an is_admin()
+-- guard at the top, granted to `authenticated` only.
+--
+-- Implementation is a thin wrapper over public.get_leaderboard so that
+-- the scoring SQL stays in one place — we just join back to predictions
+-- and auth.users to attach the email column.
+
+create or replace function public.admin_get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    email text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    champion_pick_points int,
+    total_goals int,
+    total_count bigint
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    return query
+    select
+        lb.rank,
+        lb.prediction_id,
+        lb.prediction_name,
+        lb.username,
+        u.email::text as email,
+        lb.points,
+        lb.group_points,
+        lb.advancer_points,
+        lb.knockout_points,
+        lb.champion_pick_points,
+        lb.total_goals,
+        lb.total_count
+    from public.get_leaderboard(p_tournament_id, p_page, p_page_size) lb
+    join public.predictions p on p.id = lb.prediction_id
+    left join auth.users u on u.id = p.user_id
+    order by lb.rank;
+end;
+$$;
+
+grant execute on function public.admin_get_leaderboard(uuid, int, int) to authenticated;


### PR DESCRIPTION
Part of the 5-item batch (PR 2 of 5). Companion to the email-exposure audit (PR 1) which confirmed the rest of the surface is already clean.

## Summary
- Admin viewers of \`/leaderboard\` now see the prediction owner's email under the prediction name (in place of username). Public and authenticated non-admin viewers see username, unchanged
- New SECURITY DEFINER RPC \`admin_get_leaderboard\` wraps \`get_leaderboard\` and joins \`auth.users.email\`. \`is_admin()\` guard rejects non-admin callers with \`'forbidden'\` (P0001). Granted to \`authenticated\` only, mirroring \`admin_list_users\` (\`0037_admin_list_users_email.sql\`)
- \`/api/leaderboard\` branches on \`is_admin\` looked up from the cookie session, calls the appropriate RPC, and only spreads the email field into the response when both \`isAdmin\` and \`row.email\` are present — defence in depth, so even an upstream RPC mistake can't leak
- \`LeaderboardEntry\` type gains an optional \`email?: string\`; table renders \`entry.email ?? entry.username\`

## Deploy notes
- **DB migration must be applied before the code deploy** — admin callers will 500 otherwise
- Public/anon leaderboard behaviour unchanged; non-admin authenticated callers also unchanged

## Test plan
- [x] \`npm run lint\`, \`npm run typecheck\`, \`npm test\` (341 tests, +3) all pass
- [x] DB smoke test: \`set role authenticated; set local 'request.jwt.claims' = '{...admin sub...}'\` → RPC executes, returns leaderboard rows with email
- [x] DB smoke test: anon role / non-admin → RPC raises \`'forbidden'\`
- [x] Anon \`curl /api/leaderboard\` confirmed no \`email\` field in any entry (data set is empty but field absence is the assertion)
- [x] Route tests cover both branches: anon → \`get_leaderboard\`, no email; admin → \`admin_get_leaderboard\`, email present; non-admin authenticated → \`get_leaderboard\`, email stripped even if RPC mock leaked it