### PR TITLE
feat(admin): expand dashboard with pot, charity, rewards + top-3 users

### DIFF
--- a/frontend/src/app/admin/AdminDashboard.tsx
+++ b/frontend/src/app/admin/AdminDashboard.tsx
@@ -1,29 +1,61 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import {
+  Award,
+  Banknote,
+  CircleDollarSign,
+  Clock,
+  Crown,
+  Gift,
+  HeartHandshake,
+  ListChecks,
+  Trophy,
+  UserCheck,
+  UserPlus,
+  Users,
+} from 'lucide-react';
+
 import { PageLayout } from '@/components/layout/PageLayout';
 import { AdminNav } from '@/components/admin/AdminNav';
 import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
+import { TeamFlag } from '@/components/shared/TeamFlag';
 import { Badge } from '@/components/ui/badge';
-import type { LeaderboardEntry } from '@/types/tournament';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { LeaderboardEntry, Team } from '@/types/tournament';
 
-interface TournamentInfo {
-  id: string;
-  slug: string;
-  name: string;
-  status: 'upcoming' | 'group_stage' | 'knockout' | 'completed';
-  lockTime: string;
+interface AdminStats {
+  tournament: {
+    id: string;
+    status: 'upcoming' | 'group_stage' | 'knockout' | 'completed';
+    lockTime: string;
+    isLocked: boolean;
+  };
+  totalRegistrations: number;
+  usersWithPaidPrediction: number;
   totalEntries: number;
+  cashPaidCount: number;
+  freeEntries: number;
+  potTotalCAD: number;
+  charityTotalCAD: number;
+  referralCreditsEarned: number;
+  referralCreditsRedeemed: number;
+  loyaltyCreditsEarned: number;
+  loyaltyCreditsRedeemed: number;
+  topChampionTeamId: string | null;
+  topChampionPickCount: number;
+  topUsers: Array<{
+    userId: string;
+    username: string | null;
+    email: string | null;
+    paidCount: number;
+  }>;
 }
 
 interface LeaderboardResponse {
   entries: LeaderboardEntry[];
-  total: number;
-}
-
-interface UserList {
   total: number;
 }
 
@@ -33,22 +65,91 @@ async function fetchJSON<T>(url: string): Promise<T> {
   return res.json();
 }
 
+const CAD = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+  maximumFractionDigits: 0,
+});
+
+function formatTimeRemaining(lockMs: number, nowMs: number): string {
+  const diff = lockMs - nowMs;
+  if (diff <= 0) return 'Locked';
+  const days = Math.floor(diff / 86_400_000);
+  const hours = Math.floor((diff % 86_400_000) / 3_600_000);
+  const minutes = Math.floor((diff % 3_600_000) / 60_000);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+  subtitle,
+  isLoading,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: React.ReactNode;
+  subtitle?: React.ReactNode;
+  isLoading?: boolean;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription className="flex items-center gap-2">
+          <Icon className="h-4 w-4" />
+          {label}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-8 w-20" />
+        ) : (
+          <>
+            <p className="text-2xl font-bold">{value}</p>
+            {subtitle ? (
+              <p className="text-muted-foreground mt-1 text-xs">{subtitle}</p>
+            ) : null}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export function AdminDashboard() {
-  const tournament = useQuery<TournamentInfo>({
-    queryKey: ['tournament'],
-    queryFn: () => fetchJSON('/api/tournament'),
+  const stats = useQuery<AdminStats>({
+    queryKey: ['admin-stats'],
+    queryFn: () => fetchJSON('/api/admin/stats'),
+    refetchInterval: 30_000,
   });
   const leaderboard = useQuery<LeaderboardResponse>({
     queryKey: ['leaderboard', 1],
     queryFn: () => fetchJSON('/api/leaderboard?page=1&pageSize=10'),
   });
-  const users = useQuery<UserList>({
-    queryKey: ['admin-users-count'],
-    queryFn: () => fetchJSON('/api/admin/users?pageSize=1'),
+  const teams = useQuery<Team[]>({
+    queryKey: ['teams'],
+    queryFn: () => fetchJSON('/api/teams'),
   });
 
-  const lockTime = tournament.data ? new Date(tournament.data.lockTime) : null;
-  const locked = lockTime ? new Date() >= lockTime : false;
+  // Tick once per minute so the lock countdown updates without a refetch.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const data = stats.data;
+  const isLoading = stats.isLoading;
+  const lockTime = data ? new Date(data.tournament.lockTime) : null;
+  const locked = data?.tournament.isLocked ?? false;
+
+  const topChampionTeamId = data?.topChampionTeamId ?? null;
+  const topTeam = topChampionTeamId
+    ? (teams.data?.find((t) => t.id === topChampionTeamId) ?? null)
+    : null;
 
   return (
     <PageLayout>
@@ -58,53 +159,170 @@ export function AdminDashboard() {
       </p>
       <AdminNav />
 
-      <div className="mb-6 grid gap-4 sm:grid-cols-3">
+      {/* Row 1: Tournament + Users */}
+      <h2 className="mb-3 text-lg font-semibold">Tournament</h2>
+      <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={Trophy}
+          label="Status"
+          value={
+            <Badge variant="outline" className="text-sm font-semibold">
+              {data?.tournament.status ?? '—'}
+            </Badge>
+          }
+          subtitle={locked ? 'Predictions locked' : 'Predictions open'}
+          isLoading={isLoading}
+        />
+        <StatCard
+          icon={Clock}
+          label="Lock countdown"
+          value={lockTime ? formatTimeRemaining(lockTime.getTime(), now) : '—'}
+          subtitle={lockTime?.toLocaleString()}
+          isLoading={isLoading}
+        />
+        <StatCard
+          icon={Users}
+          label="Registered users"
+          value={(data?.totalRegistrations ?? 0).toLocaleString()}
+          isLoading={isLoading}
+        />
+        <StatCard
+          icon={UserCheck}
+          label="Users with paid entry"
+          value={(data?.usersWithPaidPrediction ?? 0).toLocaleString()}
+          subtitle={
+            data && data.totalRegistrations > 0
+              ? `${Math.round((data.usersWithPaidPrediction / data.totalRegistrations) * 100)}% of registrations`
+              : null
+          }
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Row 2: Entries + Money */}
+      <h2 className="mb-3 text-lg font-semibold">Entries & money</h2>
+      <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          icon={ListChecks}
+          label="Total entries"
+          value={(data?.totalEntries ?? 0).toLocaleString()}
+          subtitle={
+            data ? `${data.cashPaidCount} cash · ${data.freeEntries} free` : null
+          }
+          isLoading={isLoading}
+        />
+        <StatCard
+          icon={Banknote}
+          label="Cash entries"
+          value={(data?.cashPaidCount ?? 0).toLocaleString()}
+          isLoading={isLoading}
+        />
+        <StatCard
+          icon={CircleDollarSign}
+          label="Pot total"
+          value={CAD.format(data?.potTotalCAD ?? 0)}
+          isLoading={isLoading}
+        />
+        <StatCard
+          icon={HeartHandshake}
+          label="Raised for charity"
+          value={CAD.format(data?.charityTotalCAD ?? 0)}
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Row 3: Credits */}
+      <h2 className="mb-3 text-lg font-semibold">Free-pick credits</h2>
+      <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <StatCard
+          icon={UserPlus}
+          label="Referral credits"
+          value={(data?.referralCreditsEarned ?? 0).toLocaleString()}
+          subtitle={
+            data ? `${data.referralCreditsRedeemed} redeemed (lifetime)` : null
+          }
+          isLoading={isLoading}
+        />
+        <StatCard
+          icon={Award}
+          label="Loyalty credits"
+          value={(data?.loyaltyCreditsEarned ?? 0).toLocaleString()}
+          subtitle={
+            data ? `${data.loyaltyCreditsRedeemed} redeemed (this tournament)` : null
+          }
+          isLoading={isLoading}
+        />
+        <StatCard
+          icon={Gift}
+          label="Free entries (applied)"
+          value={(data?.freeEntries ?? 0).toLocaleString()}
+          subtitle="Sum of redemptions on the leaderboard"
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Row 4: Engagement */}
+      <h2 className="mb-3 text-lg font-semibold">Engagement</h2>
+      <div className="mb-6 grid gap-4 sm:grid-cols-2">
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">Tournament</CardTitle>
+            <CardDescription className="flex items-center gap-2">
+              <Crown className="h-4 w-4" />
+              Most-picked champion (Phase 1)
+            </CardDescription>
           </CardHeader>
           <CardContent>
-            {tournament.isLoading ? (
-              <Skeleton className="h-6 w-32" />
-            ) : tournament.data ? (
-              <div className="space-y-1">
-                <p className="font-semibold">{tournament.data.name}</p>
-                <div className="text-muted-foreground text-sm">
-                  Status: <Badge variant="outline">{tournament.data.status}</Badge>
-                </div>
-                <div className="text-muted-foreground text-sm">
-                  Lock: {lockTime?.toLocaleString()}{' '}
-                  {locked ? <Badge variant="outline">locked</Badge> : null}
+            {isLoading ? (
+              <Skeleton className="h-8 w-40" />
+            ) : topTeam ? (
+              <div className="flex items-center gap-3">
+                <TeamFlag code={topTeam.code} className="h-8 w-12 rounded" />
+                <div>
+                  <p className="font-semibold">{topTeam.name}</p>
+                  <p className="text-muted-foreground text-xs">
+                    {data?.topChampionPickCount ?? 0} pick
+                    {(data?.topChampionPickCount ?? 0) === 1 ? '' : 's'}
+                  </p>
                 </div>
               </div>
             ) : (
-              <p className="text-muted-foreground text-sm">No active tournament</p>
+              <p className="text-muted-foreground text-sm">No picks yet</p>
             )}
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">Registered users</CardTitle>
+            <CardDescription className="flex items-center gap-2">
+              <Trophy className="h-4 w-4" />
+              Top 3 by paid entries
+            </CardDescription>
           </CardHeader>
           <CardContent>
-            {users.isLoading ? (
-              <Skeleton className="h-6 w-16" />
+            {isLoading ? (
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-full" />
+                <Skeleton className="h-5 w-full" />
+                <Skeleton className="h-5 w-full" />
+              </div>
+            ) : data && data.topUsers.length > 0 ? (
+              <ol className="space-y-2 text-sm">
+                {data.topUsers.map((u, i) => (
+                  <li key={u.userId} className="flex items-center justify-between gap-3">
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Badge variant="secondary" className="h-5 w-5 justify-center p-0">
+                        {i + 1}
+                      </Badge>
+                      <span className="truncate">{u.email ?? u.username ?? u.userId}</span>
+                    </span>
+                    <span className="text-muted-foreground shrink-0 text-xs">
+                      {u.paidCount} paid
+                    </span>
+                  </li>
+                ))}
+              </ol>
             ) : (
-              <p className="text-2xl font-bold">{users.data?.total ?? 0}</p>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base">Submissions</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {leaderboard.isLoading ? (
-              <Skeleton className="h-6 w-16" />
-            ) : (
-              <p className="text-2xl font-bold">{leaderboard.data?.total ?? 0}</p>
+              <p className="text-muted-foreground text-sm">No paid entries yet</p>
             )}
           </CardContent>
         </Card>

--- a/frontend/src/app/api/admin/stats/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/stats/__tests__/route.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment node
+ */
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route');
+
+function mockProfileAndTournament(
+  isAdmin: boolean,
+  tournament: { id: string; status: string; lock_time: string } | null = {
+    id: 't1',
+    status: 'upcoming',
+    lock_time: new Date(Date.now() + 86_400_000).toISOString(),
+  }
+) {
+  supabaseMock.from.mockImplementation((table: string) => {
+    if (table === 'tournaments') {
+      return {
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => ({ data: tournament, error: null }) }),
+        }),
+      };
+    }
+    return {
+      select: () => ({
+        eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+      }),
+    };
+  });
+}
+
+describe('GET /api/admin/stats', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when authenticated but not admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockProfileAndTournament(false);
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when no active tournament', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin1' } } });
+    mockProfileAndTournament(true, null);
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+
+  it('shapes RPC output and derives pot + charity totals', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin1' } } });
+    mockProfileAndTournament(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: [
+        {
+          total_registrations: 50,
+          users_with_paid_prediction: 12,
+          total_entries: 20,
+          cash_paid_count: 18,
+          free_entries: 2,
+          referral_credits_earned: 3,
+          referral_credits_redeemed: 1,
+          loyalty_credits_earned: 2,
+          loyalty_credits_redeemed: 0,
+          top_champion_team_id: 'bra',
+          top_champion_pick_count: 7,
+          top_users: [
+            { user_id: 'a', username: 'alice', email: 'a@x', paid_count: 5 },
+            { user_id: 'b', username: 'bob', email: 'b@x', paid_count: 3 },
+          ],
+        },
+      ],
+      error: null,
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_get_dashboard_stats', {
+      p_tournament_id: 't1',
+    });
+    expect(body.tournament.isLocked).toBe(false);
+    expect(body.totalEntries).toBe(20);
+    expect(body.cashPaidCount).toBe(18);
+    expect(body.potTotalCAD).toBe(18 * 30);
+    expect(body.charityTotalCAD).toBe(18 * 5);
+    expect(body.topChampionTeamId).toBe('bra');
+    expect(body.topUsers).toEqual([
+      { userId: 'a', username: 'alice', email: 'a@x', paidCount: 5 },
+      { userId: 'b', username: 'bob', email: 'b@x', paidCount: 3 },
+    ]);
+  });
+
+  it('marks tournament as locked when lock_time has passed', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin1' } } });
+    mockProfileAndTournament(true, {
+      id: 't1',
+      status: 'group_stage',
+      lock_time: new Date(Date.now() - 60_000).toISOString(),
+    });
+    supabaseMock.rpc.mockResolvedValue({ data: [], error: null });
+    const res = await GET();
+    const body = await res.json();
+    expect(body.tournament.isLocked).toBe(true);
+  });
+});

