### PR TITLE
fix(predictions): unblock Phase 2 submit (third-place match + Phase 1 decoupling)

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -478,7 +478,19 @@ export function PredictionsPageContent({
     !hydrated;
 
   const totalGroupsCount = groups?.length ?? 0;
-  const totalKnockoutMatches = matches?.length ?? 0;
+  // M103 (third-place playoff) lives in knockout_matches but has no
+  // wizard step under v4 — users never pick it. Counting it would make
+  // isBracketComplete permanently false (totalKnockoutMatches would
+  // always exceed what the UI lets the user fill), so it's excluded from
+  // both the completion check and the progress bar.
+  const pickableKnockoutMatchIds = React.useMemo(
+    () =>
+      new Set(
+        (matches ?? []).filter((m) => m.stage !== 'third_place').map((m) => m.id)
+      ),
+    [matches]
+  );
+  const totalKnockoutMatches = pickableKnockoutMatchIds.size;
   const filledGroupSlots = groupPredictions.reduce(
     (sum, p) => sum + Object.values(p.positions).filter((v) => v !== null).length,
     0
@@ -487,7 +499,9 @@ export function PredictionsPageContent({
   const completedGroups = groupPredictions.filter(
     (p) => Object.values(p.positions).filter((v) => v !== null).length === 4
   ).length;
-  const completedKnockoutMatches = knockoutPredictions.filter((p) => p.winnerId !== null).length;
+  const completedKnockoutMatches = knockoutPredictions.filter(
+    (p) => p.winnerId !== null && pickableKnockoutMatchIds.has(p.matchId)
+  ).length;
   const completedAdvancers = advancerPredictions.filter((a) => !!a.teamId).length;
   const tiebreakerSlots = 1;
   const filledTiebreaker = totalGoals !== null ? 1 : 0;

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -495,25 +495,22 @@ export function PredictionsPageContent({
   const filledChampion = championTeamId !== null ? 1 : 0;
 
   const usesAdminRoute = effectiveApiBasePath.startsWith('/api/admin/');
-  // The champion pick is a Phase 1 field — frozen in Phase 2 and the
-  // payload omits it there (see sendPhase1Fields below). Submitting in
-  // Phase 2 must therefore not require it, otherwise a legacy prediction
-  // with champion_team_id = null leaves the user stuck (they can't edit
-  // the field to "complete" it).
-  const championRequired = usesAdminRoute || phase === 'phase1';
+  // The two phases are decoupled end-to-end (server RPC branches on
+  // phase; payload composition strips fields from the other phase; UI
+  // disables the other phase's forms). The submit / progress gates
+  // follow suit: only check the fields this save can actually write.
+  // Otherwise a legacy prediction with stale Phase 1 state (null
+  // champion, missing advancers, partial groups) traps the user — they
+  // can't edit Phase 1 in Phase 2 to satisfy the gate.
+  const requiresPhase1Fields = usesAdminRoute || phase === 'phase1';
+  const requiresPhase2Fields = usesAdminRoute || phase === 'phase2_open';
 
   const totalSlots =
-    (championRequired ? championSlots : 0) +
-    totalGroupSlots +
-    ADVANCER_COUNT +
-    totalKnockoutMatches +
-    tiebreakerSlots;
+    (requiresPhase1Fields ? championSlots + totalGroupSlots + ADVANCER_COUNT : 0) +
+    (requiresPhase2Fields ? totalKnockoutMatches + tiebreakerSlots : 0);
   const filledSlots =
-    (championRequired ? filledChampion : 0) +
-    filledGroupSlots +
-    completedAdvancers +
-    completedKnockoutMatches +
-    filledTiebreaker;
+    (requiresPhase1Fields ? filledChampion + filledGroupSlots + completedAdvancers : 0) +
+    (requiresPhase2Fields ? completedKnockoutMatches + filledTiebreaker : 0);
   const overallPercent = totalSlots > 0 ? Math.round((filledSlots / totalSlots) * 100) : 0;
 
   const isChampionPickComplete = championTeamId !== null;
@@ -523,18 +520,14 @@ export function PredictionsPageContent({
     totalKnockoutMatches > 0 && completedKnockoutMatches === totalKnockoutMatches;
   const isTiebreakerComplete = totalGoals !== null;
 
-  // Submit ("mark this prediction submitted") requires the bracket to be
-  // fully built — i.e. every section the user can still edit in the
-  // current phase. Save Progress doesn't use this gate; users save
-  // partial drafts in either phase. In Phase 1 the knockout UI is
-  // read-only for regular users so isBracketComplete is naturally false
-  // and Submit stays disabled until Phase 2 opens.
+  // Submit ("mark this prediction submitted") requires only the fields
+  // the current phase is responsible for. Phase 1's commit is the
+  // "Save Phase 1 Picks" button; Phase 2's commit is "Submit
+  // Prediction" on the tiebreaker. Each commits its own slice.
   const isPredictionsComplete =
-    (!championRequired || isChampionPickComplete) &&
-    isGroupsComplete &&
-    isAdvancersComplete &&
-    isBracketComplete &&
-    isTiebreakerComplete;
+    (!requiresPhase1Fields ||
+      (isChampionPickComplete && isGroupsComplete && isAdvancersComplete)) &&
+    (!requiresPhase2Fields || (isBracketComplete && isTiebreakerComplete));
 
   const trimmedName = predictionName.trim();
   const nameError =

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -108,7 +108,12 @@ jest.mock('@/components/predictions/KnockoutBracket', () => ({
         type="button"
         data-testid="fill-all-knockout"
         onClick={() => {
-          knockoutPredictions.forEach((m) => onPredictionChange(m.matchId, 'winner'));
+          // Mirror the real bracket: M103 (third-place playoff) has no
+          // pickable UI under v4, so it never gets a winner here. Filling
+          // it would mask the bug where isBracketComplete counts M103.
+          knockoutPredictions
+            .filter((m) => m.matchId !== 'M103')
+            .forEach((m) => onPredictionChange(m.matchId, 'winner'));
         }}
       />
     </div>
@@ -824,6 +829,58 @@ describe('PredictionsPageContent — autosave', () => {
     expect(submitCall).toBeDefined();
     const submitBody = JSON.parse((submitCall![1] as RequestInit).body as string);
     expect(submitBody.championTeamId).toBeUndefined();
+  });
+
+  it('Phase 2 submit succeeds with the bracket filled through the UI (M103 excluded)', async () => {
+    // Regression: knockout_matches contains M103 (third-place playoff),
+    // but it has no wizard step under v4 — the real KnockoutBracket
+    // never renders a picker for it. isBracketComplete counted M103 in
+    // totalKnockoutMatches, so completedKnockoutMatches (max = matches
+    // minus M103) could never equal it and Submit was permanently
+    // blocked for every Phase 2 user. The fill-all-knockout mock now
+    // mirrors the real UI by skipping M103.
+    configureQueries({ phase: 'phase2_open' });
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictionId: 'pred-1' }),
+    });
+
+    const initial = {
+      id: 'pred-1',
+      name: 'Main',
+      totalGoals: null,
+      championTeamId: 'arg',
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups: [],
+      knockout: [],
+      advancers: [],
+    };
+
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="edit" predictionId="pred-1" initial={initial} />);
+
+    // Wizard auto-jumps to R32; fill every pickable match (mock skips M103),
+    // then walk to the tiebreaker.
+    await screen.findByTestId('knockout-bracket');
+    await user.click(screen.getByTestId('fill-all-knockout'));
+    for (const next of ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Tiebreaker']) {
+      await user.click(
+        await screen.findByRole('button', {
+          name: new RegExp(`Continue to ${next}`, 'i'),
+        })
+      );
+    }
+    await user.click(screen.getByTestId('set-tiebreaker'));
+
+    await user.click(screen.getByRole('button', { name: /Submit Prediction/ }));
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Prediction submitted'));
+    expect(toastError).not.toHaveBeenCalledWith(
+      'Please complete all predictions before submitting'
+    );
   });
 
   it('does not render a Save progress button in Phase 1', async () => {

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -751,15 +751,15 @@ describe('PredictionsPageContent — autosave', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('Phase 2 submit succeeds for a legacy prediction with null champion_team_id', async () => {
-    // Regression: a regular user in Phase 2 could not submit a prediction
-    // whose champion_team_id was null (allowed by the schema for legacy
-    // rows). The completion gate required the champion pick — but the
-    // user can't edit that field in Phase 2 (it's frozen post-Phase-1),
-    // so they were stuck on "Please complete all predictions before
-    // submitting" with no way out. Submit should ignore the champion
-    // field when the wizard isn't going to send it (Phase 2 regular
-    // user; non-admin route).
+  it('Phase 2 submit succeeds for a legacy prediction with stale Phase 1 fields', async () => {
+    // Regression: in Phase 2 the submit gate used to require ALL Phase 1
+    // fields to be complete (champion + 12×4 group positions + 8
+    // advancers). Legacy predictions can have null champion, partial
+    // group standings (no 3rd/4th from pre-advancers schema), or zero
+    // advancer rows — none of which a regular user can fix in Phase 2
+    // (the forms are read-only). The two phases are decoupled
+    // everywhere else (server RPC, payload composition, UI editability),
+    // so the submit gate must only check Phase 2 fields.
     configureQueries({ phase: 'phase2_open' });
     const fetchMock = global.fetch as jest.Mock;
     fetchMock.mockResolvedValue({
@@ -771,25 +771,25 @@ describe('PredictionsPageContent — autosave', () => {
       id: 'pred-legacy',
       name: 'Legacy',
       totalGoals: null,
-      championTeamId: null,
+      championTeamId: null, // legacy: no champion picked
       submittedAt: new Date(Date.now() - 60_000).toISOString(),
       isPaid: false,
       paidAt: null,
+      // Partial groups: 1st/2nd only, no 3rd/4th — mirrors pre-advancers
+      // schema where 3rd-place picks weren't collected.
       groups: fixtureGroups.map((g) => ({
         groupId: g.id,
         first: g.teams[0].id,
         second: g.teams[1].id,
-        third: g.teams[2].id,
-        fourth: g.teams[3].id,
+        third: null,
+        fourth: null,
       })),
       knockout: fixtureKnockoutMatches.map((m) => ({
         matchId: m.id,
         winner: 'mex',
       })),
-      advancers: Array.from({ length: 8 }, (_, i) => ({
-        rank: i + 1,
-        teamId: 'mex',
-      })),
+      // No advancer rows at all (legacy pre-0025 prediction).
+      advancers: [],
     };
 
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
Phase 2 "Submit Prediction" was blocked with "Please complete all predictions before submitting" even with the bracket fully filled. Two distinct causes, both fixed here:

### 1. Third-place match (the actual blocker for everyone) — `4dbbb0e`
M103 (third-place playoff) is a row in `knockout_matches`, but it has **no wizard step under v4** — `KnockoutBracket` never renders a picker for it (it's excluded from `STEP_ORDER` / `KNOCKOUT_STAGE_LIST`). Yet `isBracketComplete` counted it:
```
isBracketComplete = totalKnockoutMatches(31, incl. M103) === completedKnockoutMatches(≤30)  // never true
```
So **every** Phase 2 user was stuck. Per-step Continue gating used `stageCompletion` (which already excludes `third_place`), which is why users could *reach* the tiebreaker but never submit.

The test suite masked this: the `fill-all-knockout` mock filled *all* predictions including M103. The mock now mirrors the real UI (skips M103), and a dedicated regression covers the UI-filled submit path.

**Fix:** exclude `third_place` matches from `totalKnockoutMatches` / `completedKnockoutMatches` (and the progress bar).

### 2. Submit gate still coupled to Phase 1 fields — `94fc7cd`
The two phases are decoupled in the server RPC, payload composition, and UI editability — but the submit gate still required all Phase 1 fields. A legacy prediction with null champion / partial groups / missing advancers (unfixable in Phase 2) would also be blocked. Gate now mirrors `sendPhase1Fields` / `sendPhase2Fields`: regular Phase 2 submit checks only bracket + tiebreaker.

## Test plan
- [x] `npm test` — 393 pass. New regressions: `Phase 2 submit succeeds with the bracket filled through the UI (M103 excluded)` and `Phase 2 submit succeeds for a legacy prediction with stale Phase 1 fields`.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [ ] Manual (local, prediction `0684a272-6a78-436a-8b11-20b3eee908f0`): Phase 2, fill bracket + tiebreaker, Submit → succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)