### PR TITLE
feat(predictions): restore third-place (M103) as a scored knockout round

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -62,9 +62,8 @@ type Step =
 
 type TopStep = 'groups' | 'best_thirds' | 'champion_pick' | 'knockout' | 'tiebreaker';
 
-// 'third_place' (M103) is intentionally omitted — the match is no longer
-// scored under v4 so users don't pick it. The DB stage enum keeps the value
-// so the bracket / admin results editor can still surface M103 read-only.
+// 'third_place' (M103) sits after the Final: users pick the third-place
+// winner (scored +5) before the tiebreaker.
 const STEP_ORDER: Step[] = [
   'groups',
   'best_thirds',
@@ -74,6 +73,7 @@ const STEP_ORDER: Step[] = [
   'quarter_finals',
   'semi_finals',
   'final',
+  'third_place',
   'tiebreaker',
 ];
 
@@ -96,6 +96,7 @@ const KNOCKOUT_STAGE_LIST: KnockoutStage[] = [
   'quarter_finals',
   'semi_finals',
   'final',
+  'third_place',
 ];
 
 const SUB_STEP_LABELS: Record<KnockoutStage, string> = {
@@ -478,19 +479,9 @@ export function PredictionsPageContent({
     !hydrated;
 
   const totalGroupsCount = groups?.length ?? 0;
-  // M103 (third-place playoff) lives in knockout_matches but has no
-  // wizard step under v4 — users never pick it. Counting it would make
-  // isBracketComplete permanently false (totalKnockoutMatches would
-  // always exceed what the UI lets the user fill), so it's excluded from
-  // both the completion check and the progress bar.
-  const pickableKnockoutMatchIds = React.useMemo(
-    () =>
-      new Set(
-        (matches ?? []).filter((m) => m.stage !== 'third_place').map((m) => m.id)
-      ),
-    [matches]
-  );
-  const totalKnockoutMatches = pickableKnockoutMatchIds.size;
+  // Every knockout match is pickable — including M103 (third-place
+  // playoff), which is a required, scored (+5) round again.
+  const totalKnockoutMatches = matches?.length ?? 0;
   const filledGroupSlots = groupPredictions.reduce(
     (sum, p) => sum + Object.values(p.positions).filter((v) => v !== null).length,
     0
@@ -500,7 +491,7 @@ export function PredictionsPageContent({
     (p) => Object.values(p.positions).filter((v) => v !== null).length === 4
   ).length;
   const completedKnockoutMatches = knockoutPredictions.filter(
-    (p) => p.winnerId !== null && pickableKnockoutMatchIds.has(p.matchId)
+    (p) => p.winnerId !== null
   ).length;
   const completedAdvancers = advancerPredictions.filter((a) => !!a.teamId).length;
   const tiebreakerSlots = 1;

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -62,8 +62,9 @@ type Step =
 
 type TopStep = 'groups' | 'best_thirds' | 'champion_pick' | 'knockout' | 'tiebreaker';
 
-// 'third_place' (M103) sits after the Final: users pick the third-place
-// winner (scored +5) before the tiebreaker.
+// 'third_place' (M103) sits between the semi-finals and the Final: the
+// SF losers are known by then, and users pick the third-place winner
+// (scored +5) just before the championship match.
 const STEP_ORDER: Step[] = [
   'groups',
   'best_thirds',
@@ -72,8 +73,8 @@ const STEP_ORDER: Step[] = [
   'round_of_16',
   'quarter_finals',
   'semi_finals',
-  'final',
   'third_place',
+  'final',
   'tiebreaker',
 ];
 
@@ -95,8 +96,8 @@ const KNOCKOUT_STAGE_LIST: KnockoutStage[] = [
   'round_of_16',
   'quarter_finals',
   'semi_finals',
-  'final',
   'third_place',
+  'final',
 ];
 
 const SUB_STEP_LABELS: Record<KnockoutStage, string> = {

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -108,9 +108,17 @@ jest.mock('@/components/predictions/KnockoutBracket', () => ({
         type="button"
         data-testid="fill-all-knockout"
         onClick={() => {
-          // Mirror the real bracket: M103 (third-place playoff) has no
-          // pickable UI under v4, so it never gets a winner here. Filling
-          // it would mask the bug where isBracketComplete counts M103.
+          // Fill every knockout match including M103 (third-place playoff),
+          // which is a required, scored round again.
+          knockoutPredictions.forEach((m) => onPredictionChange(m.matchId, 'winner'));
+        }}
+      />
+      <button
+        type="button"
+        data-testid="fill-all-knockout-except-third"
+        onClick={() => {
+          // Fill everything except M103 — used to assert the third-place
+          // round gates bracket completion.
           knockoutPredictions
             .filter((m) => m.matchId !== 'M103')
             .forEach((m) => onPredictionChange(m.matchId, 'winner'));
@@ -399,7 +407,7 @@ describe('PredictionsPageContent — stepper navigation', () => {
     // Filling all knockout matches at once satisfies every knockout sub-step.
     await user.click(screen.getByTestId('fill-all-knockout'));
 
-    const stages = ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final'];
+    const stages = ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Third Place'];
     for (const next of stages) {
       const btn = await screen.findByRole('button', {
         name: new RegExp(`Continue to ${next}`, 'i'),
@@ -616,13 +624,13 @@ describe('PredictionsPageContent — autosave', () => {
     await user.click(screen.getByTestId('fill-champion'));
     await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
     await user.click(screen.getByTestId('fill-all-knockout'));
-    // Walk through R16 → QF → SF → Final → Tiebreaker via Continue.
-    // 3rd-place (M103) is no longer a wizard step (unscored under v4).
+    // Walk through R16 → QF → SF → Final → Third Place → Tiebreaker.
     for (const next of [
       'Round of 16',
       'Quarter-finals',
       'Semi-finals',
       'Final',
+      'Third Place',
       'Tiebreaker',
     ]) {
       await user.click(
@@ -802,7 +810,14 @@ describe('PredictionsPageContent — autosave', () => {
 
     // Walk to the tiebreaker step (wizard auto-jumps to R32 in phase2_open).
     await screen.findByTestId('knockout-bracket');
-    for (const next of ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Tiebreaker']) {
+    for (const next of [
+      'Round of 16',
+      'Quarter-finals',
+      'Semi-finals',
+      'Final',
+      'Third Place',
+      'Tiebreaker',
+    ]) {
       await user.click(
         await screen.findByRole('button', {
           name: new RegExp(`Continue to ${next}`, 'i'),
@@ -831,14 +846,11 @@ describe('PredictionsPageContent — autosave', () => {
     expect(submitBody.championTeamId).toBeUndefined();
   });
 
-  it('Phase 2 submit succeeds with the bracket filled through the UI (M103 excluded)', async () => {
-    // Regression: knockout_matches contains M103 (third-place playoff),
-    // but it has no wizard step under v4 — the real KnockoutBracket
-    // never renders a picker for it. isBracketComplete counted M103 in
-    // totalKnockoutMatches, so completedKnockoutMatches (max = matches
-    // minus M103) could never equal it and Submit was permanently
-    // blocked for every Phase 2 user. The fill-all-knockout mock now
-    // mirrors the real UI by skipping M103.
+  it('Phase 2: the third-place (M103) round gates bracket completion', async () => {
+    // M103 (third-place playoff) is a required, scored (+5) knockout
+    // round again. Filling every other knockout match but leaving M103
+    // unpicked must leave the bracket incomplete — Continue off the Third
+    // Place step stays disabled until M103 has a winner.
     configureQueries({ phase: 'phase2_open' });
     const fetchMock = global.fetch as jest.Mock;
     fetchMock.mockResolvedValue({
@@ -862,19 +874,29 @@ describe('PredictionsPageContent — autosave', () => {
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="edit" predictionId="pred-1" initial={initial} />);
 
-    // Wizard auto-jumps to R32; fill every pickable match (mock skips M103),
-    // then walk to the tiebreaker.
+    // Wizard auto-jumps to R32; fill every match EXCEPT M103, then walk
+    // forward to the Third Place step.
     await screen.findByTestId('knockout-bracket');
-    await user.click(screen.getByTestId('fill-all-knockout'));
-    for (const next of ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Tiebreaker']) {
+    await user.click(screen.getByTestId('fill-all-knockout-except-third'));
+    for (const next of ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Third Place']) {
       await user.click(
         await screen.findByRole('button', {
           name: new RegExp(`Continue to ${next}`, 'i'),
         })
       );
     }
-    await user.click(screen.getByTestId('set-tiebreaker'));
 
+    // On the Third Place step with M103 unpicked, advancing is blocked.
+    expect(
+      await screen.findByRole('button', { name: /Continue to Tiebreaker/ })
+    ).toBeDisabled();
+
+    // Pick the third-place winner → bracket completes, Continue unlocks.
+    await user.click(screen.getByTestId('fill-all-knockout'));
+    await user.click(
+      await screen.findByRole('button', { name: /Continue to Tiebreaker/ })
+    );
+    await user.click(screen.getByTestId('set-tiebreaker'));
     await user.click(screen.getByRole('button', { name: /Submit Prediction/ }));
 
     await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Prediction submitted'));

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -407,7 +407,7 @@ describe('PredictionsPageContent — stepper navigation', () => {
     // Filling all knockout matches at once satisfies every knockout sub-step.
     await user.click(screen.getByTestId('fill-all-knockout'));
 
-    const stages = ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Third Place'];
+    const stages = ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Third Place', 'Final'];
     for (const next of stages) {
       const btn = await screen.findByRole('button', {
         name: new RegExp(`Continue to ${next}`, 'i'),
@@ -624,13 +624,13 @@ describe('PredictionsPageContent — autosave', () => {
     await user.click(screen.getByTestId('fill-champion'));
     await user.click(screen.getByRole('button', { name: /Continue to Round of 32/ }));
     await user.click(screen.getByTestId('fill-all-knockout'));
-    // Walk through R16 → QF → SF → Final → Third Place → Tiebreaker.
+    // Walk through R16 → QF → SF → Third Place → Final → Tiebreaker.
     for (const next of [
       'Round of 16',
       'Quarter-finals',
       'Semi-finals',
-      'Final',
       'Third Place',
+      'Final',
       'Tiebreaker',
     ]) {
       await user.click(
@@ -814,8 +814,8 @@ describe('PredictionsPageContent — autosave', () => {
       'Round of 16',
       'Quarter-finals',
       'Semi-finals',
-      'Final',
       'Third Place',
+      'Final',
       'Tiebreaker',
     ]) {
       await user.click(
@@ -875,10 +875,10 @@ describe('PredictionsPageContent — autosave', () => {
     render(<PredictionsPageContent mode="edit" predictionId="pred-1" initial={initial} />);
 
     // Wizard auto-jumps to R32; fill every match EXCEPT M103, then walk
-    // forward to the Third Place step.
+    // forward to the Third Place step (it sits just before the Final).
     await screen.findByTestId('knockout-bracket');
     await user.click(screen.getByTestId('fill-all-knockout-except-third'));
-    for (const next of ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Final', 'Third Place']) {
+    for (const next of ['Round of 16', 'Quarter-finals', 'Semi-finals', 'Third Place']) {
       await user.click(
         await screen.findByRole('button', {
           name: new RegExp(`Continue to ${next}`, 'i'),
@@ -888,11 +888,12 @@ describe('PredictionsPageContent — autosave', () => {
 
     // On the Third Place step with M103 unpicked, advancing is blocked.
     expect(
-      await screen.findByRole('button', { name: /Continue to Tiebreaker/ })
+      await screen.findByRole('button', { name: /Continue to Final/ })
     ).toBeDisabled();
 
-    // Pick the third-place winner → bracket completes, Continue unlocks.
+    // Pick the third-place winner → step completes, Continue unlocks.
     await user.click(screen.getByTestId('fill-all-knockout'));
+    await user.click(await screen.findByRole('button', { name: /Continue to Final/ }));
     await user.click(
       await screen.findByRole('button', { name: /Continue to Tiebreaker/ })
     );

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -68,14 +68,14 @@ export const STAGE_CONFIG: Record<
 
 // Stage order. Used by the parent stepper; the bracket itself now renders one
 // stage at a time controlled by the `stage` prop. 'third_place' (M103) sits
-// after the Final — a required, scored (+5) round.
+// between the semi-finals and the Final — a required, scored (+5) round.
 export const STAGE_ORDER: KnockoutStage[] = [
   'round_of_32',
   'round_of_16',
   'quarter_finals',
   'semi_finals',
-  'final',
   'third_place',
+  'final',
 ];
 
 interface KnockoutBracketProps {

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -55,8 +55,8 @@ export const STAGE_CONFIG: Record<
   third_place: {
     label: 'Third Place',
     shortLabel: '3rd',
-    pointsHint: 'not scored',
-    subtitle: 'Third-place match is not scored — pick a winner for completeness.',
+    pointsHint: '+5',
+    subtitle: '+5 if you pick the third-place winner correctly.',
   },
   final: {
     label: 'Final',
@@ -67,14 +67,15 @@ export const STAGE_CONFIG: Record<
 };
 
 // Stage order. Used by the parent stepper; the bracket itself now renders one
-// stage at a time controlled by the `stage` prop. 'third_place' (M103) is
-// omitted — the match is no longer scored in v4 so the wizard skips it.
+// stage at a time controlled by the `stage` prop. 'third_place' (M103) sits
+// after the Final — a required, scored (+5) round.
 export const STAGE_ORDER: KnockoutStage[] = [
   'round_of_32',
   'round_of_16',
   'quarter_finals',
   'semi_finals',
   'final',
+  'third_place',
 ];
 
 interface KnockoutBracketProps {

--- a/supabase/migrations/0053_restore_third_place_scoring.sql
+++ b/supabase/migrations/0053_restore_third_place_scoring.sql
@@ -1,0 +1,19 @@
+-- 0053_restore_third_place_scoring.sql
+--
+-- Reverses 0051's zeroing of the third-place (M103) bonus. The product
+-- decision is to bring back the third-place playoff as a required,
+-- scored knockout round worth +5 (its v3 value).
+--
+-- The third_place_score CTE in get_leaderboard / get_leaderboard_rank
+-- (0051) is still wired up — it joins knockout_predictions /
+-- knockout_results on match_id = 'M103' and multiplies a correct pick by
+-- scoring_third_place_pts(). So a single create-or-replace restores the
+-- +5 award with no need to re-emit the leaderboard RPCs.
+
+create or replace function public.scoring_third_place_pts()
+returns int
+language sql
+immutable
+parallel safe
+set search_path = public
+as $$ select 5 $$;


### PR DESCRIPTION
## Summary
Reverses the v4 removal of the third-place playoff. **M103 is again a required, pickable Phase 2 knockout round that scores +5** for a correct third-place winner.

- **Wizard** (`PredictionsPageContent.tsx`): `third_place` back in `STEP_ORDER` + `KNOCKOUT_STAGE_LIST`; bracket `STAGE_ORDER` too. Dropped the `pickableKnockoutMatchIds` filter so M103 counts toward `isBracketComplete` — that's the re-added validation (Continue off the Third Place step and final Submit both require it). Bracket copy updated from "not scored" → "+5".
- **Scoring** (`0053_restore_third_place_scoring.sql`): one-line `create or replace scoring_third_place_pts() → 5`. The `third_place_score` CTE in `get_leaderboard` / `get_leaderboard_rank` is still wired (it just multiplies by this fn), so no RPC re-emit needed. Verified locally: `select scoring_third_place_pts()` → `5`.
- **Admin results editor**: unchanged — `main` already renders the "Third Place" card and `admin_set_knockout_result` accepts M103. (This supersedes PR #153, now closed.)
- **Tests**: `fill-all-knockout` mock fills M103 again; Continue walks include the "Third Place" step; new regression `Phase 2: the third-place (M103) round gates bracket completion` asserts the bracket is incomplete until M103 is picked.

## Test plan
- [x] `npm test` (393 pass), `npm run typecheck`, `npm run lint` clean.
- [x] `supabase migration up` applied 0053; `scoring_third_place_pts()` returns 5.
- [ ] Manual (`phase2_open`): Knockout → after Final a **3rd** sub-step shows the two SF losers; Continue is disabled until a winner is picked; record M103 in `/admin/results` → correct pick adds +5 on `/leaderboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)