### PR TITLE
feat(predictions): auto-save Phase 1 and drop "Save progress" button

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -925,18 +925,21 @@ export function PredictionsPageContent({
   const handleSubmit = () => persist({ markSubmitted: true });
   const handleSavePhase1 = () =>
     persist({ markSubmitted: false, redirectTo: redirectAfterSave ?? ROUTES.predictions });
-  const handleSaveProgress = () => persist({ markSubmitted: false });
 
-  // Should the wizard auto-save before this navigation? Phase 2 regular flow
-  // and admin edits get auto-save so picks aren't marooned in localStorage
-  // between sub-step transitions. Phase 1 regular flow keeps its explicit
-  // "Save Phase 1 Picks" button — we don't want to trigger creates on partial
-  // Phase 1 state.
+  // Should the wizard auto-save before this navigation? Editable phases
+  // (phase1 + phase2_open) and admin edits get auto-save so picks aren't
+  // marooned in localStorage between sub-step transitions. In Phase 1 we
+  // still skip the save when champion_team_id is unset — the RPC requires
+  // it, so we wait until the user reaches the Champion Pick step (the
+  // draft preserves their other picks in the meantime).
   const needsAutosaveOnNav = (): boolean => {
     if (isLocked) return false;
     if (isSavingProgress || isSubmitting) return false;
-    if (!usesAdminRoute && phase !== 'phase2_open') return false;
+    const isEditablePhase = phase === 'phase1' || phase === 'phase2_open';
+    if (!usesAdminRoute && !isEditablePhase) return false;
     if (mode === 'create' && nameError) return false;
+    const willSendPhase1 = usesAdminRoute || phase === 'phase1';
+    if (willSendPhase1 && !championTeamId) return false;
     return true;
   };
 
@@ -993,21 +996,10 @@ export function PredictionsPageContent({
   const showReviewSubmit = isLastStep && !lockedReadOnly;
   const showContinue =
     !isLastStep && (lockedReadOnly || !isPhase1LastStep || isSuperAdmin);
-  // Save progress is the inline default while the prediction is still
-  // editable — replaced by Save Phase 1 Picks on the Phase 1 last step
-  // and by Submit Prediction on the tiebreaker. Phase 1 used to have a
-  // bottom "Ready to submit?" card with a (useless) Submit button; that
-  // card is gone, so Save progress now shows inline during Phase 1 too.
-  // It is also hidden on Phase 2 knockout sub-steps — Continue / Back /
-  // sub-tab clicks already auto-save server-side there, so an explicit
-  // button would just duplicate the action.
-  const isPhase2KnockoutStep =
-    phase === 'phase2_open' && isKnockoutStage(currentStep);
-  const showSaveProgressInline =
-    !showSavePhase1 &&
-    !showReviewSubmit &&
-    !lockedReadOnly &&
-    !isPhase2KnockoutStep;
+  // Continue / Back / sub-tab clicks auto-save in both editable phases now,
+  // so the wizard no longer surfaces an inline "Save progress" button. The
+  // explicit Save Phase 1 Picks (end-of-phase-1 commit + exit) and Submit
+  // Prediction (final) buttons remain.
 
   return (
     <PageLayout>
@@ -1190,17 +1182,6 @@ export function PredictionsPageContent({
             {previousStepLabel ? `Back: ${previousStepLabel}` : 'Back'}
           </Button>
           <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
-            {showSaveProgressInline && (
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleSaveProgress}
-                disabled={isLocked || isSubmitting || isSavingProgress}
-                className="sm:w-auto"
-              >
-                {isSavingProgress ? 'Saving…' : 'Save progress'}
-              </Button>
-            )}
             {showSavePhase1 && (
               <Button
                 type="button"

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -689,4 +689,73 @@ describe('PredictionsPageContent — autosave', () => {
     // Silent autosave: no "Progress saved" toast.
     expect(toastSuccess).not.toHaveBeenCalled();
   });
+
+  it('Phase 1 nav triggers a silent server save once the champion is picked', async () => {
+    configureQueries(); // phase 1 default
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictionId: 'pred-new' }),
+    });
+
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="create" />);
+
+    await user.type(screen.getByLabelText(/Prediction name/), 'Main');
+    await user.click(await screen.findByTestId('fill-all-groups'));
+    await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
+    await user.click(screen.getByTestId('fill-all-bundles'));
+    await user.click(
+      screen.getByRole('button', { name: /Continue to Gut Feeling Champion/ })
+    );
+    // No champion yet — Continue/Back nav up to this point must not fire
+    // a server save (RPC requires champion_team_id in Phase 1).
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('fill-champion'));
+    // Phase 1 champion_pick has no Continue for regular users; Back to
+    // Best 3rds still goes through navigateWithAutosave.
+    await user.click(screen.getByRole('button', { name: /Back: Best 3rds/ }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/predictions');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.submit).toBe(false);
+    expect(body.championTeamId).toBe('team-arg');
+    expect(body.groups.length).toBeGreaterThan(0);
+    // Silent autosave: no "Progress saved" toast.
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it('Phase 1 nav skips the server save until the champion is picked', async () => {
+    configureQueries(); // phase 1 default
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictionId: 'pred-new' }),
+    });
+
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="create" />);
+
+    await user.type(screen.getByLabelText(/Prediction name/), 'Main');
+    await user.click(await screen.findByTestId('fill-all-groups'));
+    await user.click(screen.getByRole('button', { name: /Continue to Best 3rds/ }));
+    await user.click(screen.getByTestId('fill-all-bundles'));
+    await user.click(
+      screen.getByRole('button', { name: /Continue to Gut Feeling Champion/ })
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not render a Save progress button in Phase 1', async () => {
+    configureQueries(); // phase 1 default
+    render(<PredictionsPageContent mode="create" />);
+
+    await screen.findByTestId('fill-all-groups');
+    expect(screen.queryByRole('button', { name: /Save progress/i })).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Extend `navigateWithAutosave` to Phase 1 — Continue / Back / sub-tab clicks now silently PATCH/POST the prediction once a champion is picked. Skips silently until then so we don't fire RPC calls that the server would reject (`champion_team_id` is required for Phase 1 writes), leaving partial picks safely in the localStorage draft.
- Remove the inline "Save progress" button and its supporting state (`handleSaveProgress`, `showSaveProgressInline`, `isPhase2KnockoutStep`). The "Draft saved · HH:MM" indicator already gives users feedback between server saves.
- Keep "Save Phase 1 Picks" — it's the explicit end-of-phase-1 commit + exit-to-`/predictions` action, distinct from per-step autosave.

## Test plan
- [x] `npm test` — 391 tests pass, including 3 new ones:
  - Phase 1 nav silently saves once the champion is picked
  - Phase 1 nav skips the save until the champion is picked
  - No "Save progress" button rendered in Phase 1
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (no new warnings)
- [ ] Manual: as a regular user on `/predictions/new` in `phase1`, fill groups + best 3rds → no network request; pick champion + Back/tab nav → silent `POST /api/predictions`; subsequent nav fires `PATCH`; "Save Phase 1 Picks" still saves and redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)