### PR TITLE
feat(scoring): v3 knockout point values + lift tiebreaker cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
-> **Version:** 3.6.0
-> **Last Updated:** 2026-05-24
+> **Version:** 3.7.0
+> **Last Updated:** 2026-05-26
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -83,7 +83,7 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 - **`admin_list_user_referrals(p_user_id)`** — moderation view; returns inbound + outbound referrals for one user.
 - **`referrals_sync_qualification()`** — trigger on `tournament_payments` AFTER INSERT/UPDATE/DELETE. Sets `referrals.qualified_at` when the referee's first non-free payment lands; clears it on delete when the referee has no remaining non-free payments. With the aggregate model in `0039_referrals_threshold.sql`, the clear is unconditional — the `greatest(0, …)` clamp in `get_referral_status` absorbs the rare clawback-after-redeem case (already-redeemed free picks stay sticky on the leaderboard).
 
-### Scoring (v2, in `migrations/0006_scoring_v2.sql`)
+### Scoring (v3, in `migrations/0045_scoring_v3.sql`)
 
 **Group stage** — set-based on the predicted top 2 vs actual top 2:
 - both correct in exact order: `+6` (`+8` for Group I "Group of Death")
@@ -94,20 +94,20 @@ All schema/policies/RPCs live in `supabase/migrations/`. Run `supabase db reset`
 
 3rd / 4th picks are unscored but still required by the form (3rd-place picks for groups A–H seed R32 via `knockout_matches.team_source = '3X'`). Max group points = 11×6 + 8 = **74**.
 
-**Knockout** — per-round, per-advancing-team scoring with a "correct side" bonus. For each team that actually advanced from a deciding match, the user scores the higher tier if they predicted that match's winner correctly, the lower tier if they predicted that team to win some other match in the same stage, else 0:
+**Knockout** — per-round, per-match scoring with a "correct side" bonus. For each team that actually won a match in a given round, the user scores the higher tier if they predicted that exact match's winner, the lower tier if they predicted that team to win some other match in the same round, else 0:
 
-| Round (advancing to)      | deciding stage    | correct slot | wrong slot |
-|---------------------------|-------------------|--------------|------------|
-| Round of 16               | round_of_32       | +5           | +3         |
-| Quarter-finals            | round_of_16       | +6           | +3         |
-| Semi-finals               | quarter_finals    | +8           | +4         |
-| Final                     | semi_finals       | +10          | +5         |
+| Round picked     | matches | correct slot | wrong slot |
+|------------------|---------|--------------|------------|
+| Round of 32      |   16    | +4           | +3         |
+| Round of 16      |    8    | +6           | +4         |
+| Quarter-finals   |    4    | +10          | +6         |
+| Semi-finals      |    2    | +14          | +9         |
 
-Plus flat bonuses on top: champion (M32 winner) `+15`, third-place winner (M31) `+5`. Round of 32 picks aren't scored directly — they decide R16 slots. The legacy `knockout_matches.point_value` column is still in the schema but the v2 RPCs ignore it. Max knockout points = 80 + 48 + 32 + 20 + 15 + 5 = **200**. Helper function `public.knockout_round_scores(tournament_id, stage, correct_pts, wrong_pts)` is shared by `get_leaderboard` and `get_leaderboard_rank`.
+Plus flat bonuses on top: champion (M32 winner) `+15`, third-place winner (M31) `+5`. The legacy `knockout_matches.point_value` column is still in the schema but the v3 RPCs ignore it. Max knockout points = 64 + 48 + 40 + 28 + 15 + 5 = **200**. Per-round point values are sourced from `public.knockout_round_config()` (and the M31/M32/gut bonuses from `scoring_third_place_pts()` / `scoring_champion_pts()` / `scoring_champion_pick_pts()`) so future tweaks only need a single `create or replace` of the config function. Helper `public.knockout_round_scores(tournament_id, stage, correct_pts, wrong_pts)` is unchanged from 0006 and shared by `get_leaderboard` and `get_leaderboard_rank`.
 
 **Gut Feeling Champion (Phase 1)** — `+5` if `predictions.champion_team_id` matches the actual M32 winner. Independent of the bracket Final (M32) pick scoring (`+15`) — users can pick the same team for both (so a correct gut pick + correct bracket Final stacks to `+20`), or split between them. The pick is collected via a dropdown as the final Phase 1 wizard step (after Best 3rds), required at create time, and writable only while the tournament is in `phase1`; once `phase1_locked` (or later) it is frozen.
 
