### PR TITLE
feat(support): add user support tickets with admin inbox

### DIFF
--- a/frontend/src/app/admin/support/AdminTicketsList.tsx
+++ b/frontend/src/app/admin/support/AdminTicketsList.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { AdminNav } from '@/components/admin/AdminNav';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  SUPPORT_TICKET_SUBJECT_LABELS,
+  type SupportTicketSubject,
+} from '@/lib/constants';
+
+interface AdminTicket {
+  id: string;
+  userId: string;
+  username: string | null;
+  email: string | null;
+  subject: SupportTicketSubject;
+  title: string;
+  description: string;
+  createdAt: string;
+}
+
+interface TicketsResponse {
+  tickets: AdminTicket[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+const PAGE_SIZE = 25;
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return body.error ?? 'Failed';
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+export function AdminTicketsList() {
+  const queryClient = useQueryClient();
+  const [page, setPage] = React.useState(1);
+  const [deleteTarget, setDeleteTarget] = React.useState<AdminTicket | null>(null);
+  const [viewTarget, setViewTarget] = React.useState<AdminTicket | null>(null);
+
+  const query = useQuery<TicketsResponse>({
+    queryKey: ['admin-support', page],
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/support?page=${page}&pageSize=${PAGE_SIZE}`);
+      if (!res.ok) throw new Error('Failed to load tickets');
+      return res.json();
+    },
+  });
+
+  const totalPages = Math.max(1, Math.ceil((query.data?.total ?? 0) / PAGE_SIZE));
+  const refetch = () => queryClient.invalidateQueries({ queryKey: ['admin-support'] });
+
+  return (
+    <PageLayout>
+      <h1 className="mb-2 text-3xl font-bold">Admin</h1>
+      <AdminNav />
+
+      <Card>
+        <CardContent className="space-y-4 p-4">
+          {query.isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : !query.data?.tickets.length ? (
+            <p className="text-muted-foreground text-sm">No tickets yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Created</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Subject</TableHead>
+                  <TableHead>Title</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {query.data.tickets.map((t) => (
+                  <TableRow key={t.id}>
+                    <TableCell className="text-muted-foreground text-xs">
+                      {formatDate(t.createdAt)}
+                    </TableCell>
+                    <TableCell className="text-sm">{t.username ?? '—'}</TableCell>
+                    <TableCell className="text-sm">
+                      {t.email ?? <span className="text-muted-foreground">—</span>}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline">{SUPPORT_TICKET_SUBJECT_LABELS[t.subject]}</Badge>
+                    </TableCell>
+                    <TableCell className="max-w-xs truncate text-sm" title={t.title}>
+                      {t.title}
+                    </TableCell>
+                    <TableCell className="space-x-2 text-right">
+                      <Button variant="outline" size="sm" onClick={() => setViewTarget(t)}>
+                        View
+                      </Button>
+                      {t.email ? (
+                        <Button variant="outline" size="sm" asChild>
+                          <a
+                            href={`mailto:${t.email}?subject=${encodeURIComponent(
+                              `Re: [ticket ${shortId(t.id)}] ${t.title}`
+                            )}`}
+                          >
+                            Email
+                          </a>
+                        </Button>
+                      ) : null}
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setDeleteTarget(t)}
+                      >
+                        Delete
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between text-sm">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                Previous
+              </Button>
+              <span className="text-muted-foreground">
+                Page {page} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <ViewTicketDialog
+        target={viewTarget}
+        onOpenChange={(open) => !open && setViewTarget(null)}
+      />
+      <DeleteTicketDialog
+        target={deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        onDeleted={refetch}
+      />
+    </PageLayout>
+  );
+}
+
+function ViewTicketDialog({
+  target,
+  onOpenChange,
+}: {
+  target: AdminTicket | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const open = target !== null;
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{target?.title ?? 'Ticket'}</DialogTitle>
+          <DialogDescription>
+            {target ? (
+              <>
+                {SUPPORT_TICKET_SUBJECT_LABELS[target.subject]} ·{' '}
+                {target.username ?? 'unknown user'} · {formatDate(target.createdAt)}
+              </>
+            ) : null}
+          </DialogDescription>
+        </DialogHeader>
+        {target ? (
+          <p className="text-sm whitespace-pre-wrap">{target.description}</p>
+        ) : null}
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeleteTicketDialog({
+  target,
+  onOpenChange,
+  onDeleted,
+}: {
+  target: AdminTicket | null;
+  onOpenChange: (open: boolean) => void;
+  onDeleted: () => void;
+}) {
+  const open = target !== null;
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (target) setSubmitting(false);
+  }, [target]);
+
+  const handleConfirm = async () => {
+    if (!target) return;
+    setSubmitting(true);
+    const res = await fetch('/api/admin/support', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: target.id }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      toast.error(await readError(res));
+      return;
+    }
+    toast.success('Ticket deleted');
+    onDeleted();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete ticket?</DialogTitle>
+          <DialogDescription>
+            This will permanently remove the ticket. Use this after you&apos;ve replied to the
+            user out-of-band.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={submitting}
+          >
+            {submitting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/admin/support/page.tsx
+++ b/frontend/src/app/admin/support/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { AdminTicketsList } from './AdminTicketsList';
+
+export const metadata: Metadata = {
+  title: 'Support | Admin',
+};
+
+export default function AdminSupportPage() {
+  return <AdminTicketsList />;
+}

--- a/frontend/src/app/api/admin/support/route.ts
+++ b/frontend/src/app/api/admin/support/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+import type { SupportTicketSubject } from '@/lib/constants';
+
+interface AdminTicketRow {
+  id: string;
+  user_id: string;
+  username: string | null;
+  email: string | null;
+  subject: SupportTicketSubject;
+  title: string;
+  description: string;
+  created_at: string;
+  total_count: number;
+}
+
+export async function GET(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const { searchParams } = new URL(request.url);
+  const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+  const pageSize = Math.min(
+    100,
+    Math.max(1, parseInt(searchParams.get('pageSize') ?? '25', 10))
+  );
+
+  const { data, error } = await ctx.supabase.rpc('admin_list_support_tickets', {
+    p_page: page,
+    p_page_size: pageSize,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: safeMessage(error) }, { status: 500 });
+  }
+
+  const rows = (data ?? []) as AdminTicketRow[];
+
+  return NextResponse.json({
+    tickets: rows.map((r) => ({
+      id: r.id,
+      userId: r.user_id,
+      username: r.username,
+      email: r.email,
+      subject: r.subject,
+      title: r.title,
+      description: r.description,
+      createdAt: r.created_at,
+    })),
+    total: Number(rows[0]?.total_count ?? 0),
+    page,
+    pageSize,
+  });
+}
+
+export async function DELETE(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json().catch(() => ({}))) as { id?: string };
+  const id = typeof body.id === 'string' ? body.id.trim() : '';
+  if (!id) {
+    return NextResponse.json({ error: 'ticket id is required' }, { status: 400 });
+  }
+
+  const { error, count } = await ctx.supabase
+    .from('support_tickets')
+    .delete({ count: 'exact' })
+    .eq('id', id);
+
+  if (error) {
+    return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
+  }
+  if (!count) {
+    return NextResponse.json({ error: 'ticket not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/frontend/src/app/api/support/route.ts
+++ b/frontend/src/app/api/support/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+import { safeMessage } from '@/lib/api/errors';
+import {
+  SUPPORT_TICKET_SUBJECTS,
+  SUPPORT_TICKET_TITLE_MAX,
+  SUPPORT_TICKET_DESCRIPTION_MAX,
+  type SupportTicketSubject,
+} from '@/lib/constants';
+
+interface SupportTicketRow {
+  id: string;
+  subject: SupportTicketSubject;
+  title: string;
+  description: string;
+  created_at: string;
+}
+
+interface CreatePayload {
+  subject?: string;
+  title?: string;
+  description?: string;
+}
+
+function isValidSubject(value: string): value is SupportTicketSubject {
+  return (SUPPORT_TICKET_SUBJECTS as readonly string[]).includes(value);
+}
+
+export async function GET() {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from('support_tickets')
+    .select('id, subject, title, description, created_at')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
+  }
+
+  return NextResponse.json({ tickets: (data ?? []) as SupportTicketRow[] });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = (await request.json().catch(() => ({}))) as CreatePayload;
+
+  const subject = typeof body.subject === 'string' ? body.subject.trim() : '';
+  const title = typeof body.title === 'string' ? body.title.trim() : '';
+  const description = typeof body.description === 'string' ? body.description.trim() : '';
+
+  if (!subject || !isValidSubject(subject)) {
+    return NextResponse.json(
+      { error: 'subject invalid', field: 'subject' },
+      { status: 400 }
+    );
+  }
+  if (!title || title.length > SUPPORT_TICKET_TITLE_MAX) {
+    return NextResponse.json(
+      { error: `title must be 1–${SUPPORT_TICKET_TITLE_MAX} characters`, field: 'title' },
+      { status: 400 }
+    );
+  }
+  if (!description || description.length > SUPPORT_TICKET_DESCRIPTION_MAX) {
+    return NextResponse.json(
+      {
+        error: `description must be 1–${SUPPORT_TICKET_DESCRIPTION_MAX} characters`,
+        field: 'description',
+      },
+      { status: 400 }
+    );
+  }
+
+  const { data, error } = await supabase
+    .from('support_tickets')
+    .insert({ user_id: user.id, subject, title, description })
+    .select('id, subject, title, description, created_at')
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
+  }
+
+  return NextResponse.json({ ticket: data as SupportTicketRow }, { status: 201 });
+}

--- a/frontend/src/app/support/SupportForm.tsx
+++ b/frontend/src/app/support/SupportForm.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import * as React from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { FieldError } from '@/components/ui/field-error';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  SUPPORT_TICKET_DESCRIPTION_MAX,
+  SUPPORT_TICKET_SUBJECTS,
+  SUPPORT_TICKET_SUBJECT_LABELS,
+  SUPPORT_TICKET_TITLE_MAX,
+  type SupportTicketSubject,
+} from '@/lib/constants';
+import { cn } from '@/lib/utils';
+
+type FieldName = 'subject' | 'title' | 'description';
+
+export function SupportForm() {
+  const queryClient = useQueryClient();
+  const [subject, setSubject] = React.useState<SupportTicketSubject | ''>('');
+  const [title, setTitle] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [touched, setTouched] = React.useState<Record<FieldName, boolean>>({
+    subject: false,
+    title: false,
+    description: false,
+  });
+  const [serverFieldError, setServerFieldError] = React.useState<{
+    field: FieldName;
+    message: string;
+  } | null>(null);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const titleRef = React.useRef<HTMLInputElement>(null);
+  const descriptionRef = React.useRef<HTMLTextAreaElement>(null);
+
+  const trimmedTitle = title.trim();
+  const trimmedDescription = description.trim();
+
+  const subjectError = !subject ? 'Please choose a subject.' : null;
+  const titleError = !trimmedTitle
+    ? 'Title is required.'
+    : trimmedTitle.length > SUPPORT_TICKET_TITLE_MAX
+      ? `Title must be ${SUPPORT_TICKET_TITLE_MAX} characters or fewer.`
+      : null;
+  const descriptionError = !trimmedDescription
+    ? 'Description is required.'
+    : trimmedDescription.length > SUPPORT_TICKET_DESCRIPTION_MAX
+      ? `Description must be ${SUPPORT_TICKET_DESCRIPTION_MAX} characters or fewer.`
+      : null;
+
+  const showError = (field: FieldName): string | null => {
+    if (serverFieldError?.field === field) return serverFieldError.message;
+    if (!touched[field]) return null;
+    if (field === 'subject') return subjectError;
+    if (field === 'title') return titleError;
+    return descriptionError;
+  };
+
+  const reset = () => {
+    setSubject('');
+    setTitle('');
+    setDescription('');
+    setTouched({ subject: false, title: false, description: false });
+    setServerFieldError(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setTouched({ subject: true, title: true, description: true });
+    setServerFieldError(null);
+
+    if (subjectError || titleError || descriptionError) {
+      if (subjectError) return;
+      if (titleError) {
+        titleRef.current?.focus();
+        return;
+      }
+      if (descriptionError) {
+        descriptionRef.current?.focus();
+        return;
+      }
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch('/api/support', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          subject,
+          title: trimmedTitle,
+          description: trimmedDescription,
+        }),
+      });
+      if (!res.ok) {
+        const errBody = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          field?: FieldName;
+        };
+        const msg = String(errBody.error ?? 'Failed to send ticket');
+        if (errBody.field === 'subject' || errBody.field === 'title' || errBody.field === 'description') {
+          setServerFieldError({ field: errBody.field, message: msg });
+          return;
+        }
+        throw new Error(msg);
+      }
+      toast.success('Ticket sent. We’ll get back to you by email.');
+      reset();
+      await queryClient.invalidateQueries({ queryKey: ['support', 'mine'] });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to send ticket');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>New ticket</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+          <div className="space-y-1">
+            <Label htmlFor="support-subject">Subject</Label>
+            <Select
+              value={subject}
+              onValueChange={(value) => {
+                setSubject(value as SupportTicketSubject);
+                if (serverFieldError?.field === 'subject') setServerFieldError(null);
+              }}
+              disabled={isSubmitting}
+            >
+              <SelectTrigger
+                id="support-subject"
+                aria-invalid={showError('subject') ? true : undefined}
+                aria-describedby={showError('subject') ? 'support-subject-error' : undefined}
+                className={cn(
+                  showError('subject') && 'border-destructive focus-visible:ring-destructive'
+                )}
+                onBlur={() => setTouched((t) => ({ ...t, subject: true }))}
+              >
+                <SelectValue placeholder="Choose a subject" />
+              </SelectTrigger>
+              <SelectContent>
+                {SUPPORT_TICKET_SUBJECTS.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {SUPPORT_TICKET_SUBJECT_LABELS[s]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FieldError id="support-subject-error" message={showError('subject') || undefined} />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="support-title">Title</Label>
+            <Input
+              id="support-title"
+              ref={titleRef}
+              type="text"
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+                if (serverFieldError?.field === 'title') setServerFieldError(null);
+              }}
+              onBlur={() => setTouched((t) => ({ ...t, title: true }))}
+              disabled={isSubmitting}
+              maxLength={SUPPORT_TICKET_TITLE_MAX}
+              placeholder="One-line summary"
+              aria-invalid={showError('title') ? true : undefined}
+              aria-describedby={showError('title') ? 'support-title-error' : undefined}
+              className={cn(
+                showError('title') && 'border-destructive focus-visible:ring-destructive'
+              )}
+            />
+            <FieldError id="support-title-error" message={showError('title') || undefined} />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="support-description">Description</Label>
+            <Textarea
+              id="support-description"
+              ref={descriptionRef}
+              value={description}
+              onChange={(e) => {
+                setDescription(e.target.value);
+                if (serverFieldError?.field === 'description') setServerFieldError(null);
+              }}
+              onBlur={() => setTouched((t) => ({ ...t, description: true }))}
+              disabled={isSubmitting}
+              maxLength={SUPPORT_TICKET_DESCRIPTION_MAX}
+              rows={8}
+              placeholder="Steps to reproduce, account details, payment reference, etc."
+              aria-invalid={showError('description') ? true : undefined}
+              aria-describedby={
+                showError('description') ? 'support-description-error' : 'support-description-help'
+              }
+              className={cn(
+                showError('description') && 'border-destructive focus-visible:ring-destructive'
+              )}
+            />
+            <div className="flex items-center justify-between text-xs">
+              {!showError('description') ? (
+                <p id="support-description-help" className="text-muted-foreground">
+                  Be specific — it helps us reply faster.
+                </p>
+              ) : (
+                <span aria-hidden="true" />
+              )}
+              <span
+                className={cn(
+                  'text-muted-foreground tabular-nums',
+                  description.length >= SUPPORT_TICKET_DESCRIPTION_MAX && 'text-destructive'
+                )}
+              >
+                {description.length} / {SUPPORT_TICKET_DESCRIPTION_MAX}
+              </span>
+            </div>
+            <FieldError
+              id="support-description-error"
+              message={showError('description') || undefined}
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Sending…' : 'Submit ticket'}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/app/support/UserTicketsList.tsx
+++ b/frontend/src/app/support/UserTicketsList.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  SUPPORT_TICKET_SUBJECT_LABELS,
+  type SupportTicketSubject,
+} from '@/lib/constants';
+
+interface UserTicket {
+  id: string;
+  subject: SupportTicketSubject;
+  title: string;
+  description: string;
+  created_at: string;
+}
+
+interface TicketsResponse {
+  tickets: UserTicket[];
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+export function UserTicketsList() {
+  const query = useQuery<TicketsResponse>({
+    queryKey: ['support', 'mine'],
+    queryFn: async () => {
+      const res = await fetch('/api/support');
+      if (!res.ok) throw new Error('Failed to load tickets');
+      return res.json();
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Your tickets</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {query.isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full" />
+            ))}
+          </div>
+        ) : query.isError ? (
+          <p className="text-destructive text-sm">Couldn&apos;t load your tickets.</p>
+        ) : !query.data?.tickets.length ? (
+          <p className="text-muted-foreground text-sm">
+            You haven&apos;t submitted any tickets yet.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {query.data.tickets.map((t) => (
+              <UserTicketItem key={t.id} ticket={t} />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function UserTicketItem({ ticket }: { ticket: UserTicket }) {
+  const [expanded, setExpanded] = React.useState(false);
+  return (
+    <li className="border-border rounded-md border p-3">
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <Badge variant="outline">{SUPPORT_TICKET_SUBJECT_LABELS[ticket.subject]}</Badge>
+        <time className="text-muted-foreground text-xs" dateTime={ticket.created_at}>
+          {formatDate(ticket.created_at)}
+        </time>
+      </div>
+      <p className="font-medium text-sm">{ticket.title}</p>
+      <p
+        className={
+          expanded
+            ? 'text-muted-foreground mt-1 text-sm whitespace-pre-wrap'
+            : 'text-muted-foreground mt-1 line-clamp-2 text-sm'
+        }
+      >
+        {ticket.description}
+      </p>
+      {ticket.description.length > 120 && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="text-primary mt-1 text-xs hover:underline"
+        >
+          {expanded ? 'Show less' : 'Show more'}
+        </button>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/app/support/page.tsx
+++ b/frontend/src/app/support/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { SupportForm } from './SupportForm';
+import { UserTicketsList } from './UserTicketsList';
+
+export const metadata: Metadata = {
+  title: 'Support | World Cup 2026',
+};
+
+export default function SupportPage() {
+  return (
+    <PageLayout>
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl font-bold">Contact support</h1>
+        <p className="text-muted-foreground">
+          Hit a snag with your account, a payment, or your predictions? Send us a
+          ticket and we&apos;ll get back to you by email.
+        </p>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-5">
+        <div className="lg:col-span-3">
+          <SupportForm />
+        </div>
+        <div className="lg:col-span-2">
+          <UserTicketsList />
+        </div>
+      </div>
+    </PageLayout>
+  );
+}

--- a/frontend/src/components/admin/AdminNav.tsx
+++ b/frontend/src/components/admin/AdminNav.tsx
@@ -8,6 +8,7 @@ const links = [
   { label: 'Dashboard', href: '/admin' },
   { label: 'Results', href: '/admin/results' },
   { label: 'Users', href: '/admin/users' },
+  { label: 'Support', href: '/admin/support' },
   { label: 'Tournament', href: '/admin/tournament' },
 ];
 

--- a/frontend/src/components/layout/AuthMenu.tsx
+++ b/frontend/src/components/layout/AuthMenu.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Gift, LogOut, Settings, Trophy, User as UserIcon } from 'lucide-react';
+import { Gift, LifeBuoy, LogOut, Settings, Trophy, User as UserIcon } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -143,6 +143,17 @@ export function AuthMenu() {
             <Link href={ROUTES.account}>
               <Settings className="h-4 w-4" />
               Account settings
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full justify-start gap-2"
+            asChild
+          >
+            <Link href={ROUTES.support}>
+              <LifeBuoy className="h-4 w-4" />
+              Support
             </Link>
           </Button>
           <Button

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-20 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-sm transition-colors focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -72,6 +72,7 @@ export const ROUTES = {
   privacy: '/privacy',
   referrals: '/referrals',
   rewards: '/rewards',
+  support: '/support',
 } as const;
 
 /**
@@ -126,3 +127,29 @@ export const PASSWORD_MIN_LENGTH = 8;
 
 export const PREDICTION_NAME_REGEX = /^[A-Za-z0-9 _\-.''‘’]+$/;
 export const PREDICTION_NAME_MAX = 60;
+
+/**
+ * Support tickets — see `supabase/migrations/0051_support_tickets.sql`.
+ * The subject list is also enforced by the table's CHECK constraint; keep
+ * them in sync. Length constants mirror the same CHECK bounds.
+ */
+export const SUPPORT_TICKET_SUBJECTS = [
+  'account',
+  'settings',
+  'bug',
+  'prediction',
+  'payment',
+] as const;
+
+export type SupportTicketSubject = (typeof SUPPORT_TICKET_SUBJECTS)[number];
+
+export const SUPPORT_TICKET_SUBJECT_LABELS: Record<SupportTicketSubject, string> = {
+  account: 'Account',
+  settings: 'Settings',
+  bug: 'Bug report',
+  prediction: 'Prediction issue',
+  payment: 'Payment',
+};
+
+export const SUPPORT_TICKET_TITLE_MAX = 120;
+export const SUPPORT_TICKET_DESCRIPTION_MAX = 2000;

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,7 +2,14 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { env } from '@/config/env';
 
-const PROTECTED_PREFIXES = ['/predictions', '/admin', '/account', '/referrals', '/rewards'];
+const PROTECTED_PREFIXES = [
+  '/predictions',
+  '/admin',
+  '/account',
+  '/referrals',
+  '/rewards',
+  '/support',
+];
 
 // Using the deprecated middleware.ts name (not Next 16's proxy.ts) because
 // @opennextjs/cloudflare doesn't yet support proxy. Track:

--- a/supabase/migrations/0051_support_tickets.sql
+++ b/supabase/migrations/0051_support_tickets.sql
@@ -1,0 +1,114 @@
+-- WC2026 — Support tickets
+--
+-- A minimal inbound support channel. Logged-in users submit a ticket with
+-- a subject (fixed enum), a title, and a description (≤ 2000 chars).
+-- Admins view all tickets via `admin_list_support_tickets` and delete the
+-- row when the issue is resolved (reply happens out-of-band via the
+-- admin's own email client for v1; an in-app SMTP reply can be added
+-- later by adding nullable `responded_at` / `admin_notes` columns).
+--
+-- Security:
+--   * Tickets are owner-readable + admin-readable. Owners CAN insert but
+--     CANNOT update or delete; admins can delete.
+--   * `admin_list_support_tickets` is SECURITY DEFINER + is_admin()-gated
+--     so it can join `auth.users` for the email field without exposing
+--     that table to client RLS.
+
+
+create table public.support_tickets (
+    id          uuid primary key default gen_random_uuid(),
+    user_id     uuid not null references public.profiles(id) on delete cascade,
+    subject     text not null,
+    title       text not null,
+    description text not null,
+    created_at  timestamptz not null default now(),
+    constraint support_tickets_subject_check
+        check (subject in ('account','settings','bug','prediction','payment')),
+    constraint support_tickets_title_length
+        check (char_length(title) between 1 and 120),
+    constraint support_tickets_description_length
+        check (char_length(description) between 1 and 2000)
+);
+
+-- Powers the user's own ticket list (`/api/support` GET).
+create index support_tickets_user_created_idx
+    on public.support_tickets (user_id, created_at desc);
+
+-- Powers admin pagination ordered by newest first.
+create index support_tickets_created_idx
+    on public.support_tickets (created_at desc);
+
+alter table public.support_tickets enable row level security;
+
+-- Owners and admins can read.
+create policy "support_tickets_select_own_or_admin"
+    on public.support_tickets for select
+    using (auth.uid() = user_id or public.is_admin());
+
+-- Owners can insert their own ticket. No UPDATE policy — tickets are
+-- immutable from creation through deletion.
+create policy "support_tickets_insert_own"
+    on public.support_tickets for insert
+    with check (auth.uid() = user_id);
+
+-- Admins (and only admins) can delete.
+create policy "support_tickets_delete_admin"
+    on public.support_tickets for delete
+    using (public.is_admin());
+
+grant select, insert, delete on public.support_tickets to authenticated;
+
+
+-- ========== RPC: admin_list_support_tickets ==========
+-- Mirrors admin_list_users: SECURITY DEFINER, is_admin()-gated, joins
+-- auth.users for email. Returns one page of tickets ordered by newest
+-- first plus a `total_count` window for client-side pagination.
+create or replace function public.admin_list_support_tickets(
+    p_page int default 1,
+    p_page_size int default 25
+) returns table (
+    id          uuid,
+    user_id     uuid,
+    username    text,
+    email       text,
+    subject     text,
+    title       text,
+    description text,
+    created_at  timestamptz,
+    total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_limit int;
+    v_offset int;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    v_limit := greatest(1, least(coalesce(p_page_size, 25), 100));
+    v_offset := greatest(0, (coalesce(p_page, 1) - 1) * v_limit);
+
+    return query
+    select
+        t.id,
+        t.user_id,
+        p.username::text,
+        u.email::text,
+        t.subject,
+        t.title,
+        t.description,
+        t.created_at,
+        count(*) over () as total_count
+    from public.support_tickets t
+    join public.profiles p on p.id = t.user_id
+    left join auth.users u on u.id = t.user_id
+    order by t.created_at desc
+    limit v_limit offset v_offset;
+end;
+$$;
+
+grant execute on function public.admin_list_support_tickets(int, int) to authenticated;


### PR DESCRIPTION
## Summary
- New `/support` page lets signed-in users file a ticket (subject enum, title, ≤2000-char description) and see their own history; AuthMenu gains a Support entry.
- New `/admin/support` inbox lists all tickets with user contact info and a delete-when-resolved action; AdminNav gains a Support tab.
- Adds migration `0051_support_tickets.sql`: `support_tickets` table with owner-insert/admin-delete RLS, plus a SECURITY DEFINER `admin_list_support_tickets` RPC that joins `auth.users` for email without exposing that table.
- Middleware `PROTECTED_PREFIXES` now includes `/support` so anonymous hits redirect to login.

## Test plan
- [ ] `cd frontend && npm test && npm run typecheck && npm run lint`
- [ ] Run `supabase db reset` and confirm `0051_support_tickets.sql` applies cleanly
- [ ] As a regular user: submit a ticket from `/support`, confirm it appears in your history and you cannot edit/delete it
- [ ] As another user: confirm you cannot see the first user's ticket
- [ ] As an admin: confirm `/admin/support` lists all tickets with email + username, and the delete action removes the row
- [ ] Hit `/support` while logged out and confirm middleware redirects to `/login`