### PR TITLE
chore(admin): drop third-place match from knockout results editor

### DIFF
--- a/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
+++ b/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
@@ -238,6 +238,9 @@ export function KnockoutResultsEditor({
   const grouped = React.useMemo(() => {
     const map = new Map<KnockoutMatch['stage'], KnockoutMatch[]>();
     for (const m of matches) {
+      // M103 (third-place playoff) is unscored under v4 and not picked by
+      // users, so there's nothing to record a result against.
+      if (m.stage === 'third_place') continue;
       const list = map.get(m.stage) ?? [];
       list.push(m);
       map.set(m.stage, list);


### PR DESCRIPTION
## Summary
Removes the **Third Place** (M103) input card from `/admin/results` → Knockout Results. Under scoring v4 the third-place playoff is unscored (`scoring_third_place_pts()` returns 0) and users don't pick it, so there's nothing to record a result against.

One-line change: skip the `third_place` stage when grouping matches in `KnockoutResultsEditor`, so its section no longer renders.

## Safety
- **Scoring:** v4's `scoring_third_place_pts()` returns 0 — M103 contributes nothing to the leaderboard (confirmed in `0051_scoring_v4.sql`).
- **RPC:** `admin_set_knockout_result` has no completeness check; not recording M103 is a no-op server-side. Any pre-existing M103 result in the DB is simply ignored by scoring.
- **Read-only displays** (`BracketView` "Third-place play-off") are untouched — M103 still shows in the bracket, it just can't be edited from admin results.

## Test plan
- [x] `npm test` (393 pass), `npm run typecheck`, `npm run lint` all clean.
- [ ] Manual: open `/admin/results` → Knockout Results tab → confirm no "Third Place" section; R32→Final cards still save normally.

Note: not visually verified locally (admin page needs admin auth + local Supabase); change is limited to dropping one stage from the grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)