-**Tiebreaker** — closest prediction to the *champion's* total goals across all 8 of their tournament matches (regulation + extra time only; no penalty-shootout goals). Stored on `tournaments.champion_total_goals` (admin-entered when the tournament ends). `predictions.total_goals` is reused with a relaxed CHECK of `between 0 and 50`.
+**Tiebreaker** — closest prediction to the *champion's* total goals across all 8 of their tournament matches (regulation + extra time only; no penalty-shootout goals). Stored on `tournaments.champion_total_goals` (admin-entered when the tournament ends). `predictions.total_goals` is reused with a CHECK of `between 0 and 200`.
 
 **Grand total max: 74 + 10 + 200 + 5 = 289.** (Group 74 + Advancers 10 + Knockout 200 + Champion Pick 5.)
 

--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -106,8 +106,8 @@ export function TournamentSettingsForm() {
       championTotalGoals = null;
     } else {
       const parsed = Number(championGoals);
-      if (!Number.isInteger(parsed) || parsed < 0 || parsed > 50) {
-        toast.error("Champion's total goals must be an integer 0–50");
+      if (!Number.isInteger(parsed) || parsed < 0 || parsed > 200) {
+        toast.error("Champion's total goals must be an integer 0–200");
         return;
       }
       championTotalGoals = parsed;
@@ -316,7 +316,7 @@ export function TournamentSettingsForm() {
                     id="championGoals"
                     type="number"
                     min={0}
-                    max={50}
+                    max={200}
                     step={1}
                     placeholder="Leave blank until tournament ends"
                     value={championGoals}

--- a/frontend/src/app/api/admin/tournament/route.ts
+++ b/frontend/src/app/api/admin/tournament/route.ts
@@ -32,10 +32,10 @@ export async function PATCH(request: NextRequest) {
     body.championTotalGoals !== null &&
     (!Number.isInteger(body.championTotalGoals) ||
       body.championTotalGoals < 0 ||
-      body.championTotalGoals > 50)
+      body.championTotalGoals > 200)
   ) {
     return NextResponse.json(
-      { error: 'championTotalGoals must be an integer 0-50' },
+      { error: 'championTotalGoals must be an integer 0-200' },
       { status: 400 }
     );
   }

--- a/frontend/src/app/api/admin/users/[id]/predictions/[predictionId]/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/[predictionId]/route.ts
@@ -123,8 +123,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   if (name && (name.length > PREDICTION_NAME_MAX || !PREDICTION_NAME_REGEX.test(name))) {
     return NextResponse.json({ error: 'predictionName format invalid' }, { status: 400 });
   }
-  if (body.totalGoals != null && (body.totalGoals < 0 || body.totalGoals > 50)) {
-    return NextResponse.json({ error: 'totalGoals must be 0-50' }, { status: 400 });
+  if (body.totalGoals != null && (body.totalGoals < 0 || body.totalGoals > 200)) {
+    return NextResponse.json({ error: 'totalGoals must be 0-200' }, { status: 400 });
   }
   if (!Array.isArray(body.groups) || !Array.isArray(body.knockout)) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });

--- a/frontend/src/app/api/admin/users/[id]/predictions/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/route.ts
@@ -126,8 +126,8 @@ export async function POST(
   if (name.length > PREDICTION_NAME_MAX || !PREDICTION_NAME_REGEX.test(name)) {
     return NextResponse.json({ error: 'predictionName format invalid' }, { status: 400 });
   }
-  if (body.totalGoals != null && (body.totalGoals < 0 || body.totalGoals > 50)) {
-    return NextResponse.json({ error: 'totalGoals must be 0-50' }, { status: 400 });
+  if (body.totalGoals != null && (body.totalGoals < 0 || body.totalGoals > 200)) {
+    return NextResponse.json({ error: 'totalGoals must be 0-200' }, { status: 400 });
   }
   if (!Array.isArray(body.groups) || !Array.isArray(body.knockout)) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });

--- a/frontend/src/app/api/predictions/[id]/route.ts
+++ b/frontend/src/app/api/predictions/[id]/route.ts
@@ -128,8 +128,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   if (name && (name.length > PREDICTION_NAME_MAX || !PREDICTION_NAME_REGEX.test(name))) {
     return NextResponse.json({ error: 'predictionName format invalid' }, { status: 400 });
   }
-  if (body.totalGoals != null && (body.totalGoals < 0 || body.totalGoals > 50)) {
-    return NextResponse.json({ error: 'totalGoals must be 0-50' }, { status: 400 });
+  if (body.totalGoals != null && (body.totalGoals < 0 || body.totalGoals > 200)) {
+    return NextResponse.json({ error: 'totalGoals must be 0-200' }, { status: 400 });
   }
   if (!Array.isArray(body.groups) || !Array.isArray(body.knockout)) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });

