### PR TITLE
fix(scoring): reflect restored third-place match (+5) in UI and totals

### DIFF
--- a/frontend/src/components/marketing/ScoringBreakdown.tsx
+++ b/frontend/src/components/marketing/ScoringBreakdown.tsx
@@ -105,7 +105,7 @@ export function ScoringBreakdown() {
               </div>
               <div className="flex items-center justify-between gap-4">
                 <span className="text-muted-foreground">Third Place Match</span>
-                <span className="font-semibold">not scored</span>
+                <span className="font-semibold">+5 pts</span>
               </div>
               <div className="border-t pt-3">
                 <div className="flex items-center justify-between font-semibold">

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -374,7 +374,7 @@ export function KnockoutBracket({
           </p>
           <p>
             <strong>Final:</strong> +30 for picking the World Cup champion. The third-place match
-            is not scored.
+            scores +5.
           </p>
         </div>
       </details>
@@ -390,6 +390,8 @@ export function KnockoutBracket({
         <span>SF +18</span>
         <span>·</span>
         <span>Final +30</span>
+        <span>·</span>
+        <span>3rd +5</span>
       </div>
 
       <StageSection

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -9,20 +9,20 @@ export const TOURNAMENT_CONFIG = {
   totalMatches: 104,
 } as const;
 
-// Scoring v4 (migration 0051):
+// Scoring v4 (migration 0051) + third-place restored (migration 0053):
 // Group stage: 11 standard groups × 12 (exact-order top-2) + Group I "Group of Death" exact-order
 //   = 132 + 18 = 150. Reversed = 8, single correct in slot = 5, wrong slot = 0.
 // Advancers: 8 ranked 3rd-place picks × 2.5 (set + rank) = 20 max.
 // Knockout (flat, no wrong-slot bonus): R32 16×5 + R16 8×8 + QF 4×12 + SF 2×18 + Final 1×30
-//   = 80 + 64 + 48 + 36 + 30 = 258. Third-place match (M103) not scored.
+//   + third-place match (M103) 1×5 = 80 + 64 + 48 + 36 + 30 + 5 = 263.
 // Phase 1 Champions Pick: +5 if `predictions.champion_team_id` matches the actual M104 winner
 // (independent of the bracket Final pick).
 export const SCORING = {
   maxGroupPoints: 150,
   maxAdvancerPoints: 20,
-  maxKnockoutPoints: 258,
+  maxKnockoutPoints: 263,
   championPickBonus: 5,
-  maxTotalPoints: 433,
+  maxTotalPoints: 438,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary
Migration `0053_restore_third_place_scoring.sql` restored the third-place match (M103) as a scored **+5** knockout round, but the frontend still advertised it as "not scored" and the max-point totals omitted the +5. This syncs the UI text and the scoring constants.

- **`ScoringBreakdown.tsx`** (rules page + landing): "Third Place Match: not scored" → "**+5 pts**"
- **`KnockoutBracket.tsx`** (predictions wizard): "The third-place match is not scored." → "scores +5"; added `3rd +5` to the persistent scoring strip
- **`constants.ts`**: `maxKnockoutPoints` 258 → **263**, `maxTotalPoints` 433 → **438**, comment updated (16×5 + 8×8 + 4×12 + 2×18 + 30 + 5 = 263)

Note: CLAUDE.md's scoring section still describes the older v3 table (different R16/QF/SF values than the live v4 numbers) — that pre-existing doc drift is out of scope for this fix.

## Test plan
- [x] `npm test` — 397 passed (incl. `constants.test.ts` sum check)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (3 pre-existing warnings, unrelated)