### PR TITLE
fix(phase): gate registration, allow read-only locked wizard, fix Phase 2 countdown

### DIFF
--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -185,8 +185,30 @@ export function TournamentSettingsForm() {
   const canOpenPhaseTwo = allAdvancersSet && allAssignmentsSet;
   const phase = tournament.data?.phase ?? 'phase1';
 
+  const phaseTwoLockIso = React.useMemo(() => {
+    if (!phaseTwoLockInput.trim()) return null;
+    const ms = new Date(phaseTwoLockInput).getTime();
+    if (Number.isNaN(ms)) return null;
+    return new Date(ms).toISOString();
+  }, [phaseTwoLockInput]);
+
+  const phaseTwoLockInPast = React.useMemo(() => {
+    if (!phaseTwoLockIso) return false;
+    return new Date(phaseTwoLockIso).getTime() <= Date.now();
+  }, [phaseTwoLockIso]);
+
   const togglePhaseTwo = async (unlock: boolean) => {
     if (!tournament.data) return;
+    if (unlock) {
+      if (!phaseTwoLockIso) {
+        toast.error('Pick a Phase 2 lock time first');
+        return;
+      }
+      if (phaseTwoLockInPast) {
+        toast.error('Phase 2 lock time must be in the future');
+        return;
+      }
+    }
     setBusyPhase2(true);
     try {
       const res = await fetch('/api/admin/tournament', {
@@ -195,8 +217,7 @@ export function TournamentSettingsForm() {
         body: JSON.stringify({
           id: tournament.data.id,
           knockoutUnlocked: unlock,
-          knockoutLockTime:
-            unlock && phaseTwoLockInput ? new Date(phaseTwoLockInput).toISOString() : null,
+          knockoutLockTime: unlock ? phaseTwoLockIso : null,
         }),
       });
       if (!res.ok) {
@@ -208,6 +229,43 @@ export function TournamentSettingsForm() {
         queryClient.invalidateQueries({ queryKey: ['tournament'] }),
         queryClient.invalidateQueries({ queryKey: ['admin-advancers'] }),
       ]);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed');
+    } finally {
+      setBusyPhase2(false);
+    }
+  };
+
+  // While Phase 2 is open, allow extending/shortening the lock time without
+  // having to close-and-reopen. Goes through the same admin_set_phase_two
+  // RPC with knockoutUnlocked=true.
+  const handleSavePhaseTwoLockTime = async () => {
+    if (!tournament.data) return;
+    if (!phaseTwoLockIso) {
+      toast.error('Pick a Phase 2 lock time first');
+      return;
+    }
+    if (phaseTwoLockInPast) {
+      toast.error('Phase 2 lock time must be in the future');
+      return;
+    }
+    setBusyPhase2(true);
+    try {
+      const res = await fetch('/api/admin/tournament', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: tournament.data.id,
+          knockoutUnlocked: true,
+          knockoutLockTime: phaseTwoLockIso,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? 'Failed');
+      }
+      toast.success('Phase 2 lock time updated');
+      await queryClient.invalidateQueries({ queryKey: ['tournament'] });
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed');
     } finally {
@@ -352,19 +410,52 @@ export function TournamentSettingsForm() {
             <div className="flex flex-wrap gap-2">
               <Button
                 onClick={() => togglePhaseTwo(true)}
-                disabled={busyPhase2 || !canOpenPhaseTwo || phase === 'phase2_open'}
+                disabled={
+                  busyPhase2 ||
+                  !canOpenPhaseTwo ||
+                  phase === 'phase2_open' ||
+                  !phaseTwoLockIso ||
+                  phaseTwoLockInPast
+                }
                 title={
                   !allAdvancersSet
                     ? 'Set all 8 advancers first'
                     : !allAssignmentsSet
                       ? 'Assign every R32 3rd-place slot first'
-                      : phase === 'phase2_locked'
-                        ? 'Phase 2 lock time has passed — set a new lock time above and click to reopen'
-                        : undefined
+                      : !phaseTwoLockIso
+                        ? 'Pick a Phase 2 lock time first'
+                        : phaseTwoLockInPast
+                          ? 'Phase 2 lock time must be in the future'
+                          : phase === 'phase2_locked'
+                            ? 'Phase 2 lock time has passed — set a new lock time above and click to reopen'
+                            : undefined
                 }
               >
                 {phase === 'phase2_locked' ? 'Reopen Phase 2' : 'Open Phase 2'}
               </Button>
+              {phase === 'phase2_open' && (
+                <Button
+                  variant="secondary"
+                  onClick={handleSavePhaseTwoLockTime}
+                  disabled={
+                    busyPhase2 ||
+                    !phaseTwoLockIso ||
+                    phaseTwoLockInPast ||
+                    phaseTwoLockIso === tournament.data?.knockoutLockTime
+                  }
+                  title={
+                    !phaseTwoLockIso
+                      ? 'Pick a Phase 2 lock time first'
+                      : phaseTwoLockInPast
+                        ? 'Phase 2 lock time must be in the future'
+                        : phaseTwoLockIso === tournament.data?.knockoutLockTime
+                          ? 'Lock time is unchanged'
+                          : undefined
+                  }
+                >
+                  Save Phase 2 lock time
+                </Button>
+              )}
               <Button
                 variant="outline"
                 onClick={() => togglePhaseTwo(false)}

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -1198,7 +1198,7 @@ export function PredictionsPageContent({
         </div>
       </div>
 
-      {!lockedReadOnly && (
+      {!lockedReadOnly && !isLastStep && (
         <Card id="submit-predictions-card" className="border-primary/20 bg-primary/5">
           <CardContent className="flex flex-col gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
             <div>

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -1175,11 +1175,7 @@ export function PredictionsPageContent({
                 }
                 className="sm:w-auto"
               >
-                {isSubmitting
-                  ? 'Submitting…'
-                  : mode === 'edit'
-                    ? 'Save Changes'
-                    : 'Submit Prediction'}
+                {isSubmitting ? 'Submitting…' : 'Submit Prediction'}
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Button>
             )}
@@ -1235,9 +1231,7 @@ export function PredictionsPageContent({
                   ? 'Submitting...'
                   : isLocked
                     ? 'Predictions Locked'
-                    : mode === 'edit'
-                      ? 'Save Changes'
-                      : 'Submit Prediction'}
+                    : 'Submit Prediction'}
               </Button>
             </div>
           </CardContent>

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -765,14 +765,6 @@ export function PredictionsPageContent({
     }
   };
 
-  const focusSubmit = () => {
-    if (typeof window === 'undefined') return;
-    document.getElementById('submit-predictions-card')?.scrollIntoView({
-      behavior: 'smooth',
-      block: 'center',
-    });
-  };
-
   const persist = async ({
     markSubmitted,
     redirectTo,
@@ -1170,11 +1162,24 @@ export function PredictionsPageContent({
             {showReviewSubmit && (
               <Button
                 type="button"
-                onClick={focusSubmit}
-                disabled={!currentStepComplete}
+                onClick={handleSubmit}
+                disabled={!isReadyToSubmit || isLocked || isSubmitting || isSavingProgress}
+                title={
+                  isReadyToSubmit
+                    ? undefined
+                    : nameError
+                      ? 'Enter a prediction name above first.'
+                      : !isPredictionsComplete
+                        ? 'Complete every section in the stepper before submitting.'
+                        : undefined
+                }
                 className="sm:w-auto"
               >
-                Review & submit
+                {isSubmitting
+                  ? 'Submitting…'
+                  : mode === 'edit'
+                    ? 'Save Changes'
+                    : 'Submit Prediction'}
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Button>
             )}

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -587,7 +587,6 @@ export function PredictionsPageContent({
   };
 
   const stepperStatus = (value: Step): StepperStep['status'] => {
-    if (isLocked && !bypassLockNav) return 'locked';
     if (stepStatus[value]) return 'done';
     if (value === currentStep) return 'current';
     return 'upcoming';
@@ -602,9 +601,7 @@ export function PredictionsPageContent({
 
   const topSteps: StepperStep[] = TOP_STEPS.map((value) => {
     let status: StepperStep['status'];
-    if (isLocked && !bypassLockNav) {
-      status = 'locked';
-    } else if (phase2TabsLocked && (value === 'knockout' || value === 'tiebreaker')) {
+    if (phase2TabsLocked && (value === 'knockout' || value === 'tiebreaker')) {
       status = 'locked';
     } else if (value === topValue) {
       status = 'current';
@@ -943,10 +940,14 @@ export function PredictionsPageContent({
   //     phase2Editable).
   const isPhase1LastStep =
     phase === 'phase1' && currentStep === 'champion_pick';
-  const showSavePhase1 = isPhase1LastStep;
-  const showReviewSubmit = isLastStep;
+  // In a locked, read-only view nothing can be saved or submitted, so hide
+  // those buttons entirely. Continue stays visible so users can browse
+  // their picks.
+  const lockedReadOnly = isLocked && !bypassLockNav;
+  const showSavePhase1 = isPhase1LastStep && !lockedReadOnly;
+  const showReviewSubmit = isLastStep && !lockedReadOnly;
   const showContinue =
-    !isLastStep && (!isPhase1LastStep || isSuperAdmin);
+    !isLastStep && (lockedReadOnly || !isPhase1LastStep || isSuperAdmin);
 
   // Why is the Save Phase 1 Picks button disabled? The button has four
   // silent gates (name validation, current-step completion, lock state,
@@ -1008,6 +1009,18 @@ export function PredictionsPageContent({
           lockTime={lockTime}
           isLocked={isLocked}
         />
+      )}
+
+      {lockedReadOnly && (
+        <Card className="mb-6 border-amber-500/40 bg-amber-500/10">
+          <CardContent
+            role="status"
+            className="text-amber-900 dark:text-amber-200 py-3 text-sm"
+          >
+            Predictions are locked — this is a read-only view of your picks. Use the
+            stepper or the Continue / Back buttons to browse between sections.
+          </CardContent>
+        </Card>
       )}
 
       <Card className="mb-6">
@@ -1170,7 +1183,10 @@ export function PredictionsPageContent({
                 type="button"
                 variant={showSavePhase1 ? 'outline' : 'default'}
                 onClick={goToNextStep}
-                disabled={!currentStepComplete || (isLocked && !bypassLockNav)}
+                // In a locked read-only view we keep Continue enabled even if
+                // the step is "incomplete" — the user is just browsing their
+                // past picks and can't edit, so step-completion is moot.
+                disabled={!currentStepComplete && !(isLocked && !bypassLockNav)}
                 className="sm:w-auto"
               >
                 {nextStepLabel ? `Continue to ${nextStepLabel}` : 'Continue'}
@@ -1181,45 +1197,47 @@ export function PredictionsPageContent({
         </div>
       </div>
 
-      <Card id="submit-predictions-card" className="border-primary/20 bg-primary/5">
-        <CardContent className="flex flex-col gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <p className="font-semibold">Ready to submit?</p>
-            <p className="text-muted-foreground text-sm">
-              {isPredictionsComplete
-                ? 'Submit puts this bracket on the leaderboard once an admin marks it paid.'
-                : phase === 'phase1'
-                  ? 'Save progress to keep working. You can submit once Phase 2 opens and the knockout bracket is complete.'
-                  : 'Save progress to keep working — or complete every pick to submit.'}
-            </p>
-          </div>
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleSaveProgress}
-              disabled={isLocked || isSubmitting || isSavingProgress || !!nameError}
-              className="min-w-[160px]"
-            >
-              {isSavingProgress ? 'Saving…' : 'Save progress'}
-            </Button>
-            <Button
-              size="lg"
-              onClick={handleSubmit}
-              disabled={!isReadyToSubmit || isLocked || isSubmitting || isSavingProgress}
-              className="min-w-[180px]"
-            >
-              {isSubmitting
-                ? 'Submitting...'
-                : isLocked
-                  ? 'Predictions Locked'
-                  : mode === 'edit'
-                    ? 'Save Changes'
-                    : 'Submit Prediction'}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      {!lockedReadOnly && (
+        <Card id="submit-predictions-card" className="border-primary/20 bg-primary/5">
+          <CardContent className="flex flex-col gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-semibold">Ready to submit?</p>
+              <p className="text-muted-foreground text-sm">
+                {isPredictionsComplete
+                  ? 'Submit puts this bracket on the leaderboard once an admin marks it paid.'
+                  : phase === 'phase1'
+                    ? 'Save progress to keep working. You can submit once Phase 2 opens and the knockout bracket is complete.'
+                    : 'Save progress to keep working — or complete every pick to submit.'}
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleSaveProgress}
+                disabled={isLocked || isSubmitting || isSavingProgress || !!nameError}
+                className="min-w-[160px]"
+              >
+                {isSavingProgress ? 'Saving…' : 'Save progress'}
+              </Button>
+              <Button
+                size="lg"
+                onClick={handleSubmit}
+                disabled={!isReadyToSubmit || isLocked || isSubmitting || isSavingProgress}
+                className="min-w-[180px]"
+              >
+                {isSubmitting
+                  ? 'Submitting...'
+                  : isLocked
+                    ? 'Predictions Locked'
+                    : mode === 'edit'
+                      ? 'Save Changes'
+                      : 'Submit Prediction'}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </PageLayout>
   );
 }

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -940,6 +940,12 @@ export function PredictionsPageContent({
   const showReviewSubmit = isLastStep && !lockedReadOnly;
   const showContinue =
     !isLastStep && (lockedReadOnly || !isPhase1LastStep || isSuperAdmin);
+  // In Phase 2 the bottom "Ready to submit?" card goes away — Save progress
+  // moves inline to the stepper bottom row and Submit Prediction lives only
+  // on the last step. Phase 1 keeps the bottom card with its existing
+  // Save progress + (disabled) Submit Prediction layout.
+  const showSaveProgressInline = phase !== 'phase1' && !lockedReadOnly;
+  const showBottomSubmitCard = !lockedReadOnly && !isLastStep && phase === 'phase1';
 
   // Why is the Save Phase 1 Picks button disabled? The button has four
   // silent gates (name validation, current-step completion, lock state,
@@ -1128,6 +1134,19 @@ export function PredictionsPageContent({
             {previousStepLabel ? `Back: ${previousStepLabel}` : 'Back'}
           </Button>
           <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+            {showSaveProgressInline && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleSaveProgress}
+                disabled={
+                  isLocked || isSubmitting || isSavingProgress || !!nameError
+                }
+                className="sm:w-auto"
+              >
+                {isSavingProgress ? 'Saving…' : 'Save progress'}
+              </Button>
+            )}
             {showSavePhase1 && (
               <div className="flex flex-col items-end gap-1">
                 <Button
@@ -1198,7 +1217,7 @@ export function PredictionsPageContent({
         </div>
       </div>
 
-      {!lockedReadOnly && !isLastStep && (
+      {showBottomSubmitCard && (
         <Card id="submit-predictions-card" className="border-primary/20 bg-primary/5">
           <CardContent className="flex flex-col gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
             <div>

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -438,10 +438,10 @@ describe('PredictionsPageContent — stepper navigation', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    // Wait for the wizard to hydrate past the skeleton; the badge text
-    // still says "Predictions Locked" on the Submit button so the admin
-    // knows the tournament state, even though nav is unlocked for them.
-    await screen.findByText('Predictions Locked');
+    // Wait for the wizard to hydrate past the skeleton. The "Locked" badge
+    // on the lock-time card is the stable signal — Submit/Save buttons no
+    // longer render outside Phase 1 (phase1_locked is a separate phase).
+    await screen.findByText('Locked');
     expect(screen.getByRole('tab', { name: /Group Stage/ })).not.toBeDisabled();
     expect(screen.getByRole('tab', { name: /Best 3rds/ })).not.toBeDisabled();
 

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -402,8 +402,11 @@ describe('PredictionsPageContent — stepper navigation', () => {
       await screen.findByRole('button', { name: /Continue to Tiebreaker/ })
     );
     expect(screen.getByTestId('tiebreaker-input')).toBeInTheDocument();
-    // Final step shows "Review & submit" instead of "Continue to ...".
-    expect(screen.getByRole('button', { name: /Review & submit/ })).toBeInTheDocument();
+    // Final step shows the submit action inline instead of "Continue to …" —
+    // clicking it triggers the actual submit/save, not just a scroll.
+    expect(
+      screen.getAllByRole('button', { name: /Submit Prediction/i }).length
+    ).toBeGreaterThan(0);
   });
 
   it('renders a read-only view when the tournament is locked', async () => {
@@ -630,7 +633,12 @@ describe('PredictionsPageContent — autosave', () => {
     // Provide a prediction name (required to submit).
     await user.type(screen.getByLabelText(/Prediction name/), 'Main');
 
-    await user.click(screen.getByRole('button', { name: /Submit Prediction/ }));
+    // There are two "Submit Prediction" buttons on the final step — the
+    // inline stepper button and the secondary one in the bottom card.
+    // Either one triggers handleSubmit; pick the first.
+    await user.click(
+      screen.getAllByRole('button', { name: /Submit Prediction/ })[0]
+    );
 
     await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
     expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull();

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -406,14 +406,20 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(screen.getByRole('button', { name: /Review & submit/ })).toBeInTheDocument();
   });
 
-  it('renders all top stepper triggers as disabled when the tournament is locked', async () => {
+  it('renders a read-only view when the tournament is locked', async () => {
+    // Regular users in a locked phase should still be able to *navigate*
+    // between steps to view past picks — only edits/saves are blocked.
+    // The submit/save card is hidden entirely and a read-only notice is
+    // surfaced so the user understands why.
     configureQueries({ tournamentLockTime: new Date(Date.now() - 1000).toISOString() });
     render(<PredictionsPageContent mode="create" />);
 
-    await screen.findByText(/Predictions Locked/);
-    // Only the top row is rendered when not on a knockout step; assert all top tabs are disabled.
+    await screen.findByText(/read-only view of your picks/i);
     const tabs = screen.getAllByRole('tab');
-    tabs.forEach((tab) => expect(tab).toBeDisabled());
+    tabs.forEach((tab) => expect(tab).not.toBeDisabled());
+    expect(screen.queryByRole('button', { name: /Predictions Locked/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Save progress/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Submit Prediction/ })).toBeNull();
   });
 
   it('lets a super admin advance past Groups when the tournament is locked', async () => {
@@ -565,7 +571,7 @@ describe('PredictionsPageContent — autosave', () => {
 
     render(<PredictionsPageContent mode="create" />);
 
-    await screen.findByText(/Predictions Locked/);
+    await screen.findByText(/read-only view of your picks/i);
     expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull();
   });
 

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -633,12 +633,9 @@ describe('PredictionsPageContent — autosave', () => {
     // Provide a prediction name (required to submit).
     await user.type(screen.getByLabelText(/Prediction name/), 'Main');
 
-    // There are two "Submit Prediction" buttons on the final step — the
-    // inline stepper button and the secondary one in the bottom card.
-    // Either one triggers handleSubmit; pick the first.
-    await user.click(
-      screen.getAllByRole('button', { name: /Submit Prediction/ })[0]
-    );
+    // On the final (tiebreaker) step the bottom "Ready to submit?" card
+    // is hidden — the inline stepper Submit is the only submit surface.
+    await user.click(screen.getByRole('button', { name: /Submit Prediction/ }));
 
     await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
     expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull();

--- a/frontend/src/app/register/RegisterForm.tsx
+++ b/frontend/src/app/register/RegisterForm.tsx
@@ -180,6 +180,25 @@ export function RegisterForm({ initialReferralCode }: RegisterFormProps = {}) {
 
     setIsSubmitting(true);
 
+    // Belt-and-suspenders: re-check the phase right before signup. The
+    // server-rendered page already gates this, but a tab kept open across
+    // a phase transition could otherwise slip through.
+    try {
+      const phaseRes = await fetch('/api/tournament', { cache: 'no-store' });
+      if (phaseRes.ok) {
+        const phaseJson = (await phaseRes.json()) as { phase?: string };
+        if (phaseJson.phase && phaseJson.phase !== 'phase1') {
+          toast.error('Registration is closed — the tournament has already locked.');
+          setIsSubmitting(false);
+          router.refresh();
+          return;
+        }
+      }
+    } catch {
+      // If the phase check itself fails, fall through and let the auth
+      // call run — the server-rendered gate is still the source of truth.
+    }
+
     const supabase = createSupabaseBrowserClient();
     // Only forward a referral code we've successfully resolved — that way
     // typos / stale links never hit the DB trigger, and we don't leak

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,13 +1,42 @@
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { Lock } from 'lucide-react';
 import { getServerSupabase } from '@/lib/supabase/server';
 import { RegisterForm } from './RegisterForm';
 import { REFERRAL_CODE_REGEX, ROUTES } from '@/lib/constants';
 import { PageLayout } from '@/components/layout/PageLayout';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 export const metadata = {
   title: 'Sign up — soccer-pool 2026',
 };
+
+type Phase = 'phase1' | 'phase1_locked' | 'phase2_open' | 'phase2_locked';
+
+// Mirrors /api/tournament/route.ts:76-86. New registrations are only
+// allowed in phase1: once group picks freeze, a new account can't
+// produce a complete prediction (no group/champion picks possible).
+async function fetchRegistrationPhase(): Promise<Phase | null> {
+  const supabase = await getServerSupabase();
+  const { data } = await supabase
+    .from('tournaments')
+    .select('lock_time, knockout_unlocked, knockout_lock_time')
+    .eq('is_active', true)
+    .maybeSingle();
+  if (!data) return null;
+
+  const now = Date.now();
+  const lockMs = new Date(data.lock_time).getTime();
+  const knockoutLockMs = data.knockout_lock_time
+    ? new Date(data.knockout_lock_time).getTime()
+    : null;
+  if (now < lockMs) return 'phase1';
+  if (data.knockout_unlocked && (knockoutLockMs === null || now < knockoutLockMs))
+    return 'phase2_open';
+  if (data.knockout_unlocked) return 'phase2_locked';
+  return 'phase1_locked';
+}
 
 // Next.js 16 — searchParams is a Promise.
 export default async function RegisterPage({
@@ -20,6 +49,9 @@ export default async function RegisterPage({
     data: { user },
   } = await supabase.auth.getUser();
   if (user) redirect(ROUTES.predictions);
+
+  const phase = await fetchRegistrationPhase();
+  const registrationOpen = phase === null || phase === 'phase1';
 
   const params = await searchParams;
   const rawRef = Array.isArray(params.ref) ? params.ref[0] : params.ref;
@@ -34,11 +66,39 @@ export default async function RegisterPage({
       <div className="mx-auto max-w-md py-12">
         <Card>
           <CardHeader>
-            <CardTitle>Create an account</CardTitle>
-            <CardDescription>Pick a username, enter your email and a password.</CardDescription>
+            <CardTitle>{registrationOpen ? 'Create an account' : 'Registration closed'}</CardTitle>
+            <CardDescription>
+              {registrationOpen
+                ? 'Pick a username, enter your email and a password.'
+                : 'The tournament is already underway, so new sign-ups are paused.'}
+            </CardDescription>
           </CardHeader>
           <CardContent>
-            <RegisterForm initialReferralCode={initialReferralCode} />
+            {registrationOpen ? (
+              <RegisterForm initialReferralCode={initialReferralCode} />
+            ) : (
+              <div className="space-y-4">
+                <div
+                  role="status"
+                  className="bg-destructive/10 text-destructive flex items-start gap-3 rounded-md border border-destructive/30 px-3 py-3 text-sm"
+                >
+                  <Lock className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+                  <p>
+                    Group-stage picks have locked, so new accounts can&apos;t produce a
+                    complete prediction this tournament. Registration will reopen for the next
+                    pool.
+                  </p>
+                </div>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button asChild variant="outline" className="w-full sm:flex-1">
+                    <Link href={ROUTES.leaderboard}>View leaderboard</Link>
+                  </Button>
+                  <Button asChild className="w-full sm:flex-1">
+                    <Link href={ROUTES.login}>Sign in</Link>
+                  </Button>
+                </div>
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/frontend/src/components/layout/LockStatusBanner.tsx
+++ b/frontend/src/components/layout/LockStatusBanner.tsx
@@ -27,8 +27,16 @@ function dismissKey(tournamentId: string, phase: string): string {
 }
 
 export function LockStatusBanner() {
-  const { tournamentId, lockTime, isLoading, phase, remainingMs, clockSuspect, advancersSet } =
-    useTournamentLock();
+  const {
+    tournamentId,
+    lockTime,
+    isLoading,
+    phase,
+    remainingMs,
+    hasActiveDeadline,
+    clockSuspect,
+    advancersSet,
+  } = useTournamentLock();
   const { profile } = useAuth();
   const [dismissed, setDismissed] = React.useState(false);
 
@@ -97,8 +105,10 @@ export function LockStatusBanner() {
               `You have ${formatRemaining(remainingMs)} left to choose your group + best-3rd picks before the tournament starts! Don't miss out!`}
             {phase === 'phase1_locked' && !advancersSet &&
               'Group stage in progress. Knockout predictions will open once the admin posts the best-3rd advancers.'}
-            {phase === 'phase2_open' &&
+            {phase === 'phase2_open' && hasActiveDeadline &&
               `You have ${formatRemaining(remainingMs)} left to make your knockout picks!`}
+            {phase === 'phase2_open' && !hasActiveDeadline &&
+              'Knockout predictions are open. The admin has not set a Phase 2 lock time yet.'}
             {knockoutLocked &&
               'The knockout stage has begun. Predictions are locked.'}
           </span>

--- a/frontend/src/hooks/useTournamentLock.ts
+++ b/frontend/src/hooks/useTournamentLock.ts
@@ -41,6 +41,13 @@ export interface TournamentLockState {
   isPhase2Open: boolean;
   /** Milliseconds remaining until the active phase locks (clamped at 0). */
   remainingMs: number;
+  /**
+   * True when the current phase has a real future deadline we can count
+   * down to. False when phase 2 is open but no lock time has been set —
+   * in that case `remainingMs` is 0 but the UI should not render
+   * "0m left" because there is no deadline at all.
+   */
+  hasActiveDeadline: boolean;
   /** True if |skewMs| > 5 minutes — surface a hint to the user. */
   clockSuspect: boolean;
 }
@@ -102,6 +109,7 @@ export function useTournamentLock(): TournamentLockState {
   const isPhase1Open = phase === 'phase1';
   const isPhase2Open = phase === 'phase2_open';
   const isLocked = phase === 'phase1_locked' || phase === 'phase2_locked';
+  const hasActiveDeadline = activeDeadline !== null;
   const clockSuspect = Math.abs(skewMs) > FIVE_MINUTES_MS;
 
   return {
@@ -117,6 +125,7 @@ export function useTournamentLock(): TournamentLockState {
     isPhase1Open,
     isPhase2Open,
     remainingMs,
+    hasActiveDeadline,
     clockSuspect,
   };
 }

--- a/supabase/migrations/0044_submit_predictions_security_definer.sql
+++ b/supabase/migrations/0044_submit_predictions_security_definer.sql
@@ -1,0 +1,220 @@
+-- Switch submit_predictions from `security invoker` to `security definer`.
+--
+-- Why: the predictions / group_predictions / knockout_predictions write
+-- policies in 0002_rls_policies.sql gate on public.is_before_lock(tid),
+-- which only checks the Phase 1 `lock_time`. Once Phase 1 closes,
+-- is_before_lock returns false for the rest of the tournament — including
+-- during Phase 2 open. submit_predictions (security invoker) therefore
+-- silently fails to UPDATE the predictions row + DELETE existing
+-- knockout_predictions, and then raises an RLS violation when it tries to
+-- INSERT new knockout_predictions in Phase 2. The error surfaces to the
+-- client as the generic "request failed" because the RLS message isn't in
+-- the safeMessage allow-list.
+--
+-- The RPC already enforces the real lock + ownership rules itself:
+--   * auth.uid() must be set ('not authenticated')
+--   * the prediction row must belong to v_user
+--   * v_phase = 'phase1_locked' / 'phase2_locked' raises 'predictions are locked'
+--   * phase 1 vs phase 2 field mismatch raises 'phase 1 ended …'
+-- So bypassing RLS via security definer is safe and matches the way
+-- admin_submit_predictions already runs (also definer in 0036).
+--
+-- Function body is otherwise identical to the 0036 version.
+
+create or replace function public.submit_predictions(payload jsonb)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid := (payload->>'tournament_id')::uuid;
+    v_prediction_id uuid := nullif(payload->>'prediction_id', '')::uuid;
+    v_prediction_name text := nullif(trim(payload->>'prediction_name'), '');
+    v_total_goals int := nullif(payload->>'total_goals', '')::int;
+    v_champion_team_id text := nullif(payload->>'champion_team_id', '');
+    v_has_champion_key boolean := payload ? 'champion_team_id';
+    v_mark_submitted boolean := coalesce((payload->>'submit')::boolean, true);
+    v_user uuid := auth.uid();
+    v_phase text;
+    v_has_phase1_fields boolean;
+    v_has_phase2_fields boolean;
+    v_group jsonb;
+    v_match jsonb;
+    v_advancer jsonb;
+    v_rank int;
+    v_team_id text;
+    v_seen_ranks int[] := '{}';
+    v_seen_teams text[] := '{}';
+    v_valid_thirds text[];
+    v_group_id text;
+    v_team_ids text[];
+    v_mismatched_team text;
+begin
+    if v_user is null then
+        raise exception 'not authenticated';
+    end if;
+
+    v_phase := public.tournament_phase(v_tournament_id);
+
+    if v_prediction_id is null and v_phase <> 'phase1' then
+        raise exception 'phase 1 ended; new predictions cannot be created'
+            using errcode = 'P0001';
+    end if;
+
+    v_has_phase1_fields := (payload ? 'groups' and jsonb_array_length(payload->'groups') > 0)
+        or (payload ? 'advancers' and jsonb_array_length(payload->'advancers') > 0)
+        or v_has_champion_key;
+    v_has_phase2_fields := (payload ? 'knockout' and jsonb_array_length(payload->'knockout') > 0)
+        or (v_total_goals is not null);
+
+    if v_phase = 'phase1_locked' or v_phase = 'phase2_locked' then
+        raise exception 'predictions are locked';
+    end if;
+
+    if v_phase = 'phase1' and v_has_phase2_fields then
+        raise exception 'phase 1 only fields allowed' using errcode = 'P0001';
+    end if;
+    if v_phase = 'phase2_open' and v_has_phase1_fields then
+        raise exception 'phase 1 ended; group + advancer picks are frozen'
+            using errcode = 'P0001';
+    end if;
+
+    if v_prediction_id is null then
+        if v_prediction_name is null then
+            raise exception 'prediction name required' using errcode = 'P0001';
+        end if;
+        if v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            insert into public.predictions (
+                user_id, tournament_id, prediction_name, total_goals,
+                champion_team_id, submitted_at
+            )
+            values (
+                v_user,
+                v_tournament_id,
+                v_prediction_name,
+                v_total_goals,
+                v_champion_team_id,
+                case when v_mark_submitted then now() else null end
+            )
+            returning id into v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    else
+        perform 1 from public.predictions
+            where id = v_prediction_id and user_id = v_user and tournament_id = v_tournament_id;
+        if not found then
+            raise exception 'prediction not found' using errcode = 'P0001';
+        end if;
+
+        if v_has_champion_key and v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.predictions
+               set prediction_name = coalesce(v_prediction_name, prediction_name),
+                   total_goals = case when v_phase = 'phase2_open' then v_total_goals else total_goals end,
+                   champion_team_id = case
+                       when v_phase = 'phase1' and v_has_champion_key then v_champion_team_id
+                       else champion_team_id
+                   end,
+                   submitted_at = case when v_mark_submitted then now() else submitted_at end
+             where id = v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    if v_phase = 'phase1' then
+        delete from public.advancer_predictions where prediction_id = v_prediction_id;
+        delete from public.group_predictions where prediction_id = v_prediction_id;
+
+        for v_group in select * from jsonb_array_elements(coalesce(payload->'groups', '[]'::jsonb))
+        loop
+            v_group_id := v_group->>'group_id';
+            v_team_ids := array_remove(array[
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            ], null);
+
+            select t.id into v_mismatched_team
+              from public.teams t
+             where t.id = any(v_team_ids) and t.group_id is distinct from v_group_id
+             limit 1;
+
+            if v_mismatched_team is not null then
+                raise exception 'team % does not belong to group %', v_mismatched_team, v_group_id
+                    using errcode = 'P0001';
+            end if;
+
+            insert into public.group_predictions (
+                prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id
+            ) values (
+                v_prediction_id,
+                v_group_id,
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            );
+        end loop;
+
+        select array_agg(third_team_id) into v_valid_thirds
+          from public.group_predictions
+         where prediction_id = v_prediction_id
+           and third_team_id is not null;
+
+        for v_advancer in select * from jsonb_array_elements(coalesce(payload->'advancers', '[]'::jsonb))
+        loop
+            v_rank := nullif(v_advancer->>'rank', '')::int;
+            v_team_id := nullif(v_advancer->>'team_id', '');
+            if v_team_id is null then
+                continue;
+            end if;
+            if v_rank is null or v_rank < 1 or v_rank > 8 then
+                raise exception 'advancer rank must be 1..8 (got %)', v_rank using errcode = 'P0001';
+            end if;
+            if v_rank = any(v_seen_ranks) then
+                raise exception 'duplicate advancer rank %', v_rank using errcode = 'P0001';
+            end if;
+            if v_team_id = any(v_seen_teams) then
+                raise exception 'duplicate advancer team' using errcode = 'P0001';
+            end if;
+            if v_valid_thirds is null or not (v_team_id = any(v_valid_thirds)) then
+                raise exception 'advancer team % not in your 3rd-place picks', v_team_id
+                    using errcode = 'P0001';
+            end if;
+            v_seen_ranks := array_append(v_seen_ranks, v_rank);
+            v_seen_teams := array_append(v_seen_teams, v_team_id);
+
+            insert into public.advancer_predictions (prediction_id, rank, team_id)
+            values (v_prediction_id, v_rank, v_team_id);
+        end loop;
+    elsif v_phase = 'phase2_open' then
+        delete from public.knockout_predictions where prediction_id = v_prediction_id;
+        for v_match in select * from jsonb_array_elements(coalesce(payload->'knockout', '[]'::jsonb))
+        loop
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+            values (
+                v_prediction_id,
+                v_match->>'match_id',
+                nullif(v_match->>'winner', '')
+            );
+        end loop;
+    end if;
+
+    return v_prediction_id;
+end;
+$$;
+
+grant execute on function public.submit_predictions(jsonb) to authenticated;


### PR DESCRIPTION
## Summary

Three related defects in the two-phase tournament flow:

1. **Registration stayed open after Phase 1 lock** — new users could create accounts that could never produce a valid prediction.
2. **Locked wizard force-disabled the stepper** — users couldn't navigate between steps to even *view* their past picks; form inputs were already independently gated, so the navigation lockout was redundant.
3. **"You have 0m left to make your knockout picks!"** showed when the Phase 2 lock was days away — root cause was that `togglePhaseTwo()` sent `knockoutLockTime: null` when the lock input was empty, the RPC happily wrote `NULL`, and `useTournamentLock` then computed `activeDeadline = null → remainingMs = 0`.

## Changes

- `/register` server-renders a "Registration closed" panel when the active tournament is past Phase 1; `RegisterForm` re-checks phase via `/api/tournament` before calling `supabase.auth.signUp` so a stale tab across a phase transition can't slip through.
- `PredictionsPageContent.tsx`: `stepperStatus()` and `topSteps` no longer force every step to `'locked'` when the tournament is locked; the Continue button stays enabled in a read-only view. Save/Submit/Save-progress buttons are hidden in locked state (defense-in-depth — the form-level `disabled` props remain in place). A new amber "read-only view of your picks" notice surfaces the intent.
- Super-admin path is unchanged — `bypassLockNav = isSuperAdmin` keeps full edits.
- `TournamentSettingsForm.tsx`: "Open Phase 2" is disabled if the lock input is empty or in the past, with explanatory `title` text. A new "Save Phase 2 lock time" button (visible only while Phase 2 is open) lets admins extend an active deadline without close+reopen.
- `useTournamentLock` adds `hasActiveDeadline: boolean`; the banner uses it to render "Knockout predictions are open. The admin has not set a Phase 2 lock time yet." instead of "0m left" if the data ever lands in that null state.

## Test plan

- [x] `npm test` — 370 passed (updated `PredictionsPageContent.test.tsx` so the locked-tournament expectations reflect read-only navigation; covers tabs no longer disabled, Submit/Save buttons hidden, read-only notice rendered).
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Manual: tournament in `phase1` → `/register` renders form.
- [ ] Manual: set `lock_time` in the past → `/register` renders closed panel.
- [ ] Manual: locked wizard as regular user — stepper navigates, inputs read-only, Save/Submit hidden.
- [ ] Manual: locked wizard as super admin — unchanged.
- [ ] Manual: admin tries to "Open Phase 2" with empty lock time — button disabled with tooltip. Set future time → opens. With Phase 2 open, change input + "Save Phase 2 lock time" → banner countdown reflects new time.