--- a/frontend/src/app/api/predictions/__tests__/route.test.ts
+++ b/frontend/src/app/api/predictions/__tests__/route.test.ts
@@ -119,10 +119,10 @@ describe('POST /api/predictions', () => {
 
   it('returns 400 when totalGoals out of range', async () => {
     supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
-    const res = await POST(postRequest(basePostBody({ totalGoals: 99 })));
+    const res = await POST(postRequest(basePostBody({ totalGoals: 250 })));
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toMatch(/0-50/);
+    expect(body.error).toMatch(/0-200/);
   });
 
   it('returns 400 when championTeamId missing', async () => {

--- a/frontend/src/app/api/predictions/route.ts
+++ b/frontend/src/app/api/predictions/route.ts
@@ -177,8 +177,8 @@ export async function POST(request: NextRequest) {
   if (name.length > PREDICTION_NAME_MAX || !PREDICTION_NAME_REGEX.test(name)) {
     return NextResponse.json({ error: 'predictionName format invalid' }, { status: 400 });
   }
-  if (body.totalGoals != null && (body.totalGoals < 0 || body.totalGoals > 50)) {
-    return NextResponse.json({ error: 'totalGoals must be 0-50' }, { status: 400 });
+  if (body.totalGoals != null && (body.totalGoals < 0 || body.totalGoals > 200)) {
+    return NextResponse.json({ error: 'totalGoals must be 0-200' }, { status: 400 });
   }
   if (!Array.isArray(body.groups) || !Array.isArray(body.knockout)) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });

--- a/frontend/src/components/marketing/ScoringBreakdown.tsx
+++ b/frontend/src/components/marketing/ScoringBreakdown.tsx
@@ -73,31 +73,31 @@ export function ScoringBreakdown() {
             <div className="space-y-3">
               <div className="flex items-center justify-between gap-4">
                 <span className="text-muted-foreground">
-                  Round of 16{' '}
-                  <span className="text-muted-foreground/70 text-xs">(per team advancing)</span>
+                  Round of 32{' '}
+                  <span className="text-muted-foreground/70 text-xs">(per match winner)</span>
                 </span>
-                <span className="font-semibold whitespace-nowrap">+5 / +3 pts</span>
+                <span className="font-semibold whitespace-nowrap">+4 / +3 pts</span>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <span className="text-muted-foreground">
+                  Round of 16{' '}
+                  <span className="text-muted-foreground/70 text-xs">(per match winner)</span>
+                </span>
+                <span className="font-semibold whitespace-nowrap">+6 / +4 pts</span>
               </div>
               <div className="flex items-center justify-between gap-4">
                 <span className="text-muted-foreground">
                   Quarter-finals{' '}
-                  <span className="text-muted-foreground/70 text-xs">(per team advancing)</span>
+                  <span className="text-muted-foreground/70 text-xs">(per match winner)</span>
                 </span>
-                <span className="font-semibold whitespace-nowrap">+6 / +3 pts</span>
+                <span className="font-semibold whitespace-nowrap">+10 / +6 pts</span>
               </div>
               <div className="flex items-center justify-between gap-4">
                 <span className="text-muted-foreground">
                   Semi-finals{' '}
-                  <span className="text-muted-foreground/70 text-xs">(per team advancing)</span>
+                  <span className="text-muted-foreground/70 text-xs">(per match winner)</span>
                 </span>
-                <span className="font-semibold whitespace-nowrap">+8 / +4 pts</span>
-              </div>
-              <div className="flex items-center justify-between gap-4">
-                <span className="text-muted-foreground">
-                  Final{' '}
-                  <span className="text-muted-foreground/70 text-xs">(per finalist)</span>
-                </span>
-                <span className="font-semibold whitespace-nowrap">+10 / +5 pts</span>
+                <span className="font-semibold whitespace-nowrap">+14 / +9 pts</span>
               </div>
               <div className="flex items-center justify-between gap-4">
                 <span className="text-muted-foreground">Third Place Match Winner</span>
@@ -110,15 +110,8 @@ export function ScoringBreakdown() {
               <div className="bg-muted/50 rounded-md p-3 text-xs">
                 <span className="font-semibold">Correct slot vs. wrong slot:</span>{' '}
                 <span className="text-muted-foreground">
-                  Correct slot = the team advanced from the bracket match you predicted. Wrong
-                  slot = the team advanced, but from a different match in the same round.
-                </span>
-              </div>
-              <div className="bg-muted/50 rounded-md p-3 text-xs">
-                <span className="font-semibold">Round of 32:</span>{' '}
-                <span className="text-muted-foreground">
-                  Picks aren&apos;t scored on their own — they decide which teams sit in your
-                  Round-of-16 slots.
+                  Correct slot = you picked the winner of that exact match. Wrong slot = the
+                  team won, but you had them in a different match in the same round.
                 </span>
               </div>
               <div className="border-t pt-3">

--- a/frontend/src/components/predictions/TiebreakerInput.tsx
+++ b/frontend/src/components/predictions/TiebreakerInput.tsx
@@ -9,10 +9,10 @@ import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 
 // Validation range for the champion's tournament-goal tally.
-// Champion plays 8 matches (3 group + R32 + R16 + QF + SF + Final);
-// realistic range is roughly 5-25, with 0-50 as the hard bound.
+// Champion plays 8 matches; realistic range is roughly 5-25.
+// Hard bound is generous (200) — matches the DB CHECK.
 const MIN_GOALS = 0;
-const MAX_GOALS = 50;
+const MAX_GOALS = 200;
 
 interface TiebreakerInputProps {
   value: number | null;

--- a/frontend/src/components/predictions/__tests__/TiebreakerInput.test.tsx
+++ b/frontend/src/components/predictions/__tests__/TiebreakerInput.test.tsx
@@ -42,7 +42,7 @@ describe('TiebreakerInput', () => {
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
       const input = screen.getByLabelText("Champion's Total Goals");
-      expect(input).toHaveAttribute('placeholder', 'Enter a number (0-50)');
+      expect(input).toHaveAttribute('placeholder', 'Enter a number (0-200)');
     });
   });
 
@@ -85,7 +85,7 @@ describe('TiebreakerInput', () => {
       const input = screen.getByLabelText("Champion's Total Goals");
       await user.type(input, '-1');
 
-      expect(screen.getByText(/Goals must be between 0 and 50/i)).toBeInTheDocument();
+      expect(screen.getByText(/Goals must be between 0 and 200/i)).toBeInTheDocument();
       expect(mockOnChange).toHaveBeenLastCalledWith(null);
     });
 
@@ -95,10 +95,22 @@ describe('TiebreakerInput', () => {
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
       const input = screen.getByLabelText("Champion's Total Goals");
-      await user.type(input, '60');
+      await user.type(input, '250');
 
-      expect(screen.getByText(/Goals must be between 0 and 50/i)).toBeInTheDocument();
+      expect(screen.getByText(/Goals must be between 0 and 200/i)).toBeInTheDocument();
       expect(mockOnChange).toHaveBeenLastCalledWith(null);
+    });
+
+    it('should accept values above the old 50 cap', async () => {
+      const user = userEvent.setup();
+      const mockOnChange = jest.fn();
+      render(<TiebreakerInput value={null} onChange={mockOnChange} />);
+
+      const input = screen.getByLabelText("Champion's Total Goals");
+      await user.type(input, '120');
+
+      expect(mockOnChange).toHaveBeenLastCalledWith(120);
+      expect(screen.queryByText(/must be between/i)).not.toBeInTheDocument();
     });
 
     it('should show error for negative numbers', async () => {
@@ -136,7 +148,7 @@ describe('TiebreakerInput', () => {
       const input = screen.getByLabelText("Champion's Total Goals");
 
       // Enter invalid value (above max)
-      await user.type(input, '60');
+      await user.type(input, '250');
       expect(screen.getByText(/Goals must be between/i)).toBeInTheDocument();
 
       // Clear input
@@ -178,7 +190,7 @@ describe('TiebreakerInput', () => {
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
       const input = screen.getByLabelText("Champion's Total Goals");
-      await user.type(input, '60');
+      await user.type(input, '250');
 
       expect(input).toHaveAttribute('aria-invalid', 'true');
     });

--- a/supabase/migrations/0045_scoring_v3.sql
+++ b/supabase/migrations/0045_scoring_v3.sql
@@ -1,0 +1,456 @@
+-- 0045_scoring_v3.sql
+--
+-- Knockout scoring v3: relabel rounds by what you predict (R32/R16/QF/SF)
+-- instead of what they advance to, rebalance point values to reward deeper
+-- correct picks more evenly, and lift the tiebreaker CHECK constraint from
+-- 0..50 to 0..200.
+--
+-- New point values (max knockout = 200, unchanged):
+--   R32 (16 matches):  4 correct / 3 wrong-side
+--   R16 ( 8 matches):  6 correct / 4 wrong-side
+--   QF  ( 4 matches): 10 correct / 6 wrong-side
+--   SF  ( 2 matches): 14 correct / 9 wrong-side
+--   M31 (3rd place):   5
+--   M32 (champion):   15
+--   Gut-feeling pick:  5 (unchanged)
+--
+-- Values move into IMMUTABLE config functions so future tweaks only need
+-- a single `create or replace` of the config, not the full RPC body.
+-- The `knockout_round_scores` helper from 0006 is reused as-is.
+
+-- ========== scoring config (single source of truth) ==========
+
+create or replace function public.knockout_round_config()
+returns table(stage text, correct_pts int, wrong_pts int)
+language sql
+immutable
+parallel safe
+set search_path = public
+as $$
+    values
+        ('round_of_32',    4, 3),
+        ('round_of_16',    6, 4),
+        ('quarter_finals', 10, 6),
+        ('semi_finals',    14, 9)
+$$;
+
+create or replace function public.scoring_third_place_pts()
+returns int
+language sql
+immutable
+parallel safe
+set search_path = public
+as $$ select 5 $$;
+
+create or replace function public.scoring_champion_pts()
+returns int
+language sql
+immutable
+parallel safe
+set search_path = public
+as $$ select 15 $$;
+
+create or replace function public.scoring_champion_pick_pts()
+returns int
+language sql
+immutable
+parallel safe
+set search_path = public
+as $$ select 5 $$;
+
+grant execute on function public.knockout_round_config() to anon, authenticated;
+grant execute on function public.scoring_third_place_pts() to anon, authenticated;
+grant execute on function public.scoring_champion_pts() to anon, authenticated;
+grant execute on function public.scoring_champion_pick_pts() to anon, authenticated;
+
+-- ========== get_leaderboard (v3) ==========
+-- Same signature + return columns as 0036. Replaces the 4 hardcoded
+-- knockout_round_scores() calls with a single lateral over the config,
+-- and reads the M31 / M32 / gut-feeling bonuses from the config functions.
+
+create or replace function public.get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    champion_pick_points int,
+    total_goals int,
+    total_count bigint
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 8 else 6 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 4
+                    when gp.first_team_id = gs.first_team_id or gp.second_team_id = gs.second_team_id
+                        then 3
+                    when gp.first_team_id = gs.second_team_id or gp.second_team_id = gs.first_team_id
+                        then 2
+                    else 0
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 1.25
+                    when ta_team.team_id is not null then 1.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    knockout_round_totals as (
+        select s.prediction_id, coalesce(sum(s.round_points), 0)::int as round_points
+        from public.knockout_round_config() c
+        cross join lateral public.knockout_round_scores(
+            p_tournament_id, c.stage, c.correct_pts, c.wrong_pts
+        ) s
+        group by s.prediction_id
+    ),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_champion_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M32'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_third_place_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M31'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M31'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id
+                    then public.scoring_champion_pick_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(krt.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join knockout_round_totals krt on krt.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            pr.username::text as username,
+            coalesce(gsc.group_points, 0) as group_points,
+            coalesce(asc_.advancer_points, 0)::numeric as advancer_points,
+            coalesce(ksc.knockout_points, 0) as knockout_points,
+            coalesce(ksc.champion_pick_points, 0) as champion_pick_points,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            p.total_goals,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        join public.profiles pr on pr.id = p.user_id
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        rank,
+        prediction_id,
+        prediction_name,
+        username,
+        points,
+        group_points,
+        advancer_points,
+        knockout_points,
+        champion_pick_points,
+        total_goals,
+        count(*) over () as total_count
+    from ranked
+    order by rank
+    offset greatest(p_page - 1, 0) * greatest(p_page_size, 1)
+    limit greatest(p_page_size, 1);
+$$;
+
+grant execute on function public.get_leaderboard(uuid, int, int) to anon, authenticated;
+
+-- ========== get_leaderboard_rank (v3) ==========
+
+create or replace function public.get_leaderboard_rank(
+    p_tournament_id uuid,
+    p_user_id uuid,
+    p_page_size int default 25
+)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    rank int,
+    page int,
+    points numeric
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 8 else 6 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 4
+                    when gp.first_team_id = gs.first_team_id or gp.second_team_id = gs.second_team_id
+                        then 3
+                    when gp.first_team_id = gs.second_team_id or gp.second_team_id = gs.first_team_id
+                        then 2
+                    else 0
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 1.25
+                    when ta_team.team_id is not null then 1.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    knockout_round_totals as (
+        select s.prediction_id, coalesce(sum(s.round_points), 0)::int as round_points
+        from public.knockout_round_config() c
+        cross join lateral public.knockout_round_scores(
+            p_tournament_id, c.stage, c.correct_pts, c.wrong_pts
+        ) s
+        group by s.prediction_id
+    ),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_champion_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M32'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_third_place_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M31'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M31'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id
+                    then public.scoring_champion_pick_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M32'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(krt.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join knockout_round_totals krt on krt.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            p.user_id,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        prediction_id,
+        prediction_name,
+        rank,
+        ((rank - 1) / greatest(p_page_size, 1) + 1)::int as page,
+        points
+    from ranked
+    where user_id = p_user_id
+    order by rank;
+$$;
+
+grant execute on function public.get_leaderboard_rank(uuid, uuid, int) to anon, authenticated;
+
+-- ========== relax tiebreaker CHECK constraints (0..50 -> 0..200) ==========
+
+alter table public.predictions
+    drop constraint if exists predictions_total_goals_check;
+alter table public.predictions
+    add constraint predictions_total_goals_check
+    check (total_goals is null or total_goals between 0 and 200);
+
+alter table public.tournaments
+    drop constraint if exists tournaments_champion_total_goals_check;
+alter table public.tournaments
+    add constraint tournaments_champion_total_goals_check
+    check (champion_total_goals is null or champion_total_goals between 0 and 200);


### PR DESCRIPTION
## Summary

- Rebalance Phase 2 knockout point values so each round contributes more evenly to the max and relabel the UI/docs to score by the round predicted (not the round advanced to) — so R32 picks are visibly scored. Max knockout points stay at 200; max total stays at 289.
- Centralize per-round point values in `IMMUTABLE` SQL config functions (`knockout_round_config`, `scoring_third_place_pts`, `scoring_champion_pts`, `scoring_champion_pick_pts`) so future tweaks need only a single `create or replace` of the relevant config function — no need to rewrite the `get_leaderboard` RPC bodies.
- Lift the tiebreaker `total_goals` CHECK constraint from `0..50` to `0..200` on both `predictions` and `tournaments`, plus the client `TiebreakerInput`, admin tournament settings form, and all `/api/predictions` + `/api/admin/...` route validators.

### New scoring values

| Round | Correct | Wrong-side | Matches | Max |
|---|---|---|---|---|
| Round of 32 | 4 | 3 | 16 | 64 |
| Round of 16 | 6 | 4 | 8 | 48 |
| Quarter-finals | 10 | 6 | 4 | 40 |
| Semi-finals | 14 | 9 | 2 | 28 |
| Third place (M31) | 5 | — | 1 | 5 |
| Champion (M32) | 15 | — | 1 | 15 |
| **Knockout max** | | | | **200** |

Per-match correct grows ~1.5× per round (reflects exponentially harder picks); wrong-side stays at a 60–75% ratio of correct-slot so users keep getting credit for "I knew this team would go deep" even if their bracket busts early. Group 74 + Advancer 10 + Knockout 200 + Champion Pick 5 = **289** total (unchanged).

## Files

- `supabase/migrations/0045_scoring_v3.sql` — new config functions, replaced `get_leaderboard` / `get_leaderboard_rank`, relaxed CHECK constraints. `admin_get_leaderboard` (0042) is a thin wrapper over `get_leaderboard` so it auto-picks up the new values.
- `frontend/src/components/marketing/ScoringBreakdown.tsx` — rules-page table with the new round labels + point values.
- `frontend/src/components/predictions/TiebreakerInput.tsx` + tests — `MAX_GOALS` 50 → 200, error message + tests updated.
- `frontend/src/app/admin/tournament/TournamentSettingsForm.tsx` — admin tiebreaker form raised to 0–200.
- `frontend/src/app/api/predictions/*`, `frontend/src/app/api/admin/...` — totalGoals / championTotalGoals validators raised to 0–200.
- `CLAUDE.md` — scoring section rewritten with the new round labels, max calculation, and centralized config functions. Version bumped to 3.7.0.

## Test plan

- [x] `npm test` (frontend) — 371 tests, 46 suites passing.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new errors (pre-existing warnings only).
- [x] `supabase db reset --local` — migration 0045 applies cleanly on top of 0001–0044.
- [x] Verified config functions return expected values (`knockout_round_config()`, `scoring_*_pts()`).
- [x] Verified CHECK constraints now show `0..200` for `predictions.total_goals` and `tournaments.champion_total_goals`.
- [x] Verified `get_leaderboard` executes end-to-end against seeded data.
- [ ] Manual UI smoke (rules page shows new table, tiebreaker accepts 120 / rejects 250) — recommended before merge.