### PR TITLE
fix(predictions): flip knockout source labels to group-first

### DIFF
--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { TeamFlag } from '@/components/shared/TeamFlag';
 import { resolveTeamSource } from '@/lib/knockoutResolver';
-import { formatSourcePair } from '@/lib/matchLabel';
+import { formatSource, formatSourcePair } from '@/lib/matchLabel';
 import { cn } from '@/lib/utils';
 import type {
   GroupPrediction,
@@ -107,7 +107,7 @@ function getTeamDisplay(
 // back to the raw source string.
 function describeSource(source: string): string {
   if (/^3-[A-L]{5}$/.test(source)) return '3rd-place team (TBD)';
-  return source;
+  return formatSource(source);
 }
 
 // Single match card component

--- a/frontend/src/lib/matchLabel.ts
+++ b/frontend/src/lib/matchLabel.ts
@@ -1,6 +1,12 @@
+// Flip group-seed sources from DB-native `<pos><group>` (`1A`, `2L`) to the
+// more readable `<group><pos>` (`A1`, `L2`). Other shapes — match references
+// (`M73`, `L-M101`) and 3rd-place placeholders (`3-ABCDF`) — pass through.
+export const formatSource = (source: string): string =>
+  source.replace(/^(\d)([A-L])$/, '$2$1');
+
 // Render the team1_source / team2_source pair as a debug-friendly subtitle
-// alongside a match's id, e.g.:  M74 vs M77  or  1E vs 3-ABCDF  or
+// alongside a match's id, e.g.:  M74 vs M77  or  E1 vs 3-ABCDF  or
 // L-M101 vs L-M102. Used in the prediction wizard and read-only bracket so
 // admins/users can correlate against the FIFA-published bracket reference.
 export const formatSourcePair = (team1Source: string, team2Source: string): string =>
-  `${team1Source} vs ${team2Source}`;
+  `${formatSource(team1Source)} vs ${formatSource(team2Source)}`;


### PR DESCRIPTION
## Summary
- Render R32 helper labels as `C1 vs F2` instead of `1C vs 2F` — group letter first reads more naturally.
- Display-only change: DB-stored source strings (`1A`, `2F`, `M73`, `3-ABCDF`, `L-M101`) are unchanged; resolver code untouched.
- Swap regex is gated to `^(\d)([A-L])$`, so match references and 3rd-place placeholders pass through verbatim.

## Test plan
- [ ] `cd frontend && npm test && npm run typecheck && npm run lint` (all green locally; 383/383 tests pass).
- [ ] On `/predictions/new`, advance to the knockout step and confirm R32 cards show `A2 vs B2`, `E1 vs 3-ABCDF`, `C1 vs F2`, etc.
- [ ] Confirm the per-team `TBD · …` placeholder also reads `TBD · C1` instead of `TBD · 1C`.
- [ ] Confirm read-only `BracketView` on `/predictions/[id]` shows the same flipped labels.