--- a/frontend/src/app/api/admin/stats/route.ts
+++ b/frontend/src/app/api/admin/stats/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { PRICING } from '@/lib/constants';
+
+export async function GET() {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const { data: tournament, error: tErr } = await ctx.supabase
+    .from('tournaments')
+    .select('id, status, lock_time')
+    .eq('is_active', true)
+    .maybeSingle();
+  if (tErr) return NextResponse.json({ error: tErr.message }, { status: 500 });
+  if (!tournament) return NextResponse.json({ error: 'No active tournament' }, { status: 404 });
+
+  const { data, error } = await ctx.supabase.rpc('admin_get_dashboard_stats', {
+    p_tournament_id: tournament.id,
+  });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const row = (data?.[0] ?? {}) as {
+    total_registrations?: number;
+    users_with_paid_prediction?: number;
+    total_entries?: number;
+    cash_paid_count?: number;
+    free_entries?: number;
+    referral_credits_earned?: number;
+    referral_credits_redeemed?: number;
+    loyalty_credits_earned?: number;
+    loyalty_credits_redeemed?: number;
+    top_champion_team_id?: string | null;
+    top_champion_pick_count?: number | null;
+    top_users?: Array<{
+      user_id: string;
+      username: string | null;
+      email: string | null;
+      paid_count: number;
+    }>;
+  };
+
+  const cashPaidCount = row.cash_paid_count ?? 0;
+
+  const lockMs = tournament.lock_time ? new Date(tournament.lock_time).getTime() : null;
+  const isLocked = lockMs !== null && Date.now() >= lockMs;
+
+  return NextResponse.json({
+    tournament: {
+      id: tournament.id,
+      status: tournament.status,
+      lockTime: tournament.lock_time,
+      isLocked,
+    },
+    totalRegistrations: row.total_registrations ?? 0,
+    usersWithPaidPrediction: row.users_with_paid_prediction ?? 0,
+    totalEntries: row.total_entries ?? 0,
+    cashPaidCount,
+    freeEntries: row.free_entries ?? 0,
+    potTotalCAD: cashPaidCount * PRICING.entryFeeCAD,
+    charityTotalCAD: cashPaidCount * PRICING.charityPortionCAD,
+    referralCreditsEarned: row.referral_credits_earned ?? 0,
+    referralCreditsRedeemed: row.referral_credits_redeemed ?? 0,
+    loyaltyCreditsEarned: row.loyalty_credits_earned ?? 0,
+    loyaltyCreditsRedeemed: row.loyalty_credits_redeemed ?? 0,
+    topChampionTeamId: row.top_champion_team_id ?? null,
+    topChampionPickCount: row.top_champion_pick_count ?? 0,
+    topUsers: (row.top_users ?? []).map((u) => ({
+      userId: u.user_id,
+      username: u.username,
+      email: u.email,
+      paidCount: u.paid_count,
+    })),
+  });
+}

