### PR TITLE
feat(bracket-preview): show user, gut-feeling champion, and tiebreaker goals

### DIFF
--- a/frontend/src/app/api/admin/users/[id]/predictions/[predictionId]/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/[predictionId]/route.ts
@@ -31,13 +31,21 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   const { data: prediction } = await ctx.supabase
     .from('predictions')
     .select(
-      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, profiles!user_id(username), tournament_payments!prediction_id(paid_at, marked_by)'
+      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at, marked_by)'
     )
     .eq('id', predictionId)
     .eq('user_id', userId)
     .maybeSingle();
 
   if (!prediction) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  // predictions.user_id FK is on auth.users, not public.profiles, so we
+  // fetch the username separately (admins always have profile read).
+  const { data: profileRow } = await ctx.supabase
+    .from('profiles')
+    .select('username')
+    .eq('id', userId)
+    .maybeSingle();
 
   const [groupsRes, knockoutRes, advancersRes] = await Promise.all([
     ctx.supabase
@@ -55,10 +63,8 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   ]);
 
   type Payment = { paid_at: string | null; marked_by: string | null };
-  type ProfileEmbed = { username: string | null } | { username: string | null }[] | null;
   type Pred = typeof prediction & {
     tournament_payments: Payment | Payment[] | null;
-    profiles: ProfileEmbed;
   };
   const p = prediction as Pred;
   const rawPayment = p.tournament_payments;
@@ -67,12 +73,11 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     : Array.isArray(rawPayment)
       ? (rawPayment[0] ?? null)
       : rawPayment;
-  const profile = Array.isArray(p.profiles) ? (p.profiles[0] ?? null) : p.profiles;
 
   return NextResponse.json({
     id: p.id,
     name: p.prediction_name,
-    username: profile?.username ?? null,
+    username: profileRow?.username ?? null,
     tournamentId: p.tournament_id,
     totalGoals: p.total_goals,
     championTeamId: p.champion_team_id,

--- a/frontend/src/app/api/admin/users/[id]/predictions/[predictionId]/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/[predictionId]/route.ts
@@ -31,7 +31,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   const { data: prediction } = await ctx.supabase
     .from('predictions')
     .select(
-      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at, marked_by)'
+      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, profiles!user_id(username), tournament_payments!prediction_id(paid_at, marked_by)'
     )
     .eq('id', predictionId)
     .eq('user_id', userId)
@@ -55,8 +55,10 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   ]);
 
   type Payment = { paid_at: string | null; marked_by: string | null };
+  type ProfileEmbed = { username: string | null } | { username: string | null }[] | null;
   type Pred = typeof prediction & {
     tournament_payments: Payment | Payment[] | null;
+    profiles: ProfileEmbed;
   };
   const p = prediction as Pred;
   const rawPayment = p.tournament_payments;
@@ -65,10 +67,12 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     : Array.isArray(rawPayment)
       ? (rawPayment[0] ?? null)
       : rawPayment;
+  const profile = Array.isArray(p.profiles) ? (p.profiles[0] ?? null) : p.profiles;
 
   return NextResponse.json({
     id: p.id,
     name: p.prediction_name,
+    username: profile?.username ?? null,
     tournamentId: p.tournament_id,
     totalGoals: p.total_goals,
     championTeamId: p.champion_team_id,

--- a/frontend/src/app/api/predictions/[id]/route.ts
+++ b/frontend/src/app/api/predictions/[id]/route.ts
@@ -32,7 +32,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   const { data: prediction } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at, is_free)'
+      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, user_id, profiles!user_id(username), tournament_payments!prediction_id(paid_at, is_free)'
     )
     .eq('id', id)
     .maybeSingle();
@@ -57,8 +57,10 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   ]);
 
   type Payment = { paid_at: string | null; is_free: boolean | null };
+  type ProfileEmbed = { username: string | null } | { username: string | null }[] | null;
   type Pred = typeof prediction & {
     tournament_payments: Payment | Payment[] | null;
+    profiles: ProfileEmbed;
   };
   const p = prediction as Pred;
   const rawPayment = p.tournament_payments;
