### PR TITLE
fix(predictions): allow Phase 2 submit when champion_team_id is null

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -494,14 +494,22 @@ export function PredictionsPageContent({
   const championSlots = 1;
   const filledChampion = championTeamId !== null ? 1 : 0;
 
+  const usesAdminRoute = effectiveApiBasePath.startsWith('/api/admin/');
+  // The champion pick is a Phase 1 field — frozen in Phase 2 and the
+  // payload omits it there (see sendPhase1Fields below). Submitting in
+  // Phase 2 must therefore not require it, otherwise a legacy prediction
+  // with champion_team_id = null leaves the user stuck (they can't edit
+  // the field to "complete" it).
+  const championRequired = usesAdminRoute || phase === 'phase1';
+
   const totalSlots =
-    championSlots +
+    (championRequired ? championSlots : 0) +
     totalGroupSlots +
     ADVANCER_COUNT +
     totalKnockoutMatches +
     tiebreakerSlots;
   const filledSlots =
-    filledChampion +
+    (championRequired ? filledChampion : 0) +
     filledGroupSlots +
     completedAdvancers +
     completedKnockoutMatches +
@@ -515,15 +523,14 @@ export function PredictionsPageContent({
     totalKnockoutMatches > 0 && completedKnockoutMatches === totalKnockoutMatches;
   const isTiebreakerComplete = totalGoals !== null;
 
-  const usesAdminRoute = effectiveApiBasePath.startsWith('/api/admin/');
   // Submit ("mark this prediction submitted") requires the bracket to be
-  // fully built — i.e. every section, across both phases, complete. Save
-  // Progress doesn't use this gate; users save partial drafts in either
-  // phase. In Phase 1 the knockout UI is read-only for regular users so
-  // isBracketComplete is naturally false and Submit stays disabled until
-  // Phase 2 opens.
+  // fully built — i.e. every section the user can still edit in the
+  // current phase. Save Progress doesn't use this gate; users save
+  // partial drafts in either phase. In Phase 1 the knockout UI is
+  // read-only for regular users so isBracketComplete is naturally false
+  // and Submit stays disabled until Phase 2 opens.
   const isPredictionsComplete =
-    isChampionPickComplete &&
+    (!championRequired || isChampionPickComplete) &&
     isGroupsComplete &&
     isAdvancersComplete &&
     isBracketComplete &&

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -751,6 +751,81 @@ describe('PredictionsPageContent — autosave', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('Phase 2 submit succeeds for a legacy prediction with null champion_team_id', async () => {
+    // Regression: a regular user in Phase 2 could not submit a prediction
+    // whose champion_team_id was null (allowed by the schema for legacy
+    // rows). The completion gate required the champion pick — but the
+    // user can't edit that field in Phase 2 (it's frozen post-Phase-1),
+    // so they were stuck on "Please complete all predictions before
+    // submitting" with no way out. Submit should ignore the champion
+    // field when the wizard isn't going to send it (Phase 2 regular
+    // user; non-admin route).
+    configureQueries({ phase: 'phase2_open' });
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictionId: 'pred-legacy' }),
+    });
+
+    const initial = {
+      id: 'pred-legacy',
+      name: 'Legacy',
+      totalGoals: null,
+      championTeamId: null,
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups: fixtureGroups.map((g) => ({
+        groupId: g.id,
+        first: g.teams[0].id,
+        second: g.teams[1].id,
+        third: g.teams[2].id,
+        fourth: g.teams[3].id,
+      })),
+      knockout: fixtureKnockoutMatches.map((m) => ({
+        matchId: m.id,
+        winner: 'mex',
+      })),
+      advancers: Array.from({ length: 8 }, (_, i) => ({
+        rank: i + 1,
+        teamId: 'mex',
+      })),
+    };
+
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="edit" predictionId="pred-legacy" initial={initial} />);
+
+    // Walk to the tiebreaker step (wizard auto-jumps to R32 in phase2_open).
+    await screen.findByTestId('knockout-bracket');
+    for (const next of ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Tiebreaker']) {
+      await user.click(
+        await screen.findByRole('button', {
+          name: new RegExp(`Continue to ${next}`, 'i'),
+        })
+      );
+    }
+    await user.click(screen.getByTestId('set-tiebreaker'));
+
+    await user.click(screen.getByRole('button', { name: /Submit Prediction/ }));
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Prediction submitted'));
+    expect(toastError).not.toHaveBeenCalledWith(
+      'Please complete all predictions before submitting'
+    );
+    // The submit call must NOT carry championTeamId (Phase 2 regular path
+    // strips Phase 1 fields).
+    const submitCall = fetchMock.mock.calls.find(([, init]) => {
+      try {
+        return JSON.parse((init as RequestInit).body as string).submit === true;
+      } catch {
+        return false;
+      }
+    });
+    expect(submitCall).toBeDefined();
+    const submitBody = JSON.parse((submitCall![1] as RequestInit).body as string);
+    expect(submitBody.championTeamId).toBeUndefined();
+  });
+
   it('does not render a Save progress button in Phase 1', async () => {
     configureQueries(); // phase 1 default
     render(<PredictionsPageContent mode="create" />);


### PR DESCRIPTION
## Summary
Users with a legacy prediction (champion_team_id = NULL in the DB) couldn't submit in Phase 2. The completion gate required `isChampionPickComplete` unconditionally, but champion is a Phase 1 field — frozen for regular users in Phase 2 with no editable surface. Result: "Please complete all predictions before submitting" with no way to recover.

Reported against prediction `97348109-4441-47ae-9861-720a77d46aa7` on soccer-pool.com.

### Fix
- Gate the champion requirement on whether the wizard will actually send Phase 1 fields (admin route or `phase === 'phase1'`). Mirrors `sendPhase1Fields` in `persist()`.
- Drop the champion slot from the progress total when it's not required, so the bar reaches 100% for a Phase 2 user with a null champion.

The RPC payload already omits `championTeamId` in the Phase 2 regular path (`PredictionsPageContent.tsx:849`), so this was a UI-only bug.

## Test plan
- [x] `npm test` — 392 tests pass, including new regression `Phase 2 submit succeeds for a legacy prediction with null champion_team_id`.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean (no new warnings).
- [ ] Manual against prod-like data: open a prediction whose `champion_team_id` is NULL in `phase2_open`, fill out the bracket + tiebreaker, click Submit → completes successfully; submitted_at populated; no champion write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)