### PR TITLE
fix(predictions): suppress duplicate R32 teams when prediction conflicts with admin bracket

### DIFF
--- a/frontend/src/lib/__tests__/knockoutResolver.test.ts
+++ b/frontend/src/lib/__tests__/knockoutResolver.test.ts
@@ -98,4 +98,66 @@ describe('resolveTeamSource', () => {
       ).toBeNull();
     });
   });
+
+  describe('admin bracket authoritative-override for top-2 predictions', () => {
+    // When the admin places a team in an R32 3rd-place slot, that team really
+    // finished 3rd in its group, so any user prediction putting that team in a
+    // top-2 slot is falsified by reality. Resolver must return null for the
+    // user-predicted slot so the team renders once (in the admin slot) instead
+    // of duplicating across matches.
+    it('suppresses a user-predicted 1A when the team is also in bracketAssignments', () => {
+      // User predicted 'mex' as 1st of A; admin placed 'mex' in the (M2, 2) 3-XXXXX slot.
+      const assignments: R32BracketAssignment[] = [
+        { matchId: 'M2', slot: 2, teamId: 'mex' },
+      ];
+      expect(
+        resolveTeamSource('1A', matches, groupPredictions, [], assignments)
+      ).toBeNull();
+      // And the admin slot still resolves correctly to the same team.
+      expect(
+        resolveTeamSource('3-ABCDF', matches, groupPredictions, [], assignments)
+      ).toBe('mex');
+    });
+
+    it('suppresses a user-predicted 2B when the team is also in bracketAssignments', () => {
+      // Mirrors the reported bug: user has 'qat' as 2nd of B; admin placed
+      // 'qat' in the (M2, 2) 3-XXXXX slot.
+      const assignments: R32BracketAssignment[] = [
+        { matchId: 'M2', slot: 2, teamId: 'qat' },
+      ];
+      expect(
+        resolveTeamSource('2B', matches, groupPredictions, [], assignments)
+      ).toBeNull();
+    });
+
+    it('suppresses a user-predicted 3A when the team is also in bracketAssignments', () => {
+      // Consistency check: if a 3X source ever points to a team admin has
+      // already placed, the explicit admin slot wins and the 3X slot is null.
+      const assignments: R32BracketAssignment[] = [
+        { matchId: 'M2', slot: 2, teamId: 'rsa' },
+      ];
+      expect(
+        resolveTeamSource('3A', matches, groupPredictions, [], assignments)
+      ).toBeNull();
+    });
+
+    it('does not suppress when there is no overlap', () => {
+      // 'kor' is user's 2nd of A. Admin's bracket has a different team. No conflict.
+      const assignments: R32BracketAssignment[] = [
+        { matchId: 'M2', slot: 2, teamId: 'rsa' },
+      ];
+      expect(
+        resolveTeamSource('1A', matches, groupPredictions, [], assignments)
+      ).toBe('mex');
+      expect(
+        resolveTeamSource('2B', matches, groupPredictions, [], assignments)
+      ).toBe('qat');
+    });
+
+    it('does not suppress when bracketAssignments is empty (Phase 1)', () => {
+      expect(resolveTeamSource('1A', matches, groupPredictions, [], [])).toBe('mex');
+      expect(resolveTeamSource('2B', matches, groupPredictions, [], [])).toBe('qat');
+      expect(resolveTeamSource('3A', matches, groupPredictions, [], [])).toBe('rsa');
+    });
+  });
 });

--- a/frontend/src/lib/knockoutResolver.ts
+++ b/frontend/src/lib/knockoutResolver.ts
@@ -24,16 +24,29 @@ export function resolveTeamSource(
     const [, position, groupId] = groupMatch;
     const groupPrediction = groupPredictions.find((p) => p.groupId === groupId);
     if (!groupPrediction) return null;
+    let resolved: string | null;
     switch (position) {
       case '1':
-        return groupPrediction.positions.first;
+        resolved = groupPrediction.positions.first;
+        break;
       case '2':
-        return groupPrediction.positions.second;
+        resolved = groupPrediction.positions.second;
+        break;
       case '3':
-        return groupPrediction.positions.third;
+        resolved = groupPrediction.positions.third;
+        break;
       default:
         return null;
     }
+    // Admin's bracket assignments are tournament truth. If the user-predicted
+    // team for this slot is already placed by the admin in a 3-XXXXX R32 slot,
+    // that team really finished 3rd in its group and cannot also be its actual
+    // 1st/2nd. Suppress here so the team renders once (in the admin slot) and
+    // this slot shows as TBD instead of duplicating.
+    if (resolved && bracketAssignments.some((a) => a.teamId === resolved)) {
+      return null;
+    }
+    return resolved;
   }
 
   // Best-3rd-of-bundle source: '3-ABCDF' etc. In the new model these strings


### PR DESCRIPTION
## Summary

- Users reported seeing the same team in multiple R32 matches after Phase 2 opened (e.g., South Korea in M1 + M2, Switzerland in M1 + M5, Senegal in M6 + M8).
- Root cause: `resolveTeamSource` in `frontend/src/lib/knockoutResolver.ts` mixes two independent sources — user's `groupPredictions` for `1A`/`2B`/`3A` slots, and admin's `r32_bracket_assignments` for `3-XXXXX` slots. When a user predicted a team into a top-2 slot but the admin placed that same team into an R32 3rd-place slot (because the team really finished 3rd), the team rendered in both slots.
- Fix: in the `1A`/`2B`/`3A` branch, after resolving the user-predicted team_id, return `null` if that team_id appears in `bracketAssignments`. Admin's bracket is tournament truth — a team placed as an actual 3rd-place advancer cannot also be that group's actual 1st or 2nd, so the user's predicted slot is falsified by reality.
- Display-time only: user's stored predictions are untouched, so group-stage scoring still correctly penalizes the wrong top-2 pick.
- Applies to all rendering surfaces via the shared resolver (interactive R32 wizard step, locked `BracketView`, and `BracketPreviewDialog`).

## Test plan

- [x] `npm test -- knockoutResolver` — 14 tests pass (5 new override cases)
- [x] `npm test` — full suite 376/376 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings
- [ ] Manual repro on local Supabase reset: seed a user prediction with a team in a top-2 slot, admin-assign the same team to an R32 3-XXXXX slot, open Phase 2, load `/predictions/[id]` — the team renders once (admin slot) and the user-predicted slot shows as TBD
- [ ] Cross-surface check: same prediction viewed in the wizard's R32 step, the read-only `BracketView`, and the `BracketPreviewDialog` all show the same deduplicated R32

## Follow-ups (out of scope here)

- Inline UX affordance on the now-empty slot explaining "You predicted Team X here — they actually advanced as 3rd, see Mn"
- Read-only SQL audit for any legacy `advancer_predictions` rows that don't match `group_predictions.third_team_id` (pre-strict-validation data)