### PR TITLE
perf(predictions): skip nav auto-save when nothing changed

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -158,6 +158,33 @@ interface DraftData {
   championTeamId: string | null;
 }
 
+// Canonical, order-insensitive serialization of a prediction's picks, used to
+// detect whether anything changed since the last save (so nav auto-save can
+// skip the DB round-trip when nothing did). Sorting + trimming means a
+// mismatch can only ever cause an unnecessary save, never a lost one.
+function serializePicks(d: DraftData): string {
+  return JSON.stringify({
+    predictionName: d.predictionName.trim(),
+    championTeamId: d.championTeamId,
+    totalGoals: d.totalGoals,
+    groups: [...d.groupPredictions]
+      .sort((a, b) => a.groupId.localeCompare(b.groupId))
+      .map((g) => [
+        g.groupId,
+        g.positions.first,
+        g.positions.second,
+        g.positions.third,
+        g.positions.fourth,
+      ]),
+    advancers: [...d.advancerPredictions]
+      .sort((a, b) => a.rank - b.rank)
+      .map((a) => [a.rank, a.teamId]),
+    knockout: [...d.knockoutPredictions]
+      .sort((a, b) => a.matchId.localeCompare(b.matchId))
+      .map((k) => [k.matchId, k.winnerId]),
+  });
+}
+
 interface PredictionsPageContentProps {
   mode: 'create' | 'edit';
   predictionId?: string;
@@ -354,6 +381,9 @@ export function PredictionsPageContent({
   const userInteractedRef = React.useRef(false);
   const initialStepSet = React.useRef(false);
   const nameRef = React.useRef<HTMLInputElement>(null);
+  // Serialized picks as last known on the server. Nav auto-save compares
+  // against this and skips the DB round-trip when nothing changed.
+  const lastSavedSnapshotRef = React.useRef<string | null>(null);
 
   // Once we know the phase and have hydrated, jump straight to Round of 32
   // when phase 2 is open — group + advancer + champion picks are frozen at
@@ -453,6 +483,17 @@ export function PredictionsPageContent({
     setChampionTeamId(championSeed);
     setPredictionName(nameSeed);
     setHydrated(true);
+
+    // Baseline = the SERVER state (seeds before any draft override), so
+    // draft-restored unsaved changes count as dirty and save on first nav.
+    lastSavedSnapshotRef.current = serializePicks({
+      predictionName: initial?.name ?? '',
+      championTeamId: initial?.championTeamId ?? null,
+      totalGoals: initial?.totalGoals ?? null,
+      groupPredictions: seedGroups,
+      advancerPredictions: seedAdvancers,
+      knockoutPredictions: seedKnockout,
+    });
 
     if (restoredFromDraft) {
       toast.info('Restored your unsaved draft', {
@@ -813,6 +854,17 @@ export function PredictionsPageContent({
       return false;
     }
 
+    // Snapshot of the full picks being saved — becomes the new "last saved"
+    // baseline on success so a subsequent unchanged nav skips the round-trip.
+    const savedSnapshot = serializePicks({
+      predictionName: trimmedName,
+      championTeamId,
+      totalGoals,
+      groupPredictions,
+      advancerPredictions,
+      knockoutPredictions,
+    });
+
     if (markSubmitted) setIsSubmitting(true);
     else setIsSavingProgress(true);
     try {
@@ -881,6 +933,7 @@ export function PredictionsPageContent({
       const data = (await res.json().catch(() => ({}))) as { predictionId?: string };
       const newId = data.predictionId ?? predictionId;
 
+      lastSavedSnapshotRef.current = savedSnapshot;
       clearDraft();
       if (mode === 'create' && user?.id && tournament.id) {
         clearDraftForPrediction(user.id, tournament.id, NEW_PREDICTION_SENTINEL);
@@ -947,6 +1000,17 @@ export function PredictionsPageContent({
     if (mode === 'create' && nameError) return false;
     const willSendPhase1 = usesAdminRoute || phase === 'phase1';
     if (willSendPhase1 && !championTeamId) return false;
+    // Nothing changed since the last save — skip the DB round-trip; the
+    // caller (navigateWithAutosave) just navigates.
+    const currentSnapshot = serializePicks({
+      predictionName,
+      championTeamId,
+      totalGoals,
+      groupPredictions,
+      advancerPredictions,
+      knockoutPredictions,
+    });
+    if (currentSnapshot === lastSavedSnapshotRef.current) return false;
     return true;
   };
 

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -703,6 +703,77 @@ describe('PredictionsPageContent — autosave', () => {
     expect(toastSuccess).not.toHaveBeenCalled();
   });
 
+  it('Phase 2 Continue does NOT save when nothing changed', async () => {
+    // Change-detection: navigating across rounds without editing should not
+    // hit the DB — the wizard just advances. Baseline is the server state
+    // seeded at hydration (a fully-filled bracket here).
+    configureQueries({ phase: 'phase2_open' });
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictionId: 'pred-1' }),
+    });
+
+    const initial = {
+      id: 'pred-1',
+      name: 'Main',
+      totalGoals: 7,
+      championTeamId: 'arg',
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups: [],
+      knockout: fixtureKnockoutMatches.map((m) => ({ matchId: m.id, winner: 'mex' })),
+      advancers: [],
+    };
+
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="edit" predictionId="pred-1" initial={initial} />);
+
+    // Wizard auto-jumps to R32; bracket is already complete from `initial`.
+    await screen.findByTestId('knockout-bracket');
+    await user.click(screen.getByRole('button', { name: /Continue to Round of 16/ }));
+
+    // Advanced to R16 without a server round-trip.
+    await screen.findByRole('button', { name: /Continue to Quarter-finals/ });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('Phase 2 Continue saves once a pick changes (dirty after a clean baseline)', async () => {
+    // Same fully-filled baseline, but editing a pick makes it dirty, so the
+    // next nav DOES persist.
+    configureQueries({ phase: 'phase2_open' });
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ predictionId: 'pred-1' }),
+    });
+
+    const initial = {
+      id: 'pred-1',
+      name: 'Main',
+      totalGoals: 7,
+      championTeamId: 'arg',
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups: [],
+      knockout: fixtureKnockoutMatches.map((m) => ({ matchId: m.id, winner: 'mex' })),
+      advancers: [],
+    };
+
+    const user = userEvent.setup();
+    render(<PredictionsPageContent mode="edit" predictionId="pred-1" initial={initial} />);
+
+    await screen.findByTestId('knockout-bracket');
+    // Re-fill all knockout winners to a different value → dirty vs baseline.
+    await user.click(screen.getByTestId('fill-all-knockout'));
+    await user.click(screen.getByRole('button', { name: /Continue to Round of 16/ }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).submit).toBe(false);
+  });
+
   it('Phase 1 nav triggers a silent server save once the champion is picked', async () => {
     configureQueries(); // phase 1 default
     const fetchMock = global.fetch as jest.Mock;


### PR DESCRIPTION
## Summary
Yes — this was possible. The wizard auto-saved on **every** step navigation (Continue / Back / sub-tab), hitting the DB even when the user only viewed a round without editing. Now it detects whether anything changed since the last save and, if not, **skips the round-trip and just advances**.

### How
- A canonical `serializePicks()` (module-level) produces an order-insensitive, trimmed string of the six pick fields (mirrors `DraftData`).
- `lastSavedSnapshotRef` holds the picks as last known on the server. Seeded at hydration to the **server** state (so draft-restored unsaved changes still count as dirty and save on first nav), and refreshed on every successful `persist()`.
- `needsAutosaveOnNav()` compares the current snapshot to the baseline; equal → returns false → `navigateWithAutosave` just navigates (existing no-save path).

### Scope / safety
- Only the **navigation** auto-save is gated. Explicit **Save progress / Save Phase 1 Picks / Submit** still save unconditionally (deliberate actions).
- Comparison sorts + trims, so a mismatch can only ever cause an *unnecessary* save, never a *lost* one. Failed saves leave the ref untouched → next nav retries.
- The localStorage draft (debounced, local-only) is unchanged.

## Test plan
- [x] `npm test` (397 pass), `npm run typecheck`, `npm run lint` clean.
- New tests: clean nav across rounds does **not** call `fetch` (advances anyway); editing a pick after a clean baseline makes the next nav `PATCH`. Existing dirty-path nav/submit tests still pass.
- [ ] Manual (`phase2_open`, filled bracket): DevTools Network → Continue/Back without editing → no `/api/predictions` calls; edit a pick → next nav fires one `PATCH`; no edit again → silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)