### PR TITLE
chore(charities): deep-link Islamic Relief Canada to Palestine appeal

### DIFF
--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -92,7 +92,7 @@ export const CHARITIES = [
   {
     slug: 'islamic-relief-canada',
     name: 'Islamic Relief Canada',
-    url: 'https://islamicreliefcanada.org',
+    url: 'https://www.islamicreliefcanada.org/emergencies/palestine-appeal',
     displayUrl: 'islamicreliefcanada.org',
     logo: '/charities/islamic-relief-canada.png',
     tagline:


### PR DESCRIPTION
Updates the IRC outbound URL to `https://www.islamicreliefcanada.org/emergencies/palestine-appeal` so visitors land directly on the cause this donation is supporting.

The visible "Visit islamicreliefcanada.org" text is unchanged — the host is still accurate and the shorter text reads cleaner in the small badges. Say the word if you'd rather the displayed text reflect the deeper path.