### PR TITLE
fix(predictions): hide delete button when locked + harden delete API

### DIFF
--- a/frontend/src/app/api/predictions/[id]/route.ts
+++ b/frontend/src/app/api/predictions/[id]/route.ts
@@ -189,7 +189,45 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
   } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  // RLS handles ownership + lock + not-paid. A blocked delete returns 0 rows.
+  // Defense in depth: fetch ownership + lock + paid state before delegating
+  // to RLS, so we can return a precise 403 instead of a generic "Cannot
+  // delete". RLS would reject the same cases (and is the source of truth),
+  // but this gives the UI a useful reason it can surface to the user.
+  const { data: pred } = await supabase
+    .from('predictions')
+    .select(
+      'id, user_id, tournament_id, tournament_payments!prediction_id(prediction_id)'
+    )
+    .eq('id', id)
+    .maybeSingle();
+
+  if (!pred) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (pred.user_id !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  const payments = Array.isArray(pred.tournament_payments)
+    ? pred.tournament_payments
+    : pred.tournament_payments
+      ? [pred.tournament_payments]
+      : [];
+  if (payments.length > 0) {
+    return NextResponse.json(
+      { error: 'Ask an admin to mark this prediction unpaid before deleting.' },
+      { status: 409 }
+    );
+  }
+
+  // Reuse tournament_phase RPC so the lock check matches everywhere else.
+  const { data: phase } = await supabase.rpc('tournament_phase', {
+    tid: pred.tournament_id,
+  });
+  if (phase && phase !== 'phase1') {
+    return NextResponse.json(
+      { error: 'predictions are locked' },
+      { status: 403 }
+    );
+  }
+
   const { error, count } = await supabase
     .from('predictions')
     .delete({ count: 'exact' })

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -272,22 +272,22 @@ export function PredictionsListPage() {
                     <Eye className="h-4 w-4" />
                     <span className="sr-only">Preview</span>
                   </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setPendingDelete(p)}
-                    disabled={(isLocked && !isSuperAdmin) || p.isPaid}
-                    title={
-                      p.isPaid
-                        ? 'Ask an admin to mark unpaid before deleting'
-                        : isLocked && !isSuperAdmin
-                          ? 'Predictions are locked'
+                  {(!isLocked || isSuperAdmin) && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setPendingDelete(p)}
+                      disabled={p.isPaid}
+                      title={
+                        p.isPaid
+                          ? 'Ask an admin to mark unpaid before deleting'
                           : 'Delete'
-                    }
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    <span className="sr-only">Delete</span>
-                  </Button>
+                      }
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      <span className="sr-only">Delete</span>
+                    </Button>
+                  )}
                 </div>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary

User-reported bug: after Phase 2 locks, the prediction list still renders a Delete button on each prediction card. RLS was correctly rejecting any DELETE that actually fired (\`is_before_lock(tournament_id)\` returns false post-Phase-1, the row is filtered out, the route returned a generic \"Cannot delete\" 403), but the button being present at all read as \"this is an option I can take.\"

## Audit performed

I reviewed every non-admin write path against the four tournament phases (\`phase1\`, \`phase1_locked\`, \`phase2_open\`, \`phase2_locked\`). Summary:

| Path | UI gate | API gate | DB gate | Status |
|---|---|---|---|---|
| POST /api/predictions | ✓ \`canCreate = phase === 'phase1'\` | ✓ \`submit_predictions\` RPC | ✓ RPC + RLS | Safe |
| PATCH /api/predictions/[id] | ✓ \`phase1Editable\`/\`phase2Editable\` | ✓ \`submit_predictions\` RPC (security definer since 0044) | ✓ RPC | Safe |
| DELETE /api/predictions/[id] | ✗ rendered-but-disabled | ✗ relied on RLS only | ✓ \`predictions_delete_own_before_lock\` | **Fixed here** |
| POST /api/rewards/redeem | ✓ hidden when \`isLocked && !isSuperAdmin\` | ✗ relies on RPC | ✓ RPC raises \`'predictions are locked'\` | Safe |
| PATCH /api/profile | n/a (orthogonal to tournament state) | — | ✓ owner-only RLS | Correctly scoped |

The redeem RPC uses \`is_before_lock\` which only spans Phase 1 — this is **correct by design**: \`get_leaderboard\` filters payments with \`paid_at <= tournaments.lock_time\` (the Phase 1 lock), so a payment recorded after Phase 1 closes wouldn't make the prediction leaderboard-eligible anyway.

## Changes

- **UI** — \`PredictionsListPage.tsx\`: the Delete button is now wrapped in \`(!isLocked || isSuperAdmin)\` so it disappears entirely once the tournament leaves Phase 1 for non-admin users. Paid-but-unlocked predictions still render the disabled button + \"ask an admin\" tooltip (different state, different fix).
- **API** — \`/api/predictions/[id]\` DELETE: explicit ownership / payment / lock checks before delegating to RLS. The route now returns precise statuses (\`401\`, \`404\`, \`403 Forbidden\`, \`409\` with admin-unpaid hint, \`403 'predictions are locked'\`) instead of a generic \"Cannot delete.\" RLS remains the source of truth.

## Test plan

- [x] \`npm test\` — 370/370 passing
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` — no new errors
- [ ] Manual: in \`phase1\`, Delete button visible + functional on unpaid prediction
- [ ] Manual: in \`phase1_locked\` / \`phase2_open\` / \`phase2_locked\`, Delete button hidden for regular user
- [ ] Manual: super admin still sees Delete in every phase
- [ ] Manual: paid prediction shows disabled Delete with \"ask an admin\" tooltip in \`phase1\` (unchanged)
- [ ] Manual: crafted DELETE via curl during \`phase2_locked\` returns 403 \`{\"error\":\"predictions are locked\"}\`