### PR TITLE
feat(predictions): restore the "Save progress" button in both phases

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -931,6 +931,7 @@ export function PredictionsPageContent({
   const handleSubmit = () => persist({ markSubmitted: true });
   const handleSavePhase1 = () =>
     persist({ markSubmitted: false, redirectTo: redirectAfterSave ?? ROUTES.predictions });
+  const handleSaveProgress = () => persist({ markSubmitted: false });
 
   // Should the wizard auto-save before this navigation? Editable phases
   // (phase1 + phase2_open) and admin edits get auto-save so picks aren't
@@ -1002,10 +1003,14 @@ export function PredictionsPageContent({
   const showReviewSubmit = isLastStep && !lockedReadOnly;
   const showContinue =
     !isLastStep && (lockedReadOnly || !isPhase1LastStep || isSuperAdmin);
-  // Continue / Back / sub-tab clicks auto-save in both editable phases now,
-  // so the wizard no longer surfaces an inline "Save progress" button. The
-  // explicit Save Phase 1 Picks (end-of-phase-1 commit + exit) and Submit
-  // Prediction (final) buttons remain.
+  // Save progress: an explicit "persist now, don't advance" action so a user
+  // can checkpoint the current round (Phase 1 or Phase 2) in place. Auto-save
+  // still fires on Continue / Back / sub-tab; this covers staying put. Hidden
+  // where a dedicated commit button already owns the footer (Phase 1 last
+  // step → Save Phase 1 Picks; final/tiebreaker → Submit Prediction) and in a
+  // locked read-only view. Reuses persist()'s name + champion validation.
+  const showSaveProgressInline =
+    !showSavePhase1 && !showReviewSubmit && !lockedReadOnly;
 
   return (
     <PageLayout>
@@ -1188,6 +1193,17 @@ export function PredictionsPageContent({
             {previousStepLabel ? `Back: ${previousStepLabel}` : 'Back'}
           </Button>
           <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+            {showSaveProgressInline && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleSaveProgress}
+                disabled={isLocked || isSubmitting || isSavingProgress}
+                className="sm:w-auto"
+              >
+                {isSavingProgress ? 'Saving…' : 'Save progress'}
+              </Button>
+            )}
             {showSavePhase1 && (
               <Button
                 type="button"

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -906,11 +906,63 @@ describe('PredictionsPageContent — autosave', () => {
     );
   });
 
-  it('does not render a Save progress button in Phase 1', async () => {
+  it('renders Save progress on a Phase 1 round step', async () => {
     configureQueries(); // phase 1 default
     render(<PredictionsPageContent mode="create" />);
 
+    // Group Stage is a "round" — the user can checkpoint here without
+    // advancing to Best 3rds.
     await screen.findByTestId('fill-all-groups');
+    expect(screen.getByRole('button', { name: /Save progress/i })).toBeInTheDocument();
+  });
+
+  it('Save progress persists in place on a Phase 2 knockout round (no advance)', async () => {
+    // The button exists so a user editing the current round can save
+    // without navigating (auto-save only fires on Continue / Back / tab).
+    configureQueries({ phase: 'phase2_open' });
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictionId: 'pred-1' }),
+    });
+
+    const initial = {
+      id: 'pred-1',
+      name: 'Main',
+      totalGoals: null,
+      championTeamId: 'arg',
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups: [],
+      knockout: [],
+      advancers: [],
+    };
+
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="edit" predictionId="pred-1" initial={initial} />);
+
+    // Wizard auto-jumps to R32 in phase2_open.
+    await screen.findByTestId('knockout-bracket');
+    await user.click(screen.getByTestId('fill-all-knockout'));
+
+    await user.click(screen.getByRole('button', { name: /Save progress/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/predictions/pred-1');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body).submit).toBe(false);
+    // Still on the same round — Save progress does not navigate.
+    expect(screen.getByTestId('knockout-bracket')).toBeInTheDocument();
+    expect(toastSuccess).toHaveBeenCalledWith('Progress saved');
+  });
+
+  it('does not render Save progress in a locked read-only view', async () => {
+    configureQueries({ tournamentLockTime: new Date(Date.now() - 1000).toISOString() });
+    render(<PredictionsPageContent mode="create" />);
+
+    await screen.findByText(/read-only view of your picks/i);
     expect(screen.queryByRole('button', { name: /Save progress/i })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Auto-save only fires on navigation (Continue / Back / sub-tab), so a user editing the **current** round had no way to persist in place without advancing. This restores the inline **"Save progress"** button (removed in #150) on every editable round in **both phases** — including the Phase 2 knockout sub-steps, which is the case the team was hitting.

Effectively a targeted revert of the button-removal half of `c36031c`, with one deliberate change: the old version hid the button on Phase 2 knockout rounds (because they auto-saved on nav) — that hiding is exactly the gap, so it now shows there.

### Changes (`PredictionsPageContent.tsx`)
- Re-add `handleSaveProgress = () => persist({ markSubmitted: false })` — reuses the existing name + Phase 1 champion validation. No new validation logic.
- `showSaveProgressInline = !showSavePhase1 && !showReviewSubmit && !lockedReadOnly` — prior predicate minus the `!isPhase2KnockoutStep` term.
- Re-add the button JSX in its prior footer position (before Save Phase 1 Picks / Submit).

Auto-save-on-nav (`needsAutosaveOnNav` / `navigateWithAutosave`) is untouched — the button is purely additive. Stays hidden on `champion_pick` (Save Phase 1 Picks), `tiebreaker` (Submit), and in a locked read-only view.

## Test plan
- [x] `npm test` (395 pass), `npm run typecheck`, `npm run lint` clean.
- New tests: Save progress renders on a Phase 1 round; on a Phase 2 knockout round clicking it PATCHes with `submit: false` and **stays on the same round** (no navigation); absent in a locked view.
- [ ] Manual (`phase2_open`): edit a knockout round → Save progress → "Progress saved" toast, PATCH fires, no advance; Continue/Back still auto-save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)