### PR TITLE
fix(admin): StatCard hydration error with Badge value

### DIFF
--- a/frontend/src/app/admin/AdminDashboard.tsx
+++ b/frontend/src/app/admin/AdminDashboard.tsx
@@ -108,7 +108,7 @@ function StatCard({
           <Skeleton className="h-8 w-20" />
         ) : (
           <>
-            <p className="text-2xl font-bold">{value}</p>
+            <div className="text-2xl font-bold">{value}</div>
             {subtitle ? (
               <p className="text-muted-foreground mt-1 text-xs">{subtitle}</p>
             ) : null}


### PR DESCRIPTION
## Summary

The admin dashboard threw a hydration error: \`<div> cannot be a descendant of <p>\`.

`StatCard` wraps the \`value\` prop in a \`<p>\`, but several admin dashboard call sites pass a \`<Badge>\` (which renders a \`<div>\`). Swapping the wrapper to \`<div>\` keeps the existing \`text-2xl font-bold\` styling while allowing arbitrary block-level children.

## Test plan

- [x] \`npm run typecheck\` — clean.
- [ ] Manual: load \`/admin\`, confirm no hydration error in the browser console.