### PR TITLE
fix(predictions): freeze prediction-name input at Phase 1 lock

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -1028,7 +1028,10 @@ export function PredictionsPageContent({
             value={predictionName}
             onChange={(e) => handleNameChange(e.target.value)}
             onBlur={() => setPredictionNameTouched(true)}
-            disabled={isLocked || isSubmitting}
+            // Prediction name is a Phase 1 field — freezes once Phase 1
+            // locks, same as group / champion picks. Super admin keeps
+            // edit access via `phase1Editable`.
+            disabled={!phase1Editable || isSubmitting}
             maxLength={PREDICTION_NAME_MAX}
             aria-invalid={showNameError ? true : undefined}
             aria-describedby={


### PR DESCRIPTION
## Summary

Prediction-name input was only disabled at the full tournament lock (`isLocked` — the Phase 2 deadline). Bug: name is a Phase 1 field — you also can't create a new prediction after Phase 1 closes, so allowing renames on existing ones once Phase 1 locks is inconsistent (and was reported by a user).

Switch to the same `phase1Editable` gate the group / champion picks already use. Super admin still bypasses, matching the rest of the Phase 1 form.

## Test plan

- [x] `npx jest PredictionsPageContent` — 13/13 pass.
- [x] `npx tsc --noEmit` — clean.
- [ ] Reviewer: in Phase 1, name input is editable. After Phase 1 lock (admin → tournament settings → Save Phase 1 lock time), name input on existing predictions is disabled for regular users, editable for super admin.

## Server-side note

The RPC layer should also reject name changes post-Phase-1-lock (per CLAUDE.md "don't trust the client"). Worth a follow-up audit of `submit_predictions` / `admin_submit_predictions` to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)