### PR TITLE
fix(predictions): reorder Phase 2 wizard + 3rd place under Champion in preview

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -69,8 +69,8 @@ const STEP_ORDER: Step[] = [
   'round_of_16',
   'quarter_finals',
   'semi_finals',
-  'final',
   'third_place',
+  'final',
   'tiebreaker',
 ];
 
@@ -92,8 +92,8 @@ const KNOCKOUT_STAGE_LIST: KnockoutStage[] = [
   'round_of_16',
   'quarter_finals',
   'semi_finals',
-  'final',
   'third_place',
+  'final',
 ];
 
 const SUB_STEP_LABELS: Record<KnockoutStage, string> = {

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -391,7 +391,7 @@ describe('PredictionsPageContent — stepper navigation', () => {
     // Filling all knockout matches at once satisfies every knockout sub-step.
     await user.click(screen.getByTestId('fill-all-knockout'));
 
-    const stages = ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Third Place'];
+    const stages = ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Third Place', 'Final'];
     for (const next of stages) {
       const btn = await screen.findByRole('button', {
         name: new RegExp(`Continue to ${next}`, 'i'),
@@ -608,13 +608,13 @@ describe('PredictionsPageContent — autosave', () => {
     await user.click(screen.getByTestId('fill-champion'));
     await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
     await user.click(screen.getByTestId('fill-all-knockout'));
-    // Walk through R16 → QF → SF → Final → 3rd → Tiebreaker via Continue.
+    // Walk through R16 → QF → SF → 3rd → Final → Tiebreaker via Continue.
     for (const next of [
       'Round of 16',
       'Quarter-finals',
       'Semi-finals',
-      'Final',
       'Third Place',
+      'Final',
       'Tiebreaker',
     ]) {
       await user.click(

--- a/frontend/src/components/predictions/BracketView.tsx
+++ b/frontend/src/components/predictions/BracketView.tsx
@@ -147,51 +147,47 @@ export function BracketView({
   const thirdPlace = matchesByStage.third_place[0] ?? null;
 
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
-        {COLUMN_STAGES.map(({ stage, label }) => {
-          const stageMatches = matchesByStage[stage] ?? [];
-          if (stageMatches.length === 0) return null;
-          return (
-            <div key={stage} className="space-y-2">
-              <h3 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
-                {label}
-              </h3>
-              <div className="space-y-2">
-                {stageMatches.map((m) => (
-                  <MatchNode
-                    key={m.id}
-                    match={m}
-                    matches={matches}
-                    teams={teams}
-                    groupPredictions={groupPredictions}
-                    knockoutPredictions={knockoutPredictions}
-                    bracketAssignments={bracketAssignments}
-                  />
-                ))}
-              </div>
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
+      {COLUMN_STAGES.map(({ stage, label }) => {
+        const stageMatches = matchesByStage[stage] ?? [];
+        if (stageMatches.length === 0) return null;
+        const isFinalColumn = stage === 'final';
+        return (
+          <div key={stage} className="space-y-2">
+            <h3 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+              {label}
+            </h3>
+            <div className="space-y-2">
+              {stageMatches.map((m) => (
+                <MatchNode
+                  key={m.id}
+                  match={m}
+                  matches={matches}
+                  teams={teams}
+                  groupPredictions={groupPredictions}
+                  knockoutPredictions={knockoutPredictions}
+                  bracketAssignments={bracketAssignments}
+                />
+              ))}
             </div>
-          );
-        })}
-      </div>
-
-      {thirdPlace && (
-        <div className="space-y-2">
-          <h3 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
-            Third-place play-off
-          </h3>
-          <div className="max-w-xs">
-            <MatchNode
-              match={thirdPlace}
-              matches={matches}
-              teams={teams}
-              groupPredictions={groupPredictions}
-              knockoutPredictions={knockoutPredictions}
-              bracketAssignments={bracketAssignments}
-            />
+            {isFinalColumn && thirdPlace && (
+              <div className="space-y-2 pt-4">
+                <h3 className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+                  Third-place play-off
+                </h3>
+                <MatchNode
+                  match={thirdPlace}
+                  matches={matches}
+                  teams={teams}
+                  groupPredictions={groupPredictions}
+                  knockoutPredictions={knockoutPredictions}
+                  bracketAssignments={bracketAssignments}
+                />
+              </div>
+            )}
           </div>
-        </div>
-      )}
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -72,8 +72,8 @@ export const STAGE_ORDER: KnockoutStage[] = [
   'round_of_16',
   'quarter_finals',
   'semi_finals',
-  'final',
   'third_place',
+  'final',
 ];
 
 interface KnockoutBracketProps {


### PR DESCRIPTION
## Summary

- **Wizard reorder (Phase 2):** swap Final and Third Place so the flow becomes R32 → R16 → QF → SF → 3rd → Final → Tiebreaker, matching real tournament chronology (the 3rd-place play-off is played before the final).
- **Bracket preview dialog:** move the Third-place play-off card into the Final column so it renders directly beneath the Champion match, instead of as a separate full-width section below the grid.

User feedback drove both changes: the previous ordering put the final/champion before the 3rd-place match and showed 3rd-place detached from the bracket.

### Files touched
- `frontend/src/app/predictions/PredictionsPageContent.tsx` — swap `'final'` / `'third_place'` in `STEP_ORDER` and `KNOCKOUT_STAGE_LIST`. Step labels, navigation, and `topOf()` are order-agnostic.
- `frontend/src/components/predictions/KnockoutBracket.tsx` — mirror swap in the (currently unused) exported `STAGE_ORDER` for consistency.
- `frontend/src/components/predictions/BracketView.tsx` — render the third-place section inside the Final column rather than as a standalone block below the grid.
- `frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx` — update the two phase-2 walk-through tests to assert the new step order.

## Test plan
- [x] `npm test` (35/35 prediction tests pass — `PredictionsPageContent`, `PredictionStepper`, `KnockoutBracket`, `BracketView`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (no new warnings)
- [ ] Phase 2 wizard: open a paid prediction in `phase2_open`, walk through with Continue, confirm sub-step order R32 → R16 → QF → SF → **3rd → Final** → Tiebreaker. Confirm "Continue to …" labels match.
- [ ] Bracket preview dialog (`/predictions` → click a prediction): confirm the Third-place play-off card now sits in the Final column directly under M32 on desktop. Confirm mobile (single-column) layout still stacks cleanly.