### PR TITLE
fix(admin): close cache-invalidation gaps after admin mutations

### DIFF
--- a/frontend/src/app/admin/AdminDashboard.tsx
+++ b/frontend/src/app/admin/AdminDashboard.tsx
@@ -123,6 +123,14 @@ export function AdminDashboard() {
   const stats = useQuery<AdminStats>({
     queryKey: ['admin-stats'],
     queryFn: () => fetchJSON('/api/admin/stats'),
+    // Belt-and-suspenders for cache freshness: every mutation that affects
+    // dashboard counts (mark-paid, create/delete user, tournament reset,
+    // tournament/phase lock changes) explicitly invalidates this key.
+    // staleTime: 0 + refetchOnMount: 'always' guarantees navigating to
+    // /admin still refetches even if a new mutation forgets to invalidate.
+    // refetchInterval keeps the page live for long-open sessions.
+    staleTime: 0,
+    refetchOnMount: 'always',
     refetchInterval: 30_000,
   });
   const leaderboard = useQuery<LeaderboardResponse>({

--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -143,7 +143,10 @@ export function TournamentSettingsForm() {
         throw new Error(body.error ?? 'Failed to save');
       }
       toast.success('Tournament settings updated');
-      await queryClient.invalidateQueries({ queryKey: ['tournament'] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['tournament'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
+      ]);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to save');
     } finally {
@@ -172,7 +175,10 @@ export function TournamentSettingsForm() {
         throw new Error(body.error ?? 'Failed to save');
       }
       toast.success('Phase 1 lock time updated');
-      await queryClient.invalidateQueries({ queryKey: ['tournament'] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['tournament'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
+      ]);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to save');
     } finally {
@@ -242,6 +248,7 @@ export function TournamentSettingsForm() {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['tournament'] }),
         queryClient.invalidateQueries({ queryKey: ['admin-advancers'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
       ]);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed');
@@ -267,10 +274,19 @@ export function TournamentSettingsForm() {
       toast.success('Tournament reset');
       setResetDialogOpen(false);
       setResetConfirm('');
+      // Reset wipes predictions, payments, standings, results, advancers,
+      // bracket, and rewards — invalidate the whole cluster including
+      // admin-users (paid/prediction counts), admin-stats (dashboard),
+      // predictions (user prediction lists), and leaderboard (any cached
+      // viewer/page variants).
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['tournament'] }),
         queryClient.invalidateQueries({ queryKey: ['admin-advancers'] }),
         queryClient.invalidateQueries({ queryKey: ['admin-r32-bracket'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+        queryClient.invalidateQueries({ queryKey: ['predictions'] }),
+        queryClient.invalidateQueries({ queryKey: ['leaderboard'] }),
       ]);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to reset tournament');
@@ -308,7 +324,10 @@ export function TournamentSettingsForm() {
         throw new Error(body.error ?? 'Failed');
       }
       toast.success('Phase 2 lock time updated');
-      await queryClient.invalidateQueries({ queryKey: ['tournament'] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['tournament'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
+      ]);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed');
     } finally {

--- a/frontend/src/app/admin/users/AdminUsersList.tsx
+++ b/frontend/src/app/admin/users/AdminUsersList.tsx
@@ -89,7 +89,14 @@ export function AdminUsersList() {
 
   const totalPages = Math.max(1, Math.ceil((query.data?.total ?? 0) / PAGE_SIZE));
 
-  const refetchUsers = () => queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+  // Invalidate both the list and the admin dashboard stats — the stats RPC
+  // counts registrations and renders usernames in top_paid_users, so create
+  // / edit / delete user can leave the dashboard stale otherwise.
+  const refetchUsers = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+      queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
+    ]);
 
   const toggleAdmin = async (user: AdminUser) => {
     try {

--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -177,15 +177,17 @@ export function AdminUserBracket({ userId }: { userId: string }) {
   const predictions = query.data?.predictions ?? [];
 
   // After any mutation that changes a prediction's payment state or
-  // existence, invalidate BOTH the detail-page query and the user-list
-  // query — `AdminUsersList` displays `predictionCount` /
-  // `paidPredictionCount` columns that go stale otherwise (the list query
-  // key is `['admin-users']`, see AdminUsersList.tsx).
+  // existence, invalidate the detail-page query, the user-list query
+  // (`AdminUsersList` shows `predictionCount` / `paidPredictionCount`),
+  // and the admin dashboard stats (driven by `admin_get_dashboard_stats`,
+  // which counts paid/cash predictions). Skipping `['admin-stats']` here
+  // meant the dashboard stayed stale until its 30s refetchInterval ticked.
   const refresh = React.useCallback(
     () =>
       Promise.all([
         queryClient.invalidateQueries({ queryKey: ['admin-user-predictions', userId] }),
         queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
       ]),
     [queryClient, userId]
   );

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -868,13 +868,22 @@ export function PredictionsPageContent({
       }
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['predictions'] }),
-        queryClient.invalidateQueries({ queryKey: ['prediction', newId] }),
-        // When the admin wizard saves, the user list's `predictionCount`
-        // and `paidPredictionCount` columns (`AdminUsersList`, query key
-        // `['admin-users']`) reflect counts that just changed. Mark the
-        // list stale so the next /admin/users mount refetches.
+        // Prefix invalidation: covers both the wizard's
+        // ['prediction', newId] (loaded for edit mode) and
+        // BracketPreviewDialog's ['prediction', apiBasePath, predictionId].
+        queryClient.invalidateQueries({ queryKey: ['prediction'] }),
+        // When the admin wizard saves, the user list (`['admin-users']`,
+        // prediction counts), the per-user predictions view
+        // (`['admin-user-predictions', userId]`), and the dashboard stats
+        // (`['admin-stats']`, champion-pick distribution) all reflect
+        // counts/values that just changed. Mark them stale so the next
+        // mount refetches.
         ...(usesAdminRoute
-          ? [queryClient.invalidateQueries({ queryKey: ['admin-users'] })]
+          ? [
+              queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+              queryClient.invalidateQueries({ queryKey: ['admin-user-predictions'] }),
+              queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
+            ]
           : []),
       ]);
       toast.success(markSubmitted ? 'Prediction submitted' : 'Progress saved');


### PR DESCRIPTION
## Summary
- Bug: marking a prediction paid on `/admin/users/[id]` left the `/admin` dashboard stats stale because the mutation didn't invalidate `['admin-stats']`. Global `staleTime: 60s` + `refetchOnWindowFocus: false` meant nothing refetched until the 30s `refetchInterval` ticked.
- Audited every admin and user-side mutation; added `['admin-stats']` (and other dependent keys) where missing.
- Added belt-and-suspenders `staleTime: 0` + `refetchOnMount: 'always'` to the `['admin-stats']` query so `/admin` always refetches on navigation, even if a future mutation forgets to invalidate.

## Changes
**Admin invalidation gaps closed**
- `AdminUserBracket.refresh()` → adds `['admin-stats']` (mark-paid + delete-prediction)
- `AdminUsersList.refetchUsers()` → adds `['admin-stats']` (create / edit / delete user)
- `TournamentSettingsForm` → settings, Phase 1 lock, Phase 2 toggle, Phase 2 lock time, and reset handlers all invalidate `['admin-stats']`. Reset also broadcasts `['predictions']`, `['admin-users']`, `['leaderboard']`.

**User-side gaps closed (found during audit)**
- `PredictionsPageContent` admin-route save → adds `['admin-user-predictions']` + `['admin-stats']`
- `PredictionsPageContent` post-submit → switched `['prediction', newId]` to prefix `['prediction']` so `BracketPreviewDialog`'s 3-tuple key (`['prediction', apiBasePath, id]`) also invalidates

**Defense in depth**
- `AdminDashboard` `['admin-stats']` query → `staleTime: 0` + `refetchOnMount: 'always'`; kept the 30s `refetchInterval`

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 47/47 suites, 383/383 tests pass
- [ ] Manual: as admin, note dashboard stats at `/admin` → mark a user's prediction paid on `/admin/users/[id]` → navigate back to `/admin` → cash-paid stat updates immediately (no 30s wait, no hard refresh)
- [ ] Manual: as admin, create/delete a user → registrations stat updates on dashboard
- [ ] Manual: as admin, run Reset Tournament → all admin pages (dashboard, users, results, advancers) reflect the wipe
- [ ] Manual smoke: regular user submits a prediction, deletes one, redeems a free pick → counts in the predictions list update without refresh