### PR TITLE
feat(scoring): v4 rebalance + decouple Phase 2 bracket from Phase 1

### DIFF
--- a/frontend/src/app/admin/advancers/AdvancersForm.tsx
+++ b/frontend/src/app/admin/advancers/AdvancersForm.tsx
@@ -35,7 +35,10 @@ interface BracketResponse {
 
 interface GroupStandingRow {
   group_id: string;
+  first_team_id: string | null;
+  second_team_id: string | null;
   third_team_id: string | null;
+  fourth_team_id: string | null;
 }
 
 const CLEAR_VALUE = '__CLEAR__';
@@ -44,6 +47,36 @@ async function fetchJSON<T>(url: string): Promise<T> {
   const res = await fetch(url);
   if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
   return res.json();
+}
+
+type R32SourceShape =
+  | { kind: 'group'; position: 1 | 2 | 3; groupId: string }
+  | { kind: 'third'; groups: string[] }
+  | { kind: 'unknown' };
+
+function parseR32Source(source: string): R32SourceShape {
+  const groupMatch = source.match(/^([123])([A-L])$/);
+  if (groupMatch) {
+    return {
+      kind: 'group',
+      position: Number(groupMatch[1]) as 1 | 2 | 3,
+      groupId: groupMatch[2],
+    };
+  }
+  if (/^3-[A-L]+$/.test(source)) {
+    return { kind: 'third', groups: source.slice(2).split('') };
+  }
+  return { kind: 'unknown' };
+}
+
+function pickFromStanding(
+  row: GroupStandingRow | undefined,
+  position: 1 | 2 | 3
+): string | null {
+  if (!row) return null;
+  if (position === 1) return row.first_team_id;
+  if (position === 2) return row.second_team_id;
+  return row.third_team_id;
 }
 
 export function AdvancersForm() {
@@ -96,25 +129,32 @@ export function AdvancersForm() {
       .filter((t): t is Team => !!t);
   }, [standingsQuery.data, teamById]);
 
-  // The 3rd-place R32 slots, discovered by scanning seed sources. Source of
-  // truth for the count is the same as in admin_set_phase_two.
-  const thirdPlaceSlots = React.useMemo(() => {
-    const out: Array<{ matchId: string; slot: 1 | 2; sourceLabel: string }> = [];
-    for (const m of matchesQuery.data ?? []) {
-      if (m.stage !== 'round_of_32') continue;
-      if (m.team1Source.startsWith('3-')) {
-        out.push({ matchId: m.id, slot: 1, sourceLabel: m.team1Source });
-      }
-      if (m.team2Source.startsWith('3-')) {
-        out.push({ matchId: m.id, slot: 2, sourceLabel: m.team2Source });
-      }
-    }
-    return out;
+  // All 16 R32 matches, sorted by FIFA id (M73..M88).
+  const r32Matches = React.useMemo(() => {
+    return (matchesQuery.data ?? [])
+      .filter((m) => m.stage === 'round_of_32')
+      .sort((a, b) => Number(a.id.slice(1)) - Number(b.id.slice(1)));
   }, [matchesQuery.data]);
 
-  const completedAdvancers = advancers.length;
+  // Total number of 3rd-place R32 slots (8 per the seed). The matching
+  // assignment count is what `admin_set_phase_two` gates on.
+  const totalThirdSlots = React.useMemo(() => {
+    let n = 0;
+    for (const m of r32Matches) {
+      if (m.team1Source.startsWith('3-')) n++;
+      if (m.team2Source.startsWith('3-')) n++;
+    }
+    return n;
+  }, [r32Matches]);
+
+  // Lookup table for standings by group_id.
+  const standingsByGroup = React.useMemo(() => {
+    const map = new Map<string, GroupStandingRow>();
+    for (const row of standingsQuery.data ?? []) map.set(row.group_id, row);
+    return map;
+  }, [standingsQuery.data]);
+
   const completedAssignments = assignments.length;
-  const allAdvancersSet = completedAdvancers === 8;
 
   const handleRankChange = async (rank: number, teamId: string | null) => {
     if (!tournamentId) return;
@@ -217,110 +257,183 @@ export function AdvancersForm() {
 
       <section>
         <div className="mb-4">
-          <h2 className="text-xl font-semibold">FIFA R32 bracket assignment</h2>
+          <h2 className="text-xl font-semibold">R32 bracket</h2>
           <p className="text-muted-foreground text-sm">
-            For each R32 3rd-place slot, pick which of the 8 advancers FIFA placed there.
-            Available once all 8 advancers are set.
+            Each R32 match. Group-winner / runner-up slots prefill from group standings.
+            Pick the 3rd-place team for the eight 3-XXXXX slots; the dropdown is scoped to
+            the third-place finishers of the groups in that slot&apos;s source.
           </p>
         </div>
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          {thirdPlaceSlots.map(({ matchId, slot, sourceLabel }) => {
-            const current = assignments.find((a) => a.matchId === matchId && a.slot === slot);
-            const currentTeam = current ? teamById.get(current.teamId) : null;
-            // Teams already assigned to a different slot — disable them so
-            // the admin can't accidentally double-assign and hit the
-            // `unique (tournament_id, team_id)` constraint error.
-            const assignedElsewhere = new Set(
-              assignments
-                .filter((a) => !(a.matchId === matchId && a.slot === slot))
-                .map((a) => a.teamId)
-            );
+          {r32Matches.map((match) => {
+            const sourceSlots: Array<{ slot: 1 | 2; source: string }> = [
+              { slot: 1, source: match.team1Source },
+              { slot: 2, source: match.team2Source },
+            ];
+
+            // Teams already assigned to another 3rd-place slot in this
+            // tournament — used to disable duplicates so we don't hit the
+            // `unique (tournament_id, team_id)` constraint.
+            const usedInOtherSlots = (currentMatchId: string, currentSlot: 1 | 2) =>
+              new Set(
+                assignments
+                  .filter(
+                    (a) => !(a.matchId === currentMatchId && a.slot === currentSlot)
+                  )
+                  .map((a) => a.teamId)
+              );
 
             return (
-              <Card
-                key={`${matchId}-${slot}`}
-                className={current ? 'border-green-500/40' : ''}
-                data-testid={`r32-slot-${matchId}-${slot}`}
-              >
+              <Card key={match.id} data-testid={`r32-match-${match.id}`}>
                 <CardHeader className="pb-2">
                   <div className="flex items-center justify-between">
-                    <CardTitle className="text-base font-mono">{matchId} · slot {slot}</CardTitle>
-                    {current ? (
-                      <Badge variant="default" className="bg-green-600">Set</Badge>
-                    ) : (
-                      <Badge variant="outline">Unset</Badge>
-                    )}
+                    <CardTitle className="font-mono text-base">{match.id}</CardTitle>
+                    <span className="text-muted-foreground font-mono text-xs">
+                      {match.team1Source} vs {match.team2Source}
+                    </span>
                   </div>
-                  <p className="text-muted-foreground text-xs">
-                    Legacy source: {sourceLabel}
-                  </p>
                 </CardHeader>
-                <CardContent>
-                  <Select
-                    value={current?.teamId ?? ''}
-                    onValueChange={(v) => {
-                      if (v === CLEAR_VALUE) {
-                        void clearAssignment(matchId, slot);
-                        return;
-                      }
-                      void setAssignment(matchId, slot, v);
-                    }}
-                    disabled={!allAdvancersSet}
-                  >
-                    <SelectTrigger>
-                      <SelectValue
-                        placeholder={
-                          allAdvancersSet
-                            ? 'Pick an advancer'
-                            : 'Set all 8 advancers first'
-                        }
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {current ? (
-                        <SelectItem value={CLEAR_VALUE}>
-                          <span className="text-muted-foreground">(none)</span>
-                        </SelectItem>
-                      ) : null}
-                      {advancers.map((a) => {
-                        const team = teamById.get(a.teamId);
-                        if (!team) return null;
-                        const usedElsewhere = assignedElsewhere.has(team.id);
-                        return (
-                          <SelectItem
-                            key={a.rank}
-                            value={team.id}
-                            disabled={usedElsewhere}
-                          >
-                            <span className="flex items-center gap-2">
+                <CardContent className="space-y-3">
+                  {sourceSlots.map(({ slot, source }) => {
+                    const parsed = parseR32Source(source);
+
+                    if (parsed.kind === 'group') {
+                      const teamId = pickFromStanding(
+                        standingsByGroup.get(parsed.groupId),
+                        parsed.position
+                      );
+                      const team = teamId ? teamById.get(teamId) ?? null : null;
+                      return (
+                        <div
+                          key={slot}
+                          className="bg-muted/40 flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm"
+                          data-testid={`r32-slot-${match.id}-${slot}`}
+                        >
+                          <span className="text-muted-foreground font-mono text-xs w-10">
+                            {source}
+                          </span>
+                          {team ? (
+                            <>
                               <TeamFlag code={team.code} />
-                              <span className="text-muted-foreground font-mono text-xs">
-                                #{a.rank}
-                              </span>
-                              <span>{team.name}</span>
-                              {usedElsewhere && (
-                                <span className="text-muted-foreground ml-1 text-xs italic">
-                                  (assigned elsewhere)
-                                </span>
-                              )}
+                              <span className="truncate">{team.name}</span>
+                            </>
+                          ) : (
+                            <span className="text-muted-foreground italic text-xs">
+                              awaiting group standings
                             </span>
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
-                  {currentTeam && (
-                    <p className="text-muted-foreground mt-2 text-xs">
-                      Currently assigned: <span className="text-foreground">{currentTeam.name}</span>
-                    </p>
-                  )}
+                          )}
+                        </div>
+                      );
+                    }
+
+                    if (parsed.kind === 'third') {
+                      const current = assignments.find(
+                        (a) => a.matchId === match.id && a.slot === slot
+                      );
+                      const currentTeam = current ? teamById.get(current.teamId) ?? null : null;
+                      // Options: each candidate group's third placer (if entered).
+                      const options = parsed.groups
+                        .map((gid) => {
+                          const tid = standingsByGroup.get(gid)?.third_team_id ?? null;
+                          if (!tid) return null;
+                          const team = teamById.get(tid);
+                          if (!team) return null;
+                          return { groupId: gid, team };
+                        })
+                        .filter((o): o is { groupId: string; team: Team } => o !== null);
+                      const used = usedInOtherSlots(match.id, slot);
+
+                      return (
+                        <div
+                          key={slot}
+                          className={
+                            current
+                              ? 'rounded-md border border-green-500/40 px-2 py-1.5'
+                              : 'rounded-md border px-2 py-1.5'
+                          }
+                          data-testid={`r32-slot-${match.id}-${slot}`}
+                        >
+                          <div className="mb-1 flex items-center justify-between text-xs">
+                            <span className="text-muted-foreground font-mono">{source}</span>
+                            {current ? (
+                              <Badge variant="default" className="bg-green-600">Set</Badge>
+                            ) : (
+                              <Badge variant="outline">Unset</Badge>
+                            )}
+                          </div>
+                          <Select
+                            value={current?.teamId ?? ''}
+                            onValueChange={(v) => {
+                              if (v === CLEAR_VALUE) {
+                                void clearAssignment(match.id, slot);
+                                return;
+                              }
+                              void setAssignment(match.id, slot, v);
+                            }}
+                            disabled={options.length === 0}
+                          >
+                            <SelectTrigger>
+                              <SelectValue
+                                placeholder={
+                                  options.length === 0
+                                    ? 'Enter group standings first'
+                                    : 'Pick a 3rd-place team'
+                                }
+                              />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {current ? (
+                                <SelectItem value={CLEAR_VALUE}>
+                                  <span className="text-muted-foreground">(none)</span>
+                                </SelectItem>
+                              ) : null}
+                              {options.map(({ groupId, team }) => {
+                                const usedElsewhere = used.has(team.id);
+                                return (
+                                  <SelectItem
+                                    key={team.id}
+                                    value={team.id}
+                                    disabled={usedElsewhere}
+                                  >
+                                    <span className="flex items-center gap-2">
+                                      <TeamFlag code={team.code} />
+                                      <span className="text-muted-foreground font-mono text-xs">
+                                        3{groupId}
+                                      </span>
+                                      <span>{team.name}</span>
+                                      {usedElsewhere && (
+                                        <span className="text-muted-foreground ml-1 text-xs italic">
+                                          (assigned elsewhere)
+                                        </span>
+                                      )}
+                                    </span>
+                                  </SelectItem>
+                                );
+                              })}
+                            </SelectContent>
+                          </Select>
+                          {currentTeam && (
+                            <p className="text-muted-foreground mt-1 text-xs">
+                              Assigned: <span className="text-foreground">{currentTeam.name}</span>
+                            </p>
+                          )}
+                        </div>
+                      );
+                    }
+
+                    return (
+                      <div key={slot} className="text-muted-foreground text-xs">
+                        Unhandled source: {source}
+                      </div>
+                    );
+                  })}
                 </CardContent>
               </Card>
             );
           })}
         </div>
         <p className="text-muted-foreground mt-3 text-xs">
-          {completedAssignments} / {thirdPlaceSlots.length} bracket slots assigned.
+          {completedAssignments} / {totalThirdSlots} 3rd-place slots assigned.
         </p>
       </section>
     </div>

--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -51,6 +51,10 @@ interface BracketResponse {
   assignments: Array<{ matchId: string; slot: 1 | 2; teamId: string }>;
 }
 
+interface GroupStandingRow {
+  group_id: string;
+}
+
 const STATUSES = ['upcoming', 'group_stage', 'knockout', 'completed'] as const;
 
 async function fetchJSON<T>(url: string): Promise<T> {
@@ -75,9 +79,9 @@ export function TournamentSettingsForm() {
     queryFn: () => fetchJSON('/api/tournament'),
   });
 
-  // Phase 2 toggle pre-flight checks: all 8 advancers + all R32 3rd-place
-  // bracket slots must be assigned. These queries mirror the ones the
-  // /admin/advancers page used to own when it hosted the Phase 2 controls.
+  // Phase 2 toggle pre-flight checks: all 12 group standings + all R32
+  // 3rd-place bracket slots must be assigned (advancers are no longer a
+  // Phase 2 gate — they're scoring inputs that can be filled any time).
   const advancersQuery = useQuery<AdvancersResponse>({
     queryKey: ['admin-advancers'],
     queryFn: () => fetchJSON('/api/admin/third-place-advancers'),
@@ -89,6 +93,13 @@ export function TournamentSettingsForm() {
   const matchesQuery = useQuery<KnockoutMatch[]>({
     queryKey: ['knockout-matches'],
     queryFn: () => fetchJSON('/api/knockout-matches'),
+  });
+  const tournamentIdForStandings = tournament.data?.id ?? null;
+  const standingsQuery = useQuery<GroupStandingRow[]>({
+    queryKey: ['admin-group-standings', tournamentIdForStandings],
+    queryFn: () =>
+      fetchJSON(`/api/admin/group-standings?tournamentId=${tournamentIdForStandings}`),
+    enabled: !!tournamentIdForStandings,
   });
 
   const [status, setStatus] = React.useState<TournamentInfo['status']>('upcoming');
@@ -189,6 +200,7 @@ export function TournamentSettingsForm() {
   // Phase 2 derived state.
   const advancersCount = advancersQuery.data?.advancers.length ?? 0;
   const assignmentsCount = bracketQuery.data?.assignments.length ?? 0;
+  const standingsCount = standingsQuery.data?.length ?? 0;
   const thirdPlaceSlotCount = React.useMemo(() => {
     let n = 0;
     for (const m of matchesQuery.data ?? []) {
@@ -199,10 +211,10 @@ export function TournamentSettingsForm() {
     return n;
   }, [matchesQuery.data]);
 
-  const allAdvancersSet = advancersCount === 8;
+  const allStandingsSet = standingsCount === 12;
   const allAssignmentsSet =
     thirdPlaceSlotCount > 0 && assignmentsCount === thirdPlaceSlotCount;
-  const canOpenPhaseTwo = allAdvancersSet && allAssignmentsSet;
+  const canOpenPhaseTwo = allStandingsSet && allAssignmentsSet;
   const phase = tournament.data?.phase ?? 'phase1';
 
   const phaseTwoLockIso = React.useMemo(() => {
@@ -448,8 +460,9 @@ export function TournamentSettingsForm() {
                 : phase === 'phase2_locked'
                   ? 'closed (lock time has passed — set a new lock time to reopen)'
                   : 'closed'}
-              . {advancersCount}/8 advancers set ·{' '}
-              {assignmentsCount}/{thirdPlaceSlotCount || 8} bracket slots assigned.
+              . {standingsCount}/12 group standings ·{' '}
+              {assignmentsCount}/{thirdPlaceSlotCount || 8} bracket slots assigned ·{' '}
+              {advancersCount}/8 advancers (scoring only).
             </p>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -465,8 +478,9 @@ export function TournamentSettingsForm() {
               />
               <p className="text-muted-foreground text-xs">
                 When knockout predictions freeze. Set + click Open Phase 2 to start the knockout
-                window. Advancers + R32 bracket assignments must be filled on the{' '}
-                <span className="font-mono">/admin/advancers</span> tab first.
+                window. Group standings + R32 bracket assignments must be filled on the{' '}
+                <span className="font-mono">/admin/results</span> and{' '}
+                <span className="font-mono">/admin/advancers</span> tabs first.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -480,8 +494,8 @@ export function TournamentSettingsForm() {
                   phaseTwoLockInPast
                 }
                 title={
-                  !allAdvancersSet
-                    ? 'Set all 8 advancers first'
+                  !allStandingsSet
+                    ? 'Enter all 12 group standings first'
                     : !allAssignmentsSet
                       ? 'Assign every R32 3rd-place slot first'
                       : !phaseTwoLockIso

--- a/frontend/src/app/api/admin/tournament/route.ts
+++ b/frontend/src/app/api/admin/tournament/route.ts
@@ -9,7 +9,8 @@ interface Body {
   isActive?: boolean;
   championTotalGoals?: number | null;
   /** Phase 2 toggle. When set, routes through admin_set_phase_two RPC which
-   *  validates that all 8 advancers are populated before opening. */
+   *  validates that group_standings + R32 bracket assignments are populated
+   *  before opening. */
   knockoutUnlocked?: boolean;
   knockoutLockTime?: string | null;
 }
@@ -40,8 +41,9 @@ export async function PATCH(request: NextRequest) {
     );
   }
 
-  // Phase 2 toggle has its own RPC (validates advancer count). Run it first
-  // so a failed check leaves the rest of the patch intact.
+  // Phase 2 toggle has its own RPC (validates group_standings + bracket
+  // assignments). Run it first so a failed check leaves the rest of the
+  // patch intact.
   if (body.knockoutUnlocked !== undefined) {
     const { error: phaseError } = await ctx.supabase.rpc('admin_set_phase_two', {
       p_tournament_id: body.id,
@@ -50,7 +52,8 @@ export async function PATCH(request: NextRequest) {
     });
     if (phaseError) {
       const msg = phaseError.message ?? '';
-      const status = msg.includes('all 8 advancers') ? 409 : 400;
+      const status =
+        msg.includes('group standings') || msg.includes('bracket slots') ? 409 : 400;
       return NextResponse.json({ error: safeMessage(phaseError) }, { status });
     }
   }

--- a/frontend/src/app/api/group-standings/route.ts
+++ b/frontend/src/app/api/group-standings/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+
+export async function GET() {
+  const supabase = await getServerSupabase();
+  const { data: tournament } = await supabase
+    .from('tournaments')
+    .select('id')
+    .eq('is_active', true)
+    .maybeSingle();
+  if (!tournament) {
+    return NextResponse.json({ standings: [] });
+  }
+
+  const { data, error } = await supabase
+    .from('group_standings')
+    .select('group_id, first_team_id, second_team_id, third_team_id, fourth_team_id')
+    .eq('tournament_id', tournament.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({
+    standings: (data ?? []).map((r) => ({
+      groupId: r.group_id as string,
+      firstTeamId: (r.first_team_id ?? null) as string | null,
+      secondTeamId: (r.second_team_id ?? null) as string | null,
+      thirdTeamId: (r.third_team_id ?? null) as string | null,
+      fourthTeamId: (r.fourth_team_id ?? null) as string | null,
+    })),
+  });
+}

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -33,6 +33,7 @@ import type {
   AdvancerPrediction,
   Group,
   GroupPrediction,
+  GroupStanding,
   KnockoutMatch,
   KnockoutMatchPrediction,
   KnockoutStage,
@@ -318,6 +319,12 @@ export function PredictionsPageContent({
     queryFn: () => fetchJSON('/api/r32-bracket'),
   });
   const bracketAssignments = bracketQuery.data?.assignments ?? [];
+
+  const groupStandingsQuery = useQuery<{ standings: GroupStanding[] }>({
+    queryKey: ['group-standings'],
+    queryFn: () => fetchJSON('/api/group-standings'),
+  });
+  const groupStandings = groupStandingsQuery.data?.standings ?? [];
 
   const [predictionName, setPredictionName] = React.useState(initial?.name ?? '');
   const [predictionNameTouched, setPredictionNameTouched] = React.useState(false);
@@ -1111,6 +1118,7 @@ export function PredictionsPageContent({
               groupPredictions={groupPredictions}
               knockoutPredictions={knockoutPredictions}
               bracketAssignments={bracketAssignments}
+              groupStandings={groupStandings}
               onPredictionChange={handleKnockoutPredictionChange}
               disabled={!phase2Editable}
               stage={currentStep}

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -62,6 +62,9 @@ type Step =
 
 type TopStep = 'groups' | 'best_thirds' | 'champion_pick' | 'knockout' | 'tiebreaker';
 
+// 'third_place' (M103) is intentionally omitted — the match is no longer
+// scored under v4 so users don't pick it. The DB stage enum keeps the value
+// so the bracket / admin results editor can still surface M103 read-only.
 const STEP_ORDER: Step[] = [
   'groups',
   'best_thirds',
@@ -70,7 +73,6 @@ const STEP_ORDER: Step[] = [
   'round_of_16',
   'quarter_finals',
   'semi_finals',
-  'third_place',
   'final',
   'tiebreaker',
 ];
@@ -93,7 +95,6 @@ const KNOCKOUT_STAGE_LIST: KnockoutStage[] = [
   'round_of_16',
   'quarter_finals',
   'semi_finals',
-  'third_place',
   'final',
 ];
 

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -998,8 +998,16 @@ export function PredictionsPageContent({
   // and by Submit Prediction on the tiebreaker. Phase 1 used to have a
   // bottom "Ready to submit?" card with a (useless) Submit button; that
   // card is gone, so Save progress now shows inline during Phase 1 too.
+  // It is also hidden on Phase 2 knockout sub-steps — Continue / Back /
+  // sub-tab clicks already auto-save server-side there, so an explicit
+  // button would just duplicate the action.
+  const isPhase2KnockoutStep =
+    phase === 'phase2_open' && isKnockoutStage(currentStep);
   const showSaveProgressInline =
-    !showSavePhase1 && !showReviewSubmit && !lockedReadOnly;
+    !showSavePhase1 &&
+    !showReviewSubmit &&
+    !lockedReadOnly &&
+    !isPhase2KnockoutStep;
 
   return (
     <PageLayout>

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -730,17 +730,20 @@ export function PredictionsPageContent({
 
   const handleTopChange = (value: string) => {
     if (!TOP_STEPS.includes(value as TopStep)) return;
-    if (value === 'champion_pick') return goToStep('champion_pick');
-    if (value === 'groups') return goToStep('groups');
-    if (value === 'best_thirds') return goToStep('best_thirds');
-    if (value === 'tiebreaker') return goToStep('tiebreaker');
-    const target = KNOCKOUT_STAGE_LIST.find((s) => !stageCompletion[s]) ?? 'round_of_32';
-    goToStep(target);
+    navigateWithAutosave(() => {
+      if (value === 'champion_pick') return goToStep('champion_pick');
+      if (value === 'groups') return goToStep('groups');
+      if (value === 'best_thirds') return goToStep('best_thirds');
+      if (value === 'tiebreaker') return goToStep('tiebreaker');
+      const target =
+        KNOCKOUT_STAGE_LIST.find((s) => !stageCompletion[s]) ?? 'round_of_32';
+      goToStep(target);
+    });
   };
 
   const handleSubChange = (value: string) => {
     if (!KNOCKOUT_STAGE_LIST.includes(value as KnockoutStage)) return;
-    goToStep(value as Step);
+    navigateWithAutosave(() => goToStep(value as Step));
   };
 
   // After any step transition (top-tab, sub-tab, Continue button), scroll the
@@ -760,37 +763,38 @@ export function PredictionsPageContent({
 
   const goToNextStep = () => {
     const idx = STEP_ORDER.indexOf(currentStep);
-    if (idx >= 0 && idx < STEP_ORDER.length - 1) {
-      goToStep(STEP_ORDER[idx + 1]);
-    }
+    if (idx < 0 || idx >= STEP_ORDER.length - 1) return;
+    navigateWithAutosave(() => goToStep(STEP_ORDER[idx + 1]));
   };
 
   const goToPreviousStep = () => {
     const idx = STEP_ORDER.indexOf(currentStep);
-    if (idx > 0) {
-      goToStep(STEP_ORDER[idx - 1]);
-    }
+    if (idx <= 0) return;
+    navigateWithAutosave(() => goToStep(STEP_ORDER[idx - 1]));
   };
 
   const persist = async ({
     markSubmitted,
     redirectTo,
+    silent,
   }: {
     markSubmitted: boolean;
     /** Override navigation after a successful save-progress (not Submit). */
     redirectTo?: string;
-  }) => {
-    if (!tournament) return;
+    /** Suppress the "Progress saved" toast (e.g. nav-triggered autosaves). */
+    silent?: boolean;
+  }): Promise<boolean> => {
+    if (!tournament) return false;
     setPredictionNameTouched(true);
     if (nameError) {
       toast.error(nameError);
       nameRef.current?.focus();
       nameRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      return;
+      return false;
     }
     if (markSubmitted && !isPredictionsComplete) {
       toast.error('Please complete all predictions before submitting');
-      return;
+      return false;
     }
     // The submit_predictions RPC requires champion_team_id whenever Phase 1
     // writes are involved (create, or any Phase 1 edit). Guard before the
@@ -800,7 +804,7 @@ export function PredictionsPageContent({
     if (willSendPhase1 && !championTeamId) {
       toast.error('Pick a champion before saving');
       goToStep('champion_pick');
-      return;
+      return false;
     }
 
     if (markSubmitted) setIsSubmitting(true);
@@ -895,7 +899,9 @@ export function PredictionsPageContent({
             ]
           : []),
       ]);
-      toast.success(markSubmitted ? 'Prediction submitted' : 'Progress saved');
+      if (!silent) {
+        toast.success(markSubmitted ? 'Prediction submitted' : 'Progress saved');
+      }
 
       if (markSubmitted) {
         router.push(redirectAfterSave ?? ROUTES.predictions);
@@ -906,8 +912,10 @@ export function PredictionsPageContent({
         // saves update the same draft instead of creating new ones.
         router.replace(`${ROUTES.predictions}/${encodeURIComponent(newId)}`);
       }
+      return true;
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to save');
+      return false;
     } finally {
       setIsSubmitting(false);
       setIsSavingProgress(false);
@@ -918,6 +926,33 @@ export function PredictionsPageContent({
   const handleSavePhase1 = () =>
     persist({ markSubmitted: false, redirectTo: redirectAfterSave ?? ROUTES.predictions });
   const handleSaveProgress = () => persist({ markSubmitted: false });
+
+  // Should the wizard auto-save before this navigation? Phase 2 regular flow
+  // and admin edits get auto-save so picks aren't marooned in localStorage
+  // between sub-step transitions. Phase 1 regular flow keeps its explicit
+  // "Save Phase 1 Picks" button — we don't want to trigger creates on partial
+  // Phase 1 state.
+  const needsAutosaveOnNav = (): boolean => {
+    if (isLocked) return false;
+    if (isSavingProgress || isSubmitting) return false;
+    if (!usesAdminRoute && phase !== 'phase2_open') return false;
+    if (mode === 'create' && nameError) return false;
+    return true;
+  };
+
+  // Run the autosave + navigate-on-success flow. Stays sync (microtask-free)
+  // when no save is needed, so tests using fake timers don't have to advance
+  // microtasks for every Continue / Back click.
+  const navigateWithAutosave = (navigate: () => void) => {
+    if (!needsAutosaveOnNav()) {
+      navigate();
+      return;
+    }
+    void (async () => {
+      const ok = await persist({ markSubmitted: false, silent: true });
+      if (ok) navigate();
+    })();
+  };
 
   if (isLoading || !tournament || !groups || !teams || !matches) {
     return (
@@ -1140,7 +1175,7 @@ export function PredictionsPageContent({
             type="button"
             variant="ghost"
             onClick={goToPreviousStep}
-            disabled={isFirstStep}
+            disabled={isFirstStep || isSavingProgress || isSubmitting}
             className="sm:w-auto"
           >
             <ArrowLeft className="mr-2 h-4 w-4" />
@@ -1188,10 +1223,18 @@ export function PredictionsPageContent({
                 // In a locked read-only view we keep Continue enabled even if
                 // the step is "incomplete" — the user is just browsing their
                 // past picks and can't edit, so step-completion is moot.
-                disabled={!currentStepComplete && !(isLocked && !bypassLockNav)}
+                disabled={
+                  (!currentStepComplete && !(isLocked && !bypassLockNav)) ||
+                  isSavingProgress ||
+                  isSubmitting
+                }
                 className="sm:w-auto"
               >
-                {nextStepLabel ? `Continue to ${nextStepLabel}` : 'Continue'}
+                {isSavingProgress
+                  ? 'Saving…'
+                  : nextStepLabel
+                    ? `Continue to ${nextStepLabel}`
+                    : 'Continue'}
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Button>
             )}

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -643,4 +643,50 @@ describe('PredictionsPageContent — autosave', () => {
     await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
     expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull();
   });
+
+  it('Phase 2 Continue triggers a silent server save', async () => {
+    // The bug this guards against: in Phase 2 the wizard used to save picks
+    // only to localStorage on change, so a reload between rounds threw them
+    // away (because the prediction had submittedAt set from Phase 1, so the
+    // draft-restore guard skipped). Continue now PATCHes the server first.
+    configureQueries({ phase: 'phase2_open' });
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictionId: 'pred-1' }),
+    });
+
+    const initial = {
+      id: 'pred-1',
+      name: 'Main',
+      totalGoals: null,
+      championTeamId: 'arg',
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups: [],
+      knockout: [],
+      advancers: [],
+    };
+
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="edit" predictionId="pred-1" initial={initial} />);
+
+    // Wizard auto-jumps to R32 in phase2_open.
+    await screen.findByTestId('knockout-bracket');
+    await user.click(screen.getByTestId('fill-all-knockout'));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /Continue to Round of 16/ }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/predictions/pred-1');
+    expect(init.method).toBe('PATCH');
+    const body = JSON.parse(init.body);
+    expect(body.knockout.length).toBeGreaterThan(0);
+    expect(body.submit).toBe(false);
+    // Silent autosave: no "Progress saved" toast.
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -394,7 +394,7 @@ describe('PredictionsPageContent — stepper navigation', () => {
     // Filling all knockout matches at once satisfies every knockout sub-step.
     await user.click(screen.getByTestId('fill-all-knockout'));
 
-    const stages = ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Third Place', 'Final'];
+    const stages = ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final'];
     for (const next of stages) {
       const btn = await screen.findByRole('button', {
         name: new RegExp(`Continue to ${next}`, 'i'),
@@ -611,12 +611,12 @@ describe('PredictionsPageContent — autosave', () => {
     await user.click(screen.getByTestId('fill-champion'));
     await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
     await user.click(screen.getByTestId('fill-all-knockout'));
-    // Walk through R16 → QF → SF → 3rd → Final → Tiebreaker via Continue.
+    // Walk through R16 → QF → SF → Final → Tiebreaker via Continue.
+    // 3rd-place (M103) is no longer a wizard step (unscored under v4).
     for (const next of [
       'Round of 16',
       'Quarter-finals',
       'Semi-finals',
-      'Third Place',
       'Final',
       'Tiebreaker',
     ]) {

--- a/frontend/src/components/marketing/ScoringBreakdown.tsx
+++ b/frontend/src/components/marketing/ScoringBreakdown.tsx
@@ -23,19 +23,19 @@ export function ScoringBreakdown() {
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">Both top 2, exact order</span>
-                <span className="font-semibold">+6 points</span>
+                <span className="font-semibold">+12 points</span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">Both top 2, swapped</span>
-                <span className="font-semibold">+4 points</span>
+                <span className="font-semibold">+8 points</span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">One correct, in correct slot</span>
-                <span className="font-semibold">+3 points</span>
+                <span className="text-muted-foreground">Single team in its correct slot</span>
+                <span className="font-semibold">+5 points</span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">One correct, in wrong slot</span>
-                <span className="font-semibold">+2 points</span>
+                <span className="text-muted-foreground">Right team, wrong slot</span>
+                <span className="font-semibold">+0 points</span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">None correct</span>
@@ -44,8 +44,8 @@ export function ScoringBreakdown() {
               <div className="bg-muted/50 rounded-md p-3 text-sm">
                 <span className="font-semibold">Group of Death (Group I):</span>{' '}
                 <span className="text-muted-foreground">
-                  Both top 2 in exact order pays <span className="font-semibold">+8</span> instead
-                  of +6.
+                  Both top 2 in exact order pays <span className="font-semibold">+18</span>{' '}
+                  instead of +12.
                 </span>
               </div>
               <div className="border-t pt-3">
@@ -65,8 +65,8 @@ export function ScoringBreakdown() {
               Knockout Stage
             </CardTitle>
             <CardDescription>
-              Each round, every team that advances scores you points — more if you had them in
-              the right slot.
+              Each round, every match winner you pick correctly scores a flat value. Wrong picks
+              score 0 — no partial credit for the right team in the wrong slot.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -76,43 +76,36 @@ export function ScoringBreakdown() {
                   Round of 32{' '}
                   <span className="text-muted-foreground/70 text-xs">(per match winner)</span>
                 </span>
-                <span className="font-semibold whitespace-nowrap">+4 / +3 pts</span>
+                <span className="font-semibold whitespace-nowrap">+5 pts</span>
               </div>
               <div className="flex items-center justify-between gap-4">
                 <span className="text-muted-foreground">
                   Round of 16{' '}
                   <span className="text-muted-foreground/70 text-xs">(per match winner)</span>
                 </span>
-                <span className="font-semibold whitespace-nowrap">+6 / +4 pts</span>
+                <span className="font-semibold whitespace-nowrap">+8 pts</span>
               </div>
               <div className="flex items-center justify-between gap-4">
                 <span className="text-muted-foreground">
                   Quarter-finals{' '}
                   <span className="text-muted-foreground/70 text-xs">(per match winner)</span>
                 </span>
-                <span className="font-semibold whitespace-nowrap">+10 / +6 pts</span>
+                <span className="font-semibold whitespace-nowrap">+12 pts</span>
               </div>
               <div className="flex items-center justify-between gap-4">
                 <span className="text-muted-foreground">
                   Semi-finals{' '}
                   <span className="text-muted-foreground/70 text-xs">(per match winner)</span>
                 </span>
-                <span className="font-semibold whitespace-nowrap">+14 / +9 pts</span>
+                <span className="font-semibold whitespace-nowrap">+18 pts</span>
               </div>
               <div className="flex items-center justify-between gap-4">
-                <span className="text-muted-foreground">Third Place Match Winner</span>
-                <span className="font-semibold">+5 pts</span>
+                <span className="text-muted-foreground">Final / World Cup Champion</span>
+                <span className="font-semibold">+30 pts</span>
               </div>
               <div className="flex items-center justify-between gap-4">
-                <span className="text-muted-foreground">World Cup Champion</span>
-                <span className="font-semibold">+15 pts</span>
-              </div>
-              <div className="bg-muted/50 rounded-md p-3 text-xs">
-                <span className="font-semibold">Correct slot vs. wrong slot:</span>{' '}
-                <span className="text-muted-foreground">
-                  Correct slot = you picked the winner of that exact match. Wrong slot = the
-                  team won, but you had them in a different match in the same round.
-                </span>
+                <span className="text-muted-foreground">Third Place Match</span>
+                <span className="font-semibold">not scored</span>
               </div>
               <div className="border-t pt-3">
                 <div className="flex items-center justify-between font-semibold">
@@ -142,17 +135,17 @@ export function ScoringBreakdown() {
               <span className="text-muted-foreground">
                 Team in the actual top 8 (any rank)
               </span>
-              <span className="font-semibold">+1 pt</span>
+              <span className="font-semibold">+2 pts</span>
             </div>
             <div className="flex items-center justify-between">
               <span className="text-muted-foreground">Team at the exact correct rank</span>
-              <span className="font-semibold">+0.25 pts</span>
+              <span className="font-semibold">+0.5 pts</span>
             </div>
             <div className="bg-muted/50 rounded-md p-3 text-xs">
               <span className="font-semibold">Bonuses stack:</span>{' '}
               <span className="text-muted-foreground">
                 a team in the correct rank earns the full <span className="font-semibold">
-                  +1.25
+                  +2.5
                 </span>{' '}
                 (set + rank).
               </span>
@@ -197,8 +190,8 @@ export function ScoringBreakdown() {
               <span className="font-semibold">Independent of your bracket.</span>{' '}
               <span className="text-muted-foreground">
                 This is a separate gut-feeling call from your bracket Final pick. If both end up
-                right, you get the full <span className="font-semibold">+15</span> bracket champion
-                bonus <span className="italic">and</span> the{' '}
+                right, you get the full <span className="font-semibold">+30</span> bracket Final
+                value <span className="italic">and</span> the{' '}
                 <span className="font-semibold">+{SCORING.championPickBonus}</span> gut bonus.
               </span>
             </div>

--- a/frontend/src/components/predictions/AdvancersForm.tsx
+++ b/frontend/src/components/predictions/AdvancersForm.tsx
@@ -79,8 +79,8 @@ export function AdvancersForm({
                 first.
               </p>
               <p>
-                <strong>Per pick:</strong> +1 if your team is in the actual top 8;
-                additional +0.25 if it&apos;s at the exact rank. Max <strong>+10 points</strong>{' '}
+                <strong>Per pick:</strong> +2 if your team is in the actual top 8;
+                additional +0.5 if it&apos;s at the exact rank. Max <strong>+20 points</strong>{' '}
                 across all 8 ranks.
               </p>
             </>

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -226,16 +226,16 @@ export function GroupStageForm({
             </p>
             <p>
               <strong>Scoring uses only the top two finishers.</strong> 3rd and 4th picks
-              aren&apos;t scored, but your 3rd-place picks for groups A–H seed your Round of 32
-              bracket.
+              aren&apos;t scored as part of the group total; your 3rd-place picks feed the
+              separate Best 3rds step.
             </p>
             <p>
-              <strong>Per group:</strong> +6 for both top-two correct in exact order · +4 if both
-              correct but swapped · +3 for one correct in the right slot · +2 for one correct in
-              the wrong slot · 0 otherwise.
+              <strong>Per group:</strong> +12 for both top-two correct in exact order · +8 if
+              both correct but swapped · +5 per correct team in its correct slot · 0 otherwise.
+              Right team in the wrong slot does not score.
             </p>
             <p>
-              <strong>Group I (&ldquo;Group of Death&rdquo;)</strong> pays a +8 bonus instead of +6
+              <strong>Group I (&ldquo;Group of Death&rdquo;)</strong> pays +18 instead of +12
               when both top-two finishers are predicted in exact order.
             </p>
           </div>

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -67,13 +67,13 @@ export const STAGE_CONFIG: Record<
 };
 
 // Stage order. Used by the parent stepper; the bracket itself now renders one
-// stage at a time controlled by the `stage` prop.
+// stage at a time controlled by the `stage` prop. 'third_place' (M103) is
+// omitted — the match is no longer scored in v4 so the wizard skips it.
 export const STAGE_ORDER: KnockoutStage[] = [
   'round_of_32',
   'round_of_16',
   'quarter_finals',
   'semi_finals',
-  'third_place',
   'final',
 ];
 

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -12,6 +12,7 @@ import { formatSource, formatSourcePair } from '@/lib/matchLabel';
 import { cn } from '@/lib/utils';
 import type {
   GroupPrediction,
+  GroupStanding,
   KnockoutMatch,
   KnockoutMatchPrediction,
   KnockoutStage,
@@ -20,10 +21,9 @@ import type {
 } from '@/types/tournament';
 
 // Stage display configuration. `pointsHint` is the per-match badge label.
-// Each round's picks score on a correct-slot / wrong-slot tier: you get the
-// higher value if you picked the actual winner of that match, the lower value
-// if you picked the winning team to advance from some other match in the same
-// round. The Final's only payout is the +15 champion bonus.
+// Knockout v4: flat per-correct-winner scoring, no wrong-slot bonus. The
+// Final pays out +30 for picking the right champion; the third-place match
+// is no longer scored.
 export const STAGE_CONFIG: Record<
   KnockoutStage,
   { label: string; shortLabel: string; pointsHint: string; subtitle: string }
@@ -31,38 +31,38 @@ export const STAGE_CONFIG: Record<
   round_of_32: {
     label: 'Round of 32',
     shortLabel: 'R32',
-    pointsHint: '+4 / +3',
-    subtitle: '+4 if you picked the match winner correctly, +3 if right team but wrong slot.',
+    pointsHint: '+5',
+    subtitle: '+5 if you pick the match winner correctly.',
   },
   round_of_16: {
     label: 'Round of 16',
     shortLabel: 'R16',
-    pointsHint: '+6 / +4',
-    subtitle: '+6 if you picked the match winner correctly, +4 if right team but wrong slot.',
+    pointsHint: '+8',
+    subtitle: '+8 if you pick the match winner correctly.',
   },
   quarter_finals: {
     label: 'Quarter-finals',
     shortLabel: 'QF',
-    pointsHint: '+10 / +6',
-    subtitle: '+10 if you picked the match winner correctly, +6 if right team but wrong slot.',
+    pointsHint: '+12',
+    subtitle: '+12 if you pick the match winner correctly.',
   },
   semi_finals: {
     label: 'Semi-finals',
     shortLabel: 'SF',
-    pointsHint: '+14 / +9',
-    subtitle: '+14 if you picked the match winner correctly, +9 if right team but wrong slot.',
+    pointsHint: '+18',
+    subtitle: '+18 if you pick the match winner correctly.',
   },
   third_place: {
     label: 'Third Place',
     shortLabel: '3rd',
-    pointsHint: '+5',
-    subtitle: '+5 for predicting the third-place match winner correctly.',
+    pointsHint: 'not scored',
+    subtitle: 'Third-place match is not scored — pick a winner for completeness.',
   },
   final: {
     label: 'Final',
     shortLabel: 'Final',
-    pointsHint: '+15 champion',
-    subtitle: '+15 for picking the World Cup champion correctly.',
+    pointsHint: '+30 champion',
+    subtitle: '+30 for picking the World Cup champion correctly.',
   },
 };
 
@@ -83,6 +83,7 @@ interface KnockoutBracketProps {
   groupPredictions: GroupPrediction[];
   knockoutPredictions: KnockoutMatchPrediction[];
   bracketAssignments?: R32BracketAssignment[];
+  groupStandings?: GroupStanding[];
   onPredictionChange: (matchId: string, winnerId: string | null) => void;
   disabled?: boolean;
   stage: KnockoutStage;
@@ -102,11 +103,11 @@ function getTeamDisplay(
 }
 
 // Friendly placeholder for an unresolved team source. 3rd-place slots
-// (legacy "3-XXXXX" strings) read as "3rd-place team (TBD)" since FIFA
-// decides bracket placement after group stage; group/match sources fall
-// back to the raw source string.
+// (legacy "3-XXXXX" strings) read as "3rd-place team (TBD)" until the admin
+// publishes the bracket assignment; group/match sources fall back to the raw
+// source string.
 function describeSource(source: string): string {
-  if (/^3-[A-L]{5}$/.test(source)) return '3rd-place team (TBD)';
+  if (/^3-[A-L]+$/.test(source)) return '3rd-place team (TBD)';
   return formatSource(source);
 }
 
@@ -221,6 +222,7 @@ function StageSection({
   groupPredictions,
   knockoutPredictions,
   bracketAssignments,
+  groupStandings,
   onPredictionChange,
   disabled,
 }: {
@@ -231,6 +233,7 @@ function StageSection({
   groupPredictions: GroupPrediction[];
   knockoutPredictions: KnockoutMatchPrediction[];
   bracketAssignments: R32BracketAssignment[];
+  groupStandings: GroupStanding[];
   onPredictionChange: (matchId: string, winnerId: string | null) => void;
   disabled?: boolean;
 }) {
@@ -284,14 +287,16 @@ function StageSection({
             allMatches,
             groupPredictions,
             knockoutPredictions,
-            bracketAssignments
+            bracketAssignments,
+            groupStandings
           );
           const team2Id = resolveTeamSource(
             match.team2Source,
             allMatches,
             groupPredictions,
             knockoutPredictions,
-            bracketAssignments
+            bracketAssignments,
+            groupStandings
           );
           const prediction = knockoutPredictions.find((p) => p.matchId === match.id);
           const selectedWinnerId = prediction?.winnerId ?? null;
@@ -320,6 +325,7 @@ export function KnockoutBracket({
   groupPredictions,
   knockoutPredictions,
   bracketAssignments = [],
+  groupStandings = [],
   onPredictionChange,
   disabled = false,
   stage,
@@ -356,36 +362,33 @@ export function KnockoutBracket({
         <div className="text-muted-foreground mt-3 space-y-2 text-sm">
           <p>
             Click a team to pick the winner of each match. Winners automatically advance to the next
-            round. Complete your group predictions first to see teams in Round of 32.
+            round.
           </p>
           <p>
-            Each round&apos;s picks score on a <strong>correct-slot / wrong-slot</strong> tier:
-            the higher value if you picked the actual winner of that match, the lower value if you
-            picked the winning team to advance from some other match in the same round, otherwise 0.
+            Each correct match winner scores the round&apos;s flat value. Wrong picks score 0 —
+            there&apos;s no partial credit for picking the right team in the wrong slot.
           </p>
           <p>
-            <strong>Per match winner:</strong> R32 +4/+3 · R16 +6/+4 · QF +10/+6 · SF +14/+9
+            <strong>Per match winner:</strong> R32 +5 · R16 +8 · QF +12 · SF +18
           </p>
           <p>
-            <strong>Bonuses:</strong> +15 for the World Cup champion · +5 for the third-place
-            match winner.
+            <strong>Final:</strong> +30 for picking the World Cup champion. The third-place match
+            is not scored.
           </p>
         </div>
       </details>
 
       {/* Persistent scoring summary. */}
       <div className="text-muted-foreground bg-muted/20 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border px-3 py-2 font-mono text-xs">
-        <span>R32 +4/+3</span>
+        <span>R32 +5</span>
         <span>·</span>
-        <span>R16 +6/+4</span>
+        <span>R16 +8</span>
         <span>·</span>
-        <span>QF +10/+6</span>
+        <span>QF +12</span>
         <span>·</span>
-        <span>SF +14/+9</span>
+        <span>SF +18</span>
         <span>·</span>
-        <span>Champion +15</span>
-        <span>·</span>
-        <span>3rd-place +5</span>
+        <span>Final +30</span>
       </div>
 
       <StageSection
@@ -396,6 +399,7 @@ export function KnockoutBracket({
         groupPredictions={groupPredictions}
         knockoutPredictions={knockoutPredictions}
         bracketAssignments={bracketAssignments}
+        groupStandings={groupStandings}
         onPredictionChange={onPredictionChange}
         disabled={disabled}
       />

--- a/frontend/src/components/predictions/__tests__/KnockoutBracket.test.tsx
+++ b/frontend/src/components/predictions/__tests__/KnockoutBracket.test.tsx
@@ -71,13 +71,22 @@ describe('KnockoutBracket', () => {
     it('shows the stage subtitle for the active stage', () => {
       renderBracket();
       expect(
-        screen.getByText(/\+4 if you picked the match winner correctly/i)
+        screen.getByText(/\+5 if you pick the match winner correctly/i)
       ).toBeInTheDocument();
     });
 
     it('should show helper text', () => {
       renderBracket();
       expect(screen.getByText(/Click a team to pick the winner/i)).toBeInTheDocument();
+    });
+
+    it('renders v4 flat per-round badges in the persistent summary', () => {
+      renderBracket();
+      expect(screen.getByText('R32 +5')).toBeInTheDocument();
+      expect(screen.getByText('R16 +8')).toBeInTheDocument();
+      expect(screen.getByText('QF +12')).toBeInTheDocument();
+      expect(screen.getByText('SF +18')).toBeInTheDocument();
+      expect(screen.getByText('Final +30')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/lib/__tests__/knockoutResolver.test.ts
+++ b/frontend/src/lib/__tests__/knockoutResolver.test.ts
@@ -1,6 +1,7 @@
 import { resolveTeamSource } from '../knockoutResolver';
 import type {
   GroupPrediction,
+  GroupStanding,
   KnockoutMatch,
   KnockoutMatchPrediction,
   R32BracketAssignment,
@@ -158,6 +159,62 @@ describe('resolveTeamSource', () => {
       expect(resolveTeamSource('1A', matches, groupPredictions, [], [])).toBe('mex');
       expect(resolveTeamSource('2B', matches, groupPredictions, [], [])).toBe('qat');
       expect(resolveTeamSource('3A', matches, groupPredictions, [], [])).toBe('rsa');
+    });
+  });
+
+  describe('Phase 2 path: groupStandings overrides groupPredictions', () => {
+    // Once the admin enters real group standings, the resolver should use those
+    // for "1A" / "2A" / "3A" sources — not the user's Phase 1 guesses. This is
+    // the bracket-decoupling change in scoring v4 (migration 0052).
+    const adminStandings: GroupStanding[] = [
+      {
+        groupId: 'A',
+        firstTeamId: 'rsa', // user predicted mex, actual rsa
+        secondTeamId: 'cze',
+        thirdTeamId: 'kor',
+        fourthTeamId: 'mex',
+      },
+      {
+        groupId: 'B',
+        firstTeamId: 'can',
+        secondTeamId: 'bih',
+        thirdTeamId: 'sui',
+        fourthTeamId: 'qat',
+      },
+    ];
+
+    it('uses admin standings when present (Phase 2)', () => {
+      expect(
+        resolveTeamSource('1A', matches, groupPredictions, [], [], adminStandings)
+      ).toBe('rsa');
+      expect(
+        resolveTeamSource('2A', matches, groupPredictions, [], [], adminStandings)
+      ).toBe('cze');
+      expect(
+        resolveTeamSource('3B', matches, groupPredictions, [], [], adminStandings)
+      ).toBe('sui');
+    });
+
+    it('falls back to user picks when no standings for that group', () => {
+      // Standings only cover A + B; group C source falls back to user predictions
+      // (or null if user has none).
+      expect(
+        resolveTeamSource('1C', matches, groupPredictions, [], [], adminStandings)
+      ).toBeNull();
+    });
+
+    it('still respects admin-bracket override after standings lookup', () => {
+      // Admin standings put rsa as 1A. If admin then placed rsa in a 3-XXXXX
+      // bracket slot too, the 1A slot must collapse to TBD to avoid dupes.
+      const assignments: R32BracketAssignment[] = [
+        { matchId: 'M74', slot: 2, teamId: 'rsa' },
+      ];
+      expect(
+        resolveTeamSource('1A', matches, groupPredictions, [], assignments, adminStandings)
+      ).toBeNull();
+      expect(
+        resolveTeamSource('3-ABCDF', matches, groupPredictions, [], assignments, adminStandings)
+      ).toBe('rsa');
     });
   });
 });

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -41,11 +41,15 @@ const KNOWN_ERROR_FRAGMENTS = [
   'advancer rank set must be',
   'not a 3rd-place team',
   'team is already assigned to',
-  // R32 bracket assignment (migration 0026)
+  // R32 bracket assignment (migrations 0026 + 0052)
   'is not in the top-8 advancers',
+  'is not a 3rd-place finisher in any of the groups',
   'is not a 3rd-place slot',
   'unknown r32 match',
+  'malformed 3rd-place source',
   'all r32 3rd-place bracket slots',
+  // Phase 2 gate (migration 0052)
+  'all 12 group standings must be entered',
   // Referrals (migration 0035)
   'no referral credits available',
   'not your prediction',

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -9,18 +9,20 @@ export const TOURNAMENT_CONFIG = {
   totalMatches: 104,
 } as const;
 
-// Group stage: 11 standard groups × 6 (exact-order top-2) + Group I "Group of Death" exact-order = 8.
-// Advancers: 8 ranked 3rd-place picks × 1.25 (set + rank) = 10 max.
-// Knockout: per-team correct-side maxes — R16 16×5 + QF 8×6 + SF 4×8 + Final 2×10 = 180 — plus
-// flat bonuses (champion 15, 3rd-place winner 5) = 200.
+// Scoring v4 (migration 0051):
+// Group stage: 11 standard groups × 12 (exact-order top-2) + Group I "Group of Death" exact-order
+//   = 132 + 18 = 150. Reversed = 8, single correct in slot = 5, wrong slot = 0.
+// Advancers: 8 ranked 3rd-place picks × 2.5 (set + rank) = 20 max.
+// Knockout (flat, no wrong-slot bonus): R32 16×5 + R16 8×8 + QF 4×12 + SF 2×18 + Final 1×30
+//   = 80 + 64 + 48 + 36 + 30 = 258. Third-place match (M103) not scored.
 // Phase 1 Champions Pick: +5 if `predictions.champion_team_id` matches the actual M104 winner
 // (independent of the bracket Final pick).
 export const SCORING = {
-  maxGroupPoints: 74,
-  maxAdvancerPoints: 10,
-  maxKnockoutPoints: 200,
+  maxGroupPoints: 150,
+  maxAdvancerPoints: 20,
+  maxKnockoutPoints: 258,
   championPickBonus: 5,
-  maxTotalPoints: 289,
+  maxTotalPoints: 433,
 } as const;
 
 /**

--- a/frontend/src/lib/knockoutResolver.ts
+++ b/frontend/src/lib/knockoutResolver.ts
@@ -1,5 +1,6 @@
 import type {
   GroupPrediction,
+  GroupStanding,
   KnockoutMatch,
   KnockoutMatchPrediction,
   R32BracketAssignment,
@@ -7,53 +8,78 @@ import type {
 
 /**
  * Resolves a `team1_source` / `team2_source` reference (e.g. `"1A"`, `"M77"`,
- * `"L-M101"`, `"3-ABCDF"`) to the predicted team id, given the user's group +
- * knockout picks and the admin-set R32 bracket assignments. Returns null
- * when the picks (or admin assignment) for the source aren't filled in yet.
+ * `"L-M101"`, `"3-ABCDF"`) to the predicted team id.
+ *
+ * Group-position sources resolve from `groupStandings` (admin's actual top-4)
+ * when present — this is the Phase 2 path, where the bracket reflects what
+ * really happened, not what the user predicted in Phase 1. When standings are
+ * absent (Phase 1 preview), the resolver falls back to the user's own
+ * `groupPredictions` so the bracket still renders something meaningful while
+ * the group stage is unfinished.
+ *
+ * Returns null when the source can't yet be resolved.
  */
 export function resolveTeamSource(
   source: string,
   matches: KnockoutMatch[],
   groupPredictions: GroupPrediction[],
   knockoutPredictions: KnockoutMatchPrediction[],
-  bracketAssignments: R32BracketAssignment[] = []
+  bracketAssignments: R32BracketAssignment[] = [],
+  groupStandings: GroupStanding[] = []
 ): string | null {
   // Group position source: '1A' = 1st in Group A, '2B' = 2nd in Group B, etc.
   const groupMatch = source.match(/^([123])([A-L])$/);
   if (groupMatch) {
     const [, position, groupId] = groupMatch;
-    const groupPrediction = groupPredictions.find((p) => p.groupId === groupId);
-    if (!groupPrediction) return null;
-    let resolved: string | null;
-    switch (position) {
-      case '1':
-        resolved = groupPrediction.positions.first;
-        break;
-      case '2':
-        resolved = groupPrediction.positions.second;
-        break;
-      case '3':
-        resolved = groupPrediction.positions.third;
-        break;
-      default:
-        return null;
+    const standing = groupStandings.find((s) => s.groupId === groupId);
+    let resolved: string | null = null;
+    if (standing) {
+      // Phase 2 path: prefer admin-entered standings as the source of truth.
+      switch (position) {
+        case '1':
+          resolved = standing.firstTeamId;
+          break;
+        case '2':
+          resolved = standing.secondTeamId;
+          break;
+        case '3':
+          resolved = standing.thirdTeamId;
+          break;
+        default:
+          return null;
+      }
+    } else {
+      // Phase 1 preview path: fall back to the user's group prediction.
+      const groupPrediction = groupPredictions.find((p) => p.groupId === groupId);
+      if (!groupPrediction) return null;
+      switch (position) {
+        case '1':
+          resolved = groupPrediction.positions.first;
+          break;
+        case '2':
+          resolved = groupPrediction.positions.second;
+          break;
+        case '3':
+          resolved = groupPrediction.positions.third;
+          break;
+        default:
+          return null;
+      }
     }
-    // Admin's bracket assignments are tournament truth. If the user-predicted
-    // team for this slot is already placed by the admin in a 3-XXXXX R32 slot,
-    // that team really finished 3rd in its group and cannot also be its actual
-    // 1st/2nd. Suppress here so the team renders once (in the admin slot) and
-    // this slot shows as TBD instead of duplicating.
+    // Admin's bracket assignments are tournament truth. If the team resolved
+    // for this slot is already placed by the admin in a 3-XXXXX R32 slot,
+    // suppress here so the team renders once (in the admin slot) and this
+    // slot shows as TBD instead of duplicating.
     if (resolved && bracketAssignments.some((a) => a.teamId === resolved)) {
       return null;
     }
     return resolved;
   }
 
-  // Best-3rd-of-bundle source: '3-ABCDF' etc. In the new model these strings
-  // are decorative — FIFA decides which advancer fills each slot. The admin
-  // records the assignment in r32_bracket_assignments and we look it up by
-  // the (matchId, slot) tuple that owns this source string.
-  if (/^3-[A-L]{5}$/.test(source)) {
+  // Best-3rd-of-bundle source: '3-ABCDF' etc. The admin records each slot's
+  // actual advancer in r32_bracket_assignments — look it up by the
+  // (matchId, slot) tuple that owns this source string.
+  if (/^3-[A-L]+$/.test(source)) {
     const match = matches.find(
       (m) => m.team1Source === source || m.team2Source === source
     );
@@ -85,14 +111,16 @@ export function resolveTeamSource(
       matches,
       groupPredictions,
       knockoutPredictions,
-      bracketAssignments
+      bracketAssignments,
+      groupStandings
     );
     const team2Id = resolveTeamSource(
       match.team2Source,
       matches,
       groupPredictions,
       knockoutPredictions,
-      bracketAssignments
+      bracketAssignments,
+      groupStandings
     );
 
     if (matchPrediction.winnerId === team1Id) return team2Id;

--- a/frontend/src/types/tournament.ts
+++ b/frontend/src/types/tournament.ts
@@ -67,6 +67,14 @@ export interface R32BracketAssignment {
   teamId: string;
 }
 
+export interface GroupStanding {
+  groupId: string;
+  firstTeamId: string | null;
+  secondTeamId: string | null;
+  thirdTeamId: string | null;
+  fourthTeamId: string | null;
+}
+
 export interface Predictions {
   groups: GroupPrediction[];
   knockout: KnockoutMatchPrediction[];

--- a/supabase/migrations/0051_scoring_v4.sql
+++ b/supabase/migrations/0051_scoring_v4.sql
@@ -1,0 +1,445 @@
+-- 0051_scoring_v4.sql
+--
+-- Scoring v4 — full rebalance across Phase 1 and Phase 2.
+--
+-- Phase 1 group stage: per group, exact pair = 12 (18 for Group I), reversed
+-- pair = 8, otherwise +5 per pick that landed in its correct slot. Wrong-slot
+-- "right team" no longer scores. Max group total = 11×12 + 18 = 150.
+--
+-- Phase 1 advancers (top-8 best 3rds): each advancer pick in the actual top 8
+-- scores 2, with a +0.5 bonus when its predicted rank also matches the actual
+-- rank. Max = 8 × 2.5 = 20.
+--
+-- Phase 1 gut-feeling champion pick: unchanged at +5.
+--
+-- Phase 2 knockout (flat, no wrong-slot bonus):
+--   R32  +5    R16  +8    QF +12    SF +18    Final (M104) +30    M103 0
+-- The Final's +30 fully absorbs the legacy "+15 round + +15 champion bonus"
+-- shape — there is no separate champion-bonus column anymore.
+-- Max knockout = 80 + 64 + 48 + 36 + 30 = 258.
+--
+-- Grand total max = 150 (groups) + 20 (advancers) + 5 (champion pick) + 258
+-- (knockout) = 433.
+--
+-- Implementation note: knockout_round_scores (0006) takes correct_pts and
+-- wrong_pts. Passing wrong_pts = 0 collapses the helper's case-when to the
+-- correct-only path, so no signature change is needed.
+
+-- ========== scoring config ==========
+
+create or replace function public.knockout_round_config()
+returns table(stage text, correct_pts int, wrong_pts int)
+language sql
+immutable
+parallel safe
+set search_path = public
+as $$
+    values
+        ('round_of_32',     5, 0),
+        ('round_of_16',     8, 0),
+        ('quarter_finals', 12, 0),
+        ('semi_finals',    18, 0)
+$$;
+
+create or replace function public.scoring_third_place_pts()
+returns int
+language sql
+immutable
+parallel safe
+set search_path = public
+as $$ select 0 $$;
+
+create or replace function public.scoring_champion_pts()
+returns int
+language sql
+immutable
+parallel safe
+set search_path = public
+as $$ select 30 $$;
+
+-- scoring_champion_pick_pts() is unchanged at 5; re-emitting for clarity.
+create or replace function public.scoring_champion_pick_pts()
+returns int
+language sql
+immutable
+parallel safe
+set search_path = public
+as $$ select 5 $$;
+
+grant execute on function public.knockout_round_config() to anon, authenticated;
+grant execute on function public.scoring_third_place_pts() to anon, authenticated;
+grant execute on function public.scoring_champion_pts() to anon, authenticated;
+grant execute on function public.scoring_champion_pick_pts() to anon, authenticated;
+
+-- ========== get_leaderboard (v4) ==========
+-- Same signature + return columns as 0048. New group_scores (12/18/8/5/0) and
+-- advancer_scores (2.5/2/0) CTEs; everything else is verbatim from 0048.
+
+create or replace function public.get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    champion_pick_points int,
+    total_goals int,
+    total_count bigint
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 18 else 12 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 8
+                    else
+                        (case when gp.first_team_id = gs.first_team_id then 5 else 0 end)
+                      + (case when gp.second_team_id = gs.second_team_id then 5 else 0 end)
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 2.5
+                    when ta_team.team_id is not null then 2.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    knockout_round_totals as (
+        select s.prediction_id, coalesce(sum(s.round_points), 0)::int as round_points
+        from public.knockout_round_config() c
+        cross join lateral public.knockout_round_scores(
+            p_tournament_id, c.stage, c.correct_pts, c.wrong_pts
+        ) s
+        group by s.prediction_id
+    ),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_champion_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M104'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_third_place_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M103'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M103'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id
+                    then public.scoring_champion_pick_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(krt.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join knockout_round_totals krt on krt.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            pr.username::text as username,
+            coalesce(gsc.group_points, 0) as group_points,
+            coalesce(asc_.advancer_points, 0)::numeric as advancer_points,
+            coalesce(ksc.knockout_points, 0) as knockout_points,
+            coalesce(ksc.champion_pick_points, 0) as champion_pick_points,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            p.total_goals,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        join public.profiles pr on pr.id = p.user_id
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        rank,
+        prediction_id,
+        prediction_name,
+        username,
+        points,
+        group_points,
+        advancer_points,
+        knockout_points,
+        champion_pick_points,
+        total_goals,
+        count(*) over () as total_count
+    from ranked
+    order by rank
+    offset greatest(p_page - 1, 0) * greatest(p_page_size, 1)
+    limit greatest(p_page_size, 1);
+$$;
+
+grant execute on function public.get_leaderboard(uuid, int, int) to anon, authenticated;
+
+-- ========== get_leaderboard_rank (v4) ==========
+
+create or replace function public.get_leaderboard_rank(
+    p_tournament_id uuid,
+    p_user_id uuid,
+    p_page_size int default 25
+)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    rank int,
+    page int,
+    points numeric
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 18 else 12 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 8
+                    else
+                        (case when gp.first_team_id = gs.first_team_id then 5 else 0 end)
+                      + (case when gp.second_team_id = gs.second_team_id then 5 else 0 end)
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 2.5
+                    when ta_team.team_id is not null then 2.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    knockout_round_totals as (
+        select s.prediction_id, coalesce(sum(s.round_points), 0)::int as round_points
+        from public.knockout_round_config() c
+        cross join lateral public.knockout_round_scores(
+            p_tournament_id, c.stage, c.correct_pts, c.wrong_pts
+        ) s
+        group by s.prediction_id
+    ),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_champion_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M104'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_third_place_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M103'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M103'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id
+                    then public.scoring_champion_pick_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(krt.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join knockout_round_totals krt on krt.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            p.user_id,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        prediction_id,
+        prediction_name,
+        rank,
+        ((rank - 1) / greatest(p_page_size, 1) + 1)::int as page,
+        points
+    from ranked
+    where user_id = p_user_id
+    order by rank;
+$$;
+
+grant execute on function public.get_leaderboard_rank(uuid, uuid, int) to anon, authenticated;

--- a/supabase/migrations/0052_decouple_r32_bracket.sql
+++ b/supabase/migrations/0052_decouple_r32_bracket.sql
@@ -1,0 +1,142 @@
+-- 0052_decouple_r32_bracket.sql
+--
+-- Decouple Phase 2 R32 seeding from Phase 1 third-place picks / advancer
+-- ranking. Going forward, each 3rd-place R32 slot accepts only the actual
+-- third-place finisher from one of the groups encoded in its source string
+-- (e.g. M74's "3-ABCDF" slot accepts only the third placer of group A, B,
+-- C, D, or F per public.group_standings).
+--
+-- The unique (tournament_id, team_id) constraint on r32_bracket_assignments
+-- continues to block the same team being placed in two slots.
+--
+-- Also relaxes admin_set_phase_two: no longer requires tournament_advancers
+-- to be filled. Phase 2 can open as soon as group_standings is complete and
+-- all 3rd-place R32 slots are assigned. tournament_advancers still drives
+-- Phase 1 advancer scoring whenever it is filled — but it is no longer a
+-- gate for opening Phase 2.
+
+-- ========== admin_set_r32_bracket ==========
+
+create or replace function public.admin_set_r32_bracket(
+    p_tournament_id uuid,
+    p_match_id text,
+    p_slot smallint,
+    p_team_id text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_source text;
+    v_letters text;
+    v_groups text[];
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_slot not in (1, 2) then
+        raise exception 'invalid slot %', p_slot using errcode = 'P0001';
+    end if;
+
+    select case when p_slot = 1 then team1_source else team2_source end
+      into v_source
+      from public.knockout_matches
+     where id = p_match_id;
+
+    if v_source is null then
+        raise exception 'unknown R32 match %', p_match_id using errcode = 'P0001';
+    end if;
+    if v_source not like '3-%' then
+        raise exception 'R32 slot (%, %) is not a 3rd-place slot', p_match_id, p_slot
+            using errcode = 'P0001';
+    end if;
+
+    -- Source format is `3-XXXXX` where XXXXX is 4-6 single-letter group ids.
+    v_letters := substring(v_source from 3);
+    if v_letters !~ '^[A-L]+$' then
+        raise exception 'malformed 3rd-place source %', v_source using errcode = 'P0001';
+    end if;
+    v_groups := regexp_split_to_array(v_letters, '');
+
+    if not exists (
+        select 1
+        from public.group_standings gs
+        where gs.tournament_id = p_tournament_id
+          and gs.group_id = any(v_groups)
+          and gs.third_team_id = p_team_id
+    ) then
+        raise exception 'team % is not a 3rd-place finisher in any of the groups %',
+            p_team_id, v_groups
+            using errcode = 'P0001';
+    end if;
+
+    insert into public.r32_bracket_assignments (tournament_id, match_id, slot, team_id)
+    values (p_tournament_id, p_match_id, p_slot, p_team_id)
+    on conflict (tournament_id, match_id, slot)
+    do update set team_id = excluded.team_id;
+end;
+$$;
+
+grant execute on function public.admin_set_r32_bracket(uuid, text, smallint, text) to authenticated;
+
+-- ========== admin_set_phase_two ==========
+-- Replaces 0026's gate. Phase 2 may open once:
+--   * all 12 groups have a group_standings row, AND
+--   * every R32 3rd-place slot has an r32_bracket_assignments row.
+-- tournament_advancers is no longer a precondition.
+
+create or replace function public.admin_set_phase_two(
+    p_tournament_id uuid,
+    p_unlocked boolean,
+    p_lock_time timestamptz default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_standings_count int;
+    v_slot_count int;
+    v_assignment_count int;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    if p_unlocked then
+        select count(*) into v_standings_count
+          from public.group_standings
+         where tournament_id = p_tournament_id;
+        if v_standings_count <> 12 then
+            raise exception 'all 12 group standings must be entered before opening phase 2 (% of 12)',
+                v_standings_count
+                using errcode = 'P0001';
+        end if;
+
+        select count(*) into v_slot_count
+          from public.knockout_matches m
+          cross join lateral (values (1::smallint, m.team1_source), (2::smallint, m.team2_source)) as src(slot, source)
+         where src.source like '3-%' and m.stage = 'round_of_32';
+
+        select count(*) into v_assignment_count
+          from public.r32_bracket_assignments
+         where tournament_id = p_tournament_id;
+
+        if v_assignment_count <> v_slot_count then
+            raise exception 'all R32 3rd-place bracket slots must be assigned before opening phase 2 (% of % assigned)',
+                v_assignment_count, v_slot_count
+                using errcode = 'P0001';
+        end if;
+    end if;
+
+    update public.tournaments
+       set knockout_unlocked = p_unlocked,
+           knockout_lock_time = case when p_unlocked then p_lock_time else knockout_lock_time end
+     where id = p_tournament_id;
+end;
+$$;
+
+grant execute on function public.admin_set_phase_two(uuid, boolean, timestamptz) to authenticated;


### PR DESCRIPTION
## Summary

- **Phase 1 + Phase 2 scoring rebalanced (migration 0051).** Group stage now scores 12/18/8/5/0 (exact / Group-of-Death exact / reversed / single-slot / miss; wrong-slot no longer scores). Advancers move to 2.5/2/0. Knockout flattens to per-correct-winner R32 +5 / R16 +8 / QF +12 / SF +18 / Final +30 with no wrong-slot bonus and no separate champion bonus. Third-place match (M103) is no longer scored. Grand-total max moves from 289 → 433.
- **R32 bracket decoupled from Phase 1 third-place picks (migration 0052).** Each "3-XXXXX" R32 slot now accepts only the actual third-place finisher of one of the groups encoded in its source string (read from \`group_standings\`), instead of any team in the global top-8 advancer ranking. \`admin_set_phase_two\` now gates on 12 group standings + 8 bracket assignments — \`tournament_advancers\` is no longer a precondition (it still drives Phase 1 scoring whenever it is filled).
- **Admin R32 form rebuilt.** Renders all 16 R32 matches; non-3rd-place slots prefill from \`group_standings\` (read-only); 3rd-place slots are per-slot dropdowns scoped to the relevant groups' third placers.
- **Resolver + UI updated.** \`resolveTeamSource\` takes an optional \`groupStandings\` array so Phase 2 reflects admin-entered standings, not the user's Phase 1 guesses. \`KnockoutBracket\` consumes the new prop, refreshes its scoring badges, and removes the wrong-slot copy. Public \`/api/group-standings\` GET added for the wizard.
- **Marketing + helper copy refreshed** for the new v4 values (group, advancer, knockout, Final).

## Test plan

- [x] \`npm test\` — 387 passing (resolver gets new \`groupStandings\`-path coverage; KnockoutBracket asserts new badges)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 0 errors
- [x] \`supabase db reset\` — all 52 migrations apply cleanly
- [x] End-to-end SQL scenario against local Supabase: leaderboard returns expected v4 values (group 43, advancer 4.5, knockout 35, gut 5, total 87.5) for a hand-computed fixture covering every bucket
- [x] \`admin_set_r32_bracket\` rejects out-of-group teams with a specific error (\`team X is not a 3rd-place finisher in any of the groups {…}\`)
- [x] \`admin_set_phase_two\` rejects opening Phase 2 with fewer than 12 group standings entered

## Migrations

- \`supabase/migrations/0051_scoring_v4.sql\` — rewrites \`knockout_round_config\`, \`scoring_champion_pts\`, \`scoring_third_place_pts\`, and re-emits \`get_leaderboard\` / \`get_leaderboard_rank\` with the new group + advancer CTEs.
- \`supabase/migrations/0052_decouple_r32_bracket.sql\` — rewrites \`admin_set_r32_bracket\` (per-group constraint, no longer reads \`tournament_advancers\`) and \`admin_set_phase_two\` (gates on standings + assignments).