@@ -67,10 +69,12 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     : Array.isArray(rawPayment)
       ? (rawPayment[0] ?? null)
       : rawPayment;
+  const profile = Array.isArray(p.profiles) ? (p.profiles[0] ?? null) : p.profiles;
 
   return NextResponse.json({
     id: p.id,
     name: p.prediction_name,
+    username: profile?.username ?? null,
     tournamentId: p.tournament_id,
     totalGoals: p.total_goals,
     championTeamId: p.champion_team_id,

--- a/frontend/src/app/api/predictions/[id]/route.ts
+++ b/frontend/src/app/api/predictions/[id]/route.ts
@@ -32,7 +32,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   const { data: prediction } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, user_id, profiles!user_id(username), tournament_payments!prediction_id(paid_at, is_free)'
+      'id, prediction_name, tournament_id, total_goals, champion_team_id, submitted_at, user_id, tournament_payments!prediction_id(paid_at, is_free)'
     )
     .eq('id', id)
     .maybeSingle();
@@ -40,6 +40,15 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   if (!prediction) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
+
+  // predictions.user_id FK is on auth.users, not public.profiles, so the
+  // embed shortcut doesn't resolve — fetch the username with a small
+  // follow-up query gated by the existing RLS on profiles_select_all.
+  const { data: profileRow } = await supabase
+    .from('profiles')
+    .select('username')
+    .eq('id', prediction.user_id)
+    .maybeSingle();
 
   const [groupsRes, knockoutRes, advancersRes] = await Promise.all([
     supabase
@@ -57,10 +66,8 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   ]);
 
   type Payment = { paid_at: string | null; is_free: boolean | null };
-  type ProfileEmbed = { username: string | null } | { username: string | null }[] | null;
   type Pred = typeof prediction & {
     tournament_payments: Payment | Payment[] | null;
-    profiles: ProfileEmbed;
   };
   const p = prediction as Pred;
   const rawPayment = p.tournament_payments;
@@ -69,12 +76,11 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     : Array.isArray(rawPayment)
       ? (rawPayment[0] ?? null)
       : rawPayment;
-  const profile = Array.isArray(p.profiles) ? (p.profiles[0] ?? null) : p.profiles;
 
   return NextResponse.json({
     id: p.id,
     name: p.prediction_name,
-    username: profile?.username ?? null,
+    username: profileRow?.username ?? null,
     tournamentId: p.tournament_id,
     totalGoals: p.total_goals,
     championTeamId: p.champion_team_id,

--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Trophy, User as UserIcon } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import {
@@ -13,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BracketView } from '@/components/predictions/BracketView';
+import { TeamFlag } from '@/components/shared/TeamFlag';
 import type {
   Group,
   KnockoutMatch,
@@ -23,7 +25,9 @@ import type {
 interface PredictionDetail {
   id: string;
   name: string;
+  username: string | null;
   totalGoals: number | null;
+  championTeamId: string | null;
   submittedAt: string | null;
   isPaid: boolean;
   paidAt: string | null;
@@ -135,26 +139,92 @@ export function BracketPreviewDialog({
         )}
 
         {ready && (
-          <BracketView
-            matches={matchesQuery.data!}
-            teams={teamsQuery.data!}
-            groupPredictions={(predictionQuery.data!.groups ?? []).map((g) => ({
-              groupId: g.groupId,
-              positions: {
-                first: g.first,
-                second: g.second,
-                third: g.third,
-                fourth: g.fourth,
-              },
-            }))}
-            knockoutPredictions={(predictionQuery.data!.knockout ?? []).map((k) => ({
-              matchId: k.matchId,
-              winnerId: k.winner,
-            }))}
-            bracketAssignments={bracketAssignments}
-          />
+          <>
+            <PredictionMetaBar
+              username={predictionQuery.data!.username}
+              championTeamId={predictionQuery.data!.championTeamId}
+              totalGoals={predictionQuery.data!.totalGoals}
+              teams={teamsQuery.data!}
+            />
+            <BracketView
+              matches={matchesQuery.data!}
+              teams={teamsQuery.data!}
+              groupPredictions={(predictionQuery.data!.groups ?? []).map((g) => ({
+                groupId: g.groupId,
+                positions: {
+                  first: g.first,
+                  second: g.second,
+                  third: g.third,
+                  fourth: g.fourth,
+                },
+              }))}
+              knockoutPredictions={(predictionQuery.data!.knockout ?? []).map((k) => ({
+                matchId: k.matchId,
+                winnerId: k.winner,
+              }))}
+              bracketAssignments={bracketAssignments}
+            />
+          </>
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+interface PredictionMetaBarProps {
+  username: string | null;
+  championTeamId: string | null;
+  totalGoals: number | null;
+  teams: Team[];
+}
+
+function PredictionMetaBar({
+  username,
+  championTeamId,
+  totalGoals,
+  teams,
+}: PredictionMetaBarProps) {
+  const championTeam = championTeamId
+    ? (teams.find((t) => t.id === championTeamId) ?? null)
+    : null;
+
+  return (
+    <dl className="bg-muted/40 grid gap-3 rounded-md border px-4 py-3 text-sm sm:grid-cols-3">
+      <div className="flex items-start gap-2">
+        <UserIcon className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+        <div>
+          <dt className="text-muted-foreground text-xs">User</dt>
+          <dd className="font-medium">{username ? `@${username}` : '—'}</dd>
+        </div>
+      </div>
+      <div className="flex items-start gap-2">
+        <Trophy className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+        <div>
+          <dt className="text-muted-foreground text-xs">Gut Feeling Champion</dt>
+          <dd className="font-medium">
+            {championTeam ? (
+              <span className="inline-flex items-center gap-1.5">
+                <TeamFlag code={championTeam.code} className="h-4 w-6" />
+                {championTeam.name}
+              </span>
+            ) : (
+              '—'
+            )}
+          </dd>
+        </div>
+      </div>
+      <div className="flex items-start gap-2">
+        <span
+          aria-hidden
+          className="text-muted-foreground mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center text-base leading-none"
+        >
+          ⚽
+        </span>
+        <div>
+          <dt className="text-muted-foreground text-xs">Champion total goals</dt>
+          <dd className="font-medium">{totalGoals != null ? totalGoals : '—'}</dd>
+        </div>
+      </div>
+    </dl>
   );
 }


### PR DESCRIPTION
## Summary

The Prediction Preview (read-only bracket dialog) was missing three useful fields:

- **User** — whose bracket you're viewing (especially relevant from the leaderboard / admin contexts)
- **Gut Feeling Champion** — the Phase 1 champion pick (with team flag)
- **Champion total goals** — the tiebreaker prediction

Add a compact 3-column meta bar above the BracketView that surfaces all three.

## Changes

- `BracketPreviewDialog.tsx`: new \`PredictionMetaBar\` subcomponent rendered between the dialog header and the bracket. Extends \`PredictionDetail\` with \`username\` + \`championTeamId\`.
- \`/api/predictions/[id]\` GET — joins \`profiles!user_id(username)\`, returns \`username\` alongside the existing payload.
- \`/api/admin/users/[id]/predictions/[predictionId]\` GET — same join + field.
- \`/api/leaderboard/prediction/[id]\` already returned \`username\` + \`champion_team_id\` + \`total_goals\` (via \`get_public_prediction\` RPC), so no change needed.

The dialog now renders identically whether opened from the user's own predictions list, the admin user-bracket view, or the leaderboard.

## Test plan

- [x] \`npm test\` — 370/370 passing
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` — no new errors
- [ ] Manual: open the preview from \`/predictions\` → meta bar shows your username, your champion pick (with flag), and your tiebreaker number.
- [ ] Manual: open from \`/leaderboard\` → meta bar shows the row's user (not you).
- [ ] Manual: open from \`/admin/users/<id>\` → meta bar shows that user's username.
- [ ] Manual: prediction with no champion pick / no tiebreaker (legacy or in-progress) renders \`—\` placeholders without errors.