--- a/supabase/migrations/0043_admin_dashboard_stats.sql
+++ b/supabase/migrations/0043_admin_dashboard_stats.sql
@@ -1,0 +1,131 @@
+-- 0043_admin_dashboard_stats.sql
+--
+-- Single SECURITY DEFINER RPC that returns every aggregate the
+-- admin landing-page dashboard needs in one round-trip. Mirrors the
+-- pattern of admin_list_users / admin_get_leaderboard: is_admin()
+-- guard, grant to `authenticated`, RPC enforces auth itself.
+--
+-- Scoped to one tournament for entries / loyalty / champion-pick
+-- aggregates. Referral aggregates are lifetime (referrals.qualified_at
+-- is tournament-agnostic). Top users are scoped to the requested
+-- tournament's paid entries.
+
+drop function if exists public.admin_get_dashboard_stats(uuid);
+
+create or replace function public.admin_get_dashboard_stats(p_tournament_id uuid)
+returns table (
+    -- Users
+    total_registrations int,
+    users_with_paid_prediction int,
+
+    -- Entries
+    total_entries int,
+    cash_paid_count int,
+    free_entries int,
+
+    -- Rewards (system-wide)
+    referral_credits_earned int,
+    referral_credits_redeemed int,
+    loyalty_credits_earned int,
+    loyalty_credits_redeemed int,
+
+    -- Engagement
+    top_champion_team_id text,
+    top_champion_pick_count int,
+
+    -- Top 3 users by paid prediction count, as
+    -- [{ user_id, username, email, paid_count }, ...]
+    top_users jsonb
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+    v_lock_time timestamptz;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    select t.lock_time into v_lock_time
+    from public.tournaments t
+    where t.id = p_tournament_id;
+
+    return query
+    with paid_per_user as (
+        -- Per-user count of paid entries in the active tournament
+        -- (cash + free, paid before lock).
+        select p.user_id, count(*)::int as paid_count
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and tp.paid_at <= v_lock_time
+        group by p.user_id
+    ),
+    cash_per_user as (
+        -- Per-user count of CASH-paid entries (drives loyalty earning).
+        select p.user_id, count(*)::int as cash_count
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and tp.is_free = false
+        group by p.user_id
+    ),
+    referral_qualified_per_user as (
+        -- Per-referrer count of referees that have paid for real.
+        select referrer_id, count(*)::int as qualified
+        from public.referrals
+        where qualified_at is not null
+        group by referrer_id
+    ),
+    champion_picks as (
+        select p.champion_team_id, count(*)::int as cnt
+        from public.predictions p
+        where p.tournament_id = p_tournament_id
+          and p.champion_team_id is not null
+        group by p.champion_team_id
+        order by cnt desc, p.champion_team_id
+        limit 1
+    ),
+    top_users_cte as (
+        select
+            ppu.user_id,
+            ppu.paid_count,
+            pr.username::text as username,
+            u.email::text as email
+        from paid_per_user ppu
+        join public.profiles pr on pr.id = ppu.user_id
+        left join auth.users u on u.id = ppu.user_id
+        order by ppu.paid_count desc, pr.username
+        limit 3
+    )
+    select
+        (select count(*)::int from public.profiles)                                  as total_registrations,
+        (select count(*)::int from paid_per_user)                                    as users_with_paid_prediction,
+        (select coalesce(sum(paid_count), 0)::int from paid_per_user)                as total_entries,
+        (select coalesce(sum(cash_count), 0)::int from cash_per_user)                as cash_paid_count,
+        (select coalesce(sum(paid_count), 0)::int from paid_per_user)
+            - (select coalesce(sum(cash_count), 0)::int from cash_per_user)          as free_entries,
+        (select coalesce(sum(floor(qualified / 4)), 0)::int
+            from referral_qualified_per_user)                                        as referral_credits_earned,
+        (select count(*)::int from public.referral_redemptions)                      as referral_credits_redeemed,
+        (select coalesce(sum(floor(cash_count / 5)), 0)::int from cash_per_user)     as loyalty_credits_earned,
+        (select count(*)::int from public.loyalty_redemptions lr
+            where lr.tournament_id = p_tournament_id)                                as loyalty_credits_redeemed,
+        (select champion_team_id from champion_picks)                                as top_champion_team_id,
+        (select cnt from champion_picks)                                             as top_champion_pick_count,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'user_id', user_id,
+                'username', username,
+                'email', email,
+                'paid_count', paid_count
+            ) order by paid_count desc, username) from top_users_cte),
+            '[]'::jsonb
+        )                                                                            as top_users;
+end;
+$$;
+
+grant execute on function public.admin_get_dashboard_stats(uuid) to authenticated;


