### PR TITLE
feat(predictions): green/red badges for paid/unpaid status

### DIFF
--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -112,10 +112,12 @@ function PaymentRow({
           isLate ? (
             <Badge variant="destructive">paid (after lock — not eligible)</Badge>
           ) : (
-            <Badge>paid — eligible</Badge>
+            <Badge variant="default" className="bg-green-600 hover:bg-green-600/90">
+              paid — eligible
+            </Badge>
           )
         ) : (
-          <Badge variant="outline">unpaid</Badge>
+          <Badge variant="destructive">unpaid</Badge>
         )}
         {prediction.paidAt && (
           <span className="text-muted-foreground text-xs">

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -204,11 +204,11 @@ export function PredictionsListPage() {
                         <Gift className="h-3 w-3" /> Free pick
                       </Badge>
                     ) : p.isPaid ? (
-                      <Badge variant="default" className="gap-1">
+                      <Badge variant="default" className="gap-1 bg-green-600 hover:bg-green-600/90">
                         <CheckCircle2 className="h-3 w-3" /> Paid
                       </Badge>
                     ) : (
-                      <Badge variant="outline" className="gap-1">
+                      <Badge variant="destructive" className="gap-1">
                         <Clock className="h-3 w-3" /> Unpaid
                       </Badge>
                     )}

--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -102,9 +102,16 @@ export function BracketPreviewDialog({
                 <Badge variant={predictionQuery.data.submittedAt ? 'secondary' : 'outline'}>
                   {predictionQuery.data.submittedAt ? 'Submitted' : 'Draft'}
                 </Badge>
-                <Badge variant={predictionQuery.data.isPaid ? 'default' : 'outline'}>
-                  {predictionQuery.data.isPaid ? 'Paid' : 'Unpaid'}
-                </Badge>
+                {predictionQuery.data.isPaid ? (
+                  <Badge
+                    variant="default"
+                    className="bg-green-600 hover:bg-green-600/90"
+                  >
+                    Paid
+                  </Badge>
+                ) : (
+                  <Badge variant="destructive">Unpaid</Badge>
+                )}
               </>
             )}
           </DialogTitle>


### PR DESCRIPTION
Part of the 5-item batch (PR 3 of 5).

## Summary
- **Paid** badge now uses the same green style as Free Pick (\`bg-green-600\`) so the eligible states feel like one family
- **Unpaid** badge uses the destructive (red) variant so it visually pops as needing action
- Touches three render sites:
  - \`/predictions\` user list (\`PredictionsListPage\`)
  - Bracket preview dialog (\`BracketPreviewDialog\`)
  - \`/admin/users/[id]\` admin view (\`AdminUserBracket\`) — the existing "paid (after lock — not eligible)" badge stays destructive, since that's already the correct semantic for that warning state

## Test plan
- [x] \`npm run lint\`, \`npm run typecheck\`, \`npm test\` (341 tests) all pass — change is variant + className swaps only, no logic touched
- [ ] Visual eyeball after merge: log in, view \`/predictions\` and \`/admin/users/{id}\`, confirm green/red colors land correctly (couldn't drive headless login locally — Supabase auth flake)

## Note for follow-up
The local headless-auth verification path keeps tripping over the Supabase JS client + 127.0.0.1 + headless Chromium combo. Worth capturing a project skill that does session-cookie injection via the service-role admin API so future visual-verification rounds don't waste this time.