### PR TITLE
feat(admin): super-admin Reset Tournament action

### DIFF
--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -17,6 +17,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useAuthContext } from '@/providers/AuthProvider';
 import type { KnockoutMatch } from '@/types/tournament';
 
 interface TournamentInfo {
@@ -59,6 +68,8 @@ function toDatetimeLocal(iso: string | null): string {
 
 export function TournamentSettingsForm() {
   const queryClient = useQueryClient();
+  const { profile } = useAuthContext();
+  const isSuperAdmin = profile?.isSuperAdmin ?? false;
   const tournament = useQuery<TournamentInfo>({
     queryKey: ['tournament'],
     queryFn: () => fetchJSON('/api/tournament'),
@@ -87,6 +98,9 @@ export function TournamentSettingsForm() {
   const [savingSettings, setSavingSettings] = React.useState(false);
   const [savingPhase1, setSavingPhase1] = React.useState(false);
   const [busyPhase2, setBusyPhase2] = React.useState(false);
+  const [resetDialogOpen, setResetDialogOpen] = React.useState(false);
+  const [resetConfirm, setResetConfirm] = React.useState('');
+  const [resetting, setResetting] = React.useState(false);
 
   React.useEffect(() => {
     if (!tournament.data) return;
@@ -233,6 +247,35 @@ export function TournamentSettingsForm() {
       toast.error(e instanceof Error ? e.message : 'Failed');
     } finally {
       setBusyPhase2(false);
+    }
+  };
+
+  const handleReset = async () => {
+    if (!tournament.data) return;
+    if (resetConfirm !== 'RESET') return;
+    setResetting(true);
+    try {
+      const res = await fetch('/api/admin/tournament/reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: tournament.data.id, confirm: 'RESET' }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? 'Failed to reset tournament');
+      }
+      toast.success('Tournament reset');
+      setResetDialogOpen(false);
+      setResetConfirm('');
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['tournament'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-advancers'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-r32-bracket'] }),
+      ]);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to reset tournament');
+    } finally {
+      setResetting(false);
     }
   };
 
@@ -466,7 +509,86 @@ export function TournamentSettingsForm() {
             </div>
           </CardContent>
         </Card>
+
+        <Card className="border-destructive/40">
+          <CardHeader>
+            <CardTitle className="text-destructive">Danger zone</CardTitle>
+            <p className="text-muted-foreground text-sm">
+              Super-admin only. Wipes every user&apos;s predictions, payments, and reward
+              redemptions for this tournament; clears admin-entered group standings,
+              knockout results, and the R32 bracket; resets Phase 1 / Phase 2 lock times
+              and tournament status. User accounts, profiles, and referral codes are
+              preserved.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <Button
+              variant="destructive"
+              onClick={() => setResetDialogOpen(true)}
+              disabled={!isSuperAdmin || !tournament.data}
+              title={!isSuperAdmin ? 'Super admin only' : undefined}
+            >
+              Reset tournament
+            </Button>
+          </CardContent>
+        </Card>
       </div>
+
+      <Dialog
+        open={resetDialogOpen}
+        onOpenChange={(open) => {
+          setResetDialogOpen(open);
+          if (!open) setResetConfirm('');
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="text-destructive">Reset tournament</DialogTitle>
+            <DialogDescription>
+              This cannot be undone. The following will be deleted for{' '}
+              <span className="font-mono">{tournament.data?.name}</span>:
+            </DialogDescription>
+          </DialogHeader>
+          <ul className="text-muted-foreground list-disc space-y-1 pl-5 text-sm">
+            <li>All user predictions, group picks, knockout picks, advancer picks</li>
+            <li>All payment records (cash + free picks from referrals / loyalty)</li>
+            <li>All reward redemptions for this tournament</li>
+            <li>Admin-entered group standings, knockout results, R32 bracket</li>
+            <li>
+              Phase 1 lock time, Phase 2 lock time, status, and champion total goals are
+              reset
+            </li>
+          </ul>
+          <div className="space-y-1">
+            <Label htmlFor="reset-confirm">
+              Type <span className="font-mono font-semibold">RESET</span> to confirm
+            </Label>
+            <Input
+              id="reset-confirm"
+              autoComplete="off"
+              value={resetConfirm}
+              onChange={(e) => setResetConfirm(e.target.value)}
+              disabled={resetting}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setResetDialogOpen(false)}
+              disabled={resetting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleReset}
+              disabled={resetting || resetConfirm !== 'RESET'}
+            >
+              {resetting ? 'Resetting…' : 'Reset tournament'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </PageLayout>
   );
 }

--- a/frontend/src/app/api/admin/tournament/reset/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/tournament/reset/__tests__/route.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function postReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/tournament/reset', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('POST /api/admin/tournament/reset', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(postReq({ id: 't1', confirm: 'RESET' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when caller is not admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await POST(postReq({ id: 't1', confirm: 'RESET' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({ confirm: 'RESET' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/id/);
+  });
+
+  it('returns 400 when confirm does not equal RESET', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({ id: 't1', confirm: 'reset' }));
+    expect(res.status).toBe(400);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when RPC raises forbidden (non-super-admin)', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ error: { message: 'forbidden' } });
+    const res = await POST(postReq({ id: 't1', confirm: 'RESET' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when RPC raises tournament not found', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ error: { message: 'tournament not found' } });
+    const res = await POST(postReq({ id: 't1', confirm: 'RESET' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 and calls RPC on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ error: null });
+    const res = await POST(postReq({ id: 't1', confirm: 'RESET' }));
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_reset_tournament', {
+      p_tournament_id: 't1',
+    });
+  });
+});

