### PR TITLE
fix(leaderboard): include viewer identity in React Query cache key

### DIFF
--- a/frontend/src/app/admin/AdminDashboard.tsx
+++ b/frontend/src/app/admin/AdminDashboard.tsx
@@ -126,7 +126,10 @@ export function AdminDashboard() {
     refetchInterval: 30_000,
   });
   const leaderboard = useQuery<LeaderboardResponse>({
-    queryKey: ['leaderboard', 1],
+    // /admin is gated by middleware to admins only, so the response
+    // shape will always include the admin-only `email` field. Keep
+    // the viewer-tagged key in sync with LeaderboardPageContent.
+    queryKey: ['leaderboard', 1, 'admin'],
     queryFn: () => fetchJSON('/api/leaderboard?page=1&pageSize=10'),
   });
   const teams = useQuery<Team[]>({

--- a/frontend/src/app/api/admin/stats/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/stats/__tests__/route.test.ts
@@ -1,6 +1,9 @@
 /**
  * @jest-environment node
  */
+export {}; // makes this file a module so the top-level `const` doesn't
+           // collide with identically-named consts in sibling tests.
+
 const supabaseMock = {
   auth: { getUser: jest.fn() },
   from: jest.fn(),

--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -49,9 +49,21 @@ export function LeaderboardPageContent() {
   const [highlightedRank, setHighlightedRank] = React.useState<number | null>(null);
 
   const currentUsername = profile?.username ?? null;
+  // The leaderboard response shape depends on the viewer's identity:
+  // admins get an extra `email` field, anon/auth users don't. Bake the
+  // viewer kind into the cache key so logging in/out triggers a fresh
+  // fetch instead of serving the previously-cached anon payload to a
+  // newly-authenticated admin (and vice versa). Admin editors keep
+  // invalidating by the prefix `['leaderboard', N]`, which still
+  // matches the longer key.
+  const viewerKey: 'admin' | 'auth' | 'anon' = profile?.isAdmin
+    ? 'admin'
+    : user
+      ? 'auth'
+      : 'anon';
 
   const query = useQuery<LeaderboardResponse>({
-    queryKey: ['leaderboard', currentPage],
+    queryKey: ['leaderboard', currentPage, viewerKey],
     queryFn: async () => {
       const res = await fetch(
         `/api/leaderboard?page=${currentPage}&pageSize=${DEFAULT_ITEMS_PER_PAGE}`
@@ -74,7 +86,9 @@ export function LeaderboardPageContent() {
   }, [entries, currentUsername]);
 
   const meQuery = useQuery<{ matches: LeaderboardRankMatch[] }>({
-    queryKey: ['leaderboard-me'],
+    // Caller-scoped data — key on user.id so a different signed-in
+    // user doesn't see the previous account's matches.
+    queryKey: ['leaderboard-me', user?.id ?? null],
     queryFn: async () => {
       const res = await fetch(`/api/leaderboard/me?pageSize=${DEFAULT_ITEMS_PER_PAGE}`);
       if (!res.ok) throw new Error('Failed to fetch rank');

--- a/frontend/src/lib/auth/__tests__/requireAdmin.test.ts
+++ b/frontend/src/lib/auth/__tests__/requireAdmin.test.ts
@@ -1,6 +1,9 @@
 /**
  * @jest-environment node
  */
+export {}; // makes this file a module so the top-level `const` doesn't
+           // collide with identically-named consts in sibling tests.
+
 const supabaseMock = {
   auth: { getUser: jest.fn() },
   from: jest.fn(),


### PR DESCRIPTION
## Bug
Viewing \`/leaderboard\` as anon, then signing in as an admin, kept showing usernames (the anon-cached payload) until manual refresh. The cache key was just \`['leaderboard', page]\` — so two semantically-different responses (with vs without \`email\`) shared one cache slot.

## Fix
- \`LeaderboardPageContent\`: cache key now includes a viewer kind — \`['leaderboard', page, 'admin' | 'auth' | 'anon']\`. Logging in/out changes the key → React Query refetches automatically
- \`AdminDashboard\`: pinned to \`['leaderboard', 1, 'admin']\` to stay in sync
- \`leaderboard-me\` query: now keys on \`user.id\` so a different signed-in user can't see the previous account's matches
- Admin editors keep invalidating with the prefix \`['leaderboard', 1]\`. React Query's default partial-matching catches the longer keys, so no editor changes needed

## Also
Adds \`export {}\` to two test files (\`admin/stats/route.test.ts\` + \`requireAdmin.test.ts\`) that were tripping TS2451 after the new admin stats test landed — two top-level \`const supabaseMock\` in script-mode files were leaking into one global scope.

## Test plan
- [x] \`npm run lint\`, \`npm run typecheck\`, \`npm test\` (346 tests) all pass
- [ ] Repro check after merge: load \`/leaderboard\` as anon → log in as admin → emails should appear without a manual refresh