### PR DESCRIPTION
Part of the 5-item batch (PR 5 of 5 — the final one).

## Summary
Replaces the minimal three-card admin landing with a richer stats panel organized into four sections:

**Tournament**
- Status badge
- Lock countdown (ticks once/min client-side)
- Registered users
- Users with ≥1 paid entry (with % of registrations)

**Entries & money**
- Total entries (with cash/free split subtitle)
- Cash entries
- Pot total (\$)
- Raised for charity (\$)

**Free-pick credits**
- Referral credits: earned vs redeemed (lifetime)
- Loyalty credits: earned vs redeemed (this tournament)
- Free entries already applied to the leaderboard

**Engagement**
- Most-picked Phase 1 champion (with flag)
- Top 3 users by paid-prediction count (shows email + count)

The existing top-10 live leaderboard stays below.

## How it works
- New SECURITY DEFINER RPC \`admin_get_dashboard_stats(uuid)\` bundles every aggregate (users, entries, referrals, loyalty, top champion, top users JSON) into one call. \`is_admin()\` guard rejects non-admin callers with \`'forbidden'\` (P0001); granted to \`authenticated\` only — mirrors the \`admin_get_leaderboard\` / \`admin_list_users\` pattern
- \`/api/admin/stats\` wraps the RPC behind \`requireAdmin()\`, derives \`isLocked\` + \`potTotalCAD\` + \`charityTotalCAD\` server-side (using \`PRICING\` constants, matching the home page), and reshapes \`top_users\` from jsonb to camelCase
- Dashboard auto-refetches every 30s

## Deploy notes
**DB migration must be applied before the code deploy** — \`/api/admin/stats\` 500s otherwise.

## Test plan
- [x] \`npm run lint\`, \`npm run typecheck\`, \`npm test\` (346 tests, +5) pass
- [x] DB smoke test as admin: RPC returns expected aggregates for the seeded tournament (4 entries, 1 referral credit, "arg" as top champion)
- [x] DB smoke test as anon: RPC raises \`'forbidden'\`
- [x] \`curl /api/admin/stats\` unauthenticated → 401
- [x] Route tests: 401 unauth, 403 non-admin, 404 no tournament, 200 with reshape, isLocked branching
- [ ] Visual eyeball after merge: log in as admin, view /admin, confirm the four stat-section rows render correctly