--- a/frontend/src/app/api/admin/tournament/reset/route.ts
+++ b/frontend/src/app/api/admin/tournament/reset/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+interface Body {
+  id?: string;
+  confirm?: string;
+}
+
+export async function POST(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json()) as Body;
+  if (!body.id) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 });
+  }
+  if (body.confirm !== 'RESET') {
+    return NextResponse.json({ error: 'confirm must be "RESET"' }, { status: 400 });
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_reset_tournament', {
+    p_tournament_id: body.id,
+  });
+
+  if (error) {
+    const msg = (error.message ?? '').toLowerCase();
+    let status = 400;
+    if (msg.includes('forbidden')) status = 403;
+    else if (msg.includes('not found')) status = 404;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -55,6 +55,8 @@ const KNOWN_ERROR_FRAGMENTS = [
   'no loyalty credits available',
   'no free picks available',
   'tournament_id is required',
+  // Reset tournament (migration 0046)
+  'tournament not found',
 ] as const;
 
 export function safeMessage(

--- a/supabase/migrations/0046_admin_reset_tournament.sql
+++ b/supabase/migrations/0046_admin_reset_tournament.sql
@@ -1,0 +1,56 @@
+-- Super admin "Reset Tournament" action.
+--
+-- Wipes all user-generated data + admin-entered actuals for the given
+-- tournament and returns it to a clean "upcoming" state. Intended for
+-- pre-launch dress rehearsals or mid-cycle do-overs. Gated on
+-- is_super_admin() — a regular admin cannot run it.
+--
+-- Preserves: auth.users, profiles, referral_codes, referrals (lifetime
+-- social graph), all reference data (groups, teams, knockout_matches).
+--
+-- All per-tournament FKs already declare `on delete cascade`, so deleting
+-- predictions + the four admin tables (group_standings, knockout_results,
+-- tournament_advancers, r32_bracket_assignments) is sufficient. The
+-- AFTER DELETE trigger referrals_sync_qualification on tournament_payments
+-- clears referrals.qualified_at for any referee whose only non-free
+-- payments lived in this tournament; cross-tournament credits stay sticky
+-- via the greatest(0, ...) clamp in get_referral_status.
+--
+-- lock_time is NOT NULL on tournaments, so we push it 30 days out (matches
+-- the seed default) — the admin re-enters the real date afterward.
+
+create or replace function public.admin_reset_tournament(p_tournament_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if not public.is_super_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_tournament_id is null then
+        raise exception 'tournament_id is required' using errcode = 'P0001';
+    end if;
+    if not exists (select 1 from public.tournaments where id = p_tournament_id) then
+        raise exception 'tournament not found' using errcode = 'P0001';
+    end if;
+
+    delete from public.predictions where tournament_id = p_tournament_id;
+    delete from public.group_standings where tournament_id = p_tournament_id;
+    delete from public.knockout_results where tournament_id = p_tournament_id;
+    delete from public.tournament_advancers where tournament_id = p_tournament_id;
+    delete from public.r32_bracket_assignments where tournament_id = p_tournament_id;
+
+    update public.tournaments
+       set status = 'upcoming',
+           lock_time = now() + interval '30 days',
+           knockout_unlocked = false,
+           knockout_lock_time = null,
+           champion_total_goals = null
+     where id = p_tournament_id;
+end;
+$$;
+
+revoke all on function public.admin_reset_tournament(uuid) from public;
+grant execute on function public.admin_reset_tournament(uuid) to authenticated;


### PR DESCRIPTION
## Summary
- New `admin_reset_tournament(uuid)` RPC (migration `0046`) gated on `is_super_admin()` — wipes predictions / payments / reward redemptions / admin actuals for the active tournament and resets Phase 1 + Phase 2 lock times, status, and champion total goals.
- New `POST /api/admin/tournament/reset` route; requires JSON body `{ id, confirm: 'RESET' }`. Maps RPC errors to 403 / 404 / 400.
- New Danger zone card on `/admin/tournament` with type-`RESET`-to-confirm Dialog. Disabled for non-super-admins.

User accounts (`auth.users`, `profiles`, `referral_codes`) and the lifetime `referrals` social graph are preserved; the existing `referrals_sync_qualification` trigger naturally re-derives `qualified_at` as `tournament_payments` cascades out.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 383/383 pass (7 new tests cover 401 / 403 admin / 400 missing id / 400 bad confirm / 403 non-super-admin RPC / 404 / 200 paths)
- [ ] Local: `supabase db reset` to confirm migration applies cleanly
- [ ] Manual: sign in as regular admin → Reset button disabled with tooltip
- [ ] Manual: sign in as super admin → populate predictions/payments/standings → reset → verify all per-tournament tables empty, tournament back to `upcoming` with lock_time ~now()+30d, `auth.users` + `referrals` untouched
- [ ] Manual: non-admin POST to `/api/admin/tournament/reset` returns 403