### PR TITLE
feat(scoring): group-stage scoring rebalance (10/15/7/5/2)

### DIFF
--- a/frontend/src/components/marketing/ScoringBreakdown.tsx
+++ b/frontend/src/components/marketing/ScoringBreakdown.tsx
@@ -23,11 +23,11 @@ export function ScoringBreakdown() {
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">Both top 2, exact order</span>
-                <span className="font-semibold">+12 points</span>
+                <span className="font-semibold">+10 points</span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">Both top 2, swapped</span>
-                <span className="font-semibold">+8 points</span>
+                <span className="font-semibold">+7 points</span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">Single team in its correct slot</span>
@@ -44,8 +44,8 @@ export function ScoringBreakdown() {
               <div className="bg-muted/50 rounded-md p-3 text-sm">
                 <span className="font-semibold">Group of Death (Group I):</span>{' '}
                 <span className="text-muted-foreground">
-                  Both top 2 in exact order pays <span className="font-semibold">+18</span>{' '}
-                  instead of +12.
+                  Both top 2 in exact order pays <span className="font-semibold">+15</span>{' '}
+                  instead of +10.
                 </span>
               </div>
               <div className="border-t pt-3">

--- a/frontend/src/components/marketing/ScoringBreakdown.tsx
+++ b/frontend/src/components/marketing/ScoringBreakdown.tsx
@@ -34,8 +34,8 @@ export function ScoringBreakdown() {
                 <span className="font-semibold">+5 points</span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">Right team, wrong slot</span>
-                <span className="font-semibold">+0 points</span>
+                <span className="text-muted-foreground">Single team in wrong slot</span>
+                <span className="font-semibold">+2 points</span>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">None correct</span>

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -231,8 +231,8 @@ export function GroupStageForm({
             </p>
             <p>
               <strong>Per group:</strong> +12 for both top-two correct in exact order · +8 if
-              both correct but swapped · +5 per correct team in its correct slot · 0 otherwise.
-              Right team in the wrong slot does not score.
+              both correct but swapped · +5 per correct team in its correct slot · +2 for a
+              single team in the wrong slot · 0 otherwise.
             </p>
             <p>
               <strong>Group I (&ldquo;Group of Death&rdquo;)</strong> pays +18 instead of +12

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -230,12 +230,12 @@ export function GroupStageForm({
               separate Best 3rds step.
             </p>
             <p>
-              <strong>Per group:</strong> +12 for both top-two correct in exact order · +8 if
+              <strong>Per group:</strong> +10 for both top-two correct in exact order · +7 if
               both correct but swapped · +5 per correct team in its correct slot · +2 for a
               single team in the wrong slot · 0 otherwise.
             </p>
             <p>
-              <strong>Group I (&ldquo;Group of Death&rdquo;)</strong> pays +18 instead of +12
+              <strong>Group I (&ldquo;Group of Death&rdquo;)</strong> pays +15 instead of +10
               when both top-two finishers are predicted in exact order.
             </p>
           </div>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -9,20 +9,20 @@ export const TOURNAMENT_CONFIG = {
   totalMatches: 104,
 } as const;
 
-// Scoring v4 (migration 0051) + third-place restored (migration 0053):
-// Group stage: 11 standard groups × 12 (exact-order top-2) + Group I "Group of Death" exact-order
-//   = 132 + 18 = 150. Reversed = 8, single correct in slot = 5, wrong slot = 0.
+// Scoring v4 (migration 0051) + third-place restored (0053) + group rebalance (0054):
+// Group stage: 11 standard groups × 10 (exact-order top-2) + Group I "Group of Death" exact-order 15
+//   = 110 + 15 = 125. Reversed = 7, single correct in slot = 5, single in wrong slot = 2.
 // Advancers: 8 ranked 3rd-place picks × 2.5 (set + rank) = 20 max.
 // Knockout (flat, no wrong-slot bonus): R32 16×5 + R16 8×8 + QF 4×12 + SF 2×18 + Final 1×30
 //   + third-place match (M103) 1×5 = 80 + 64 + 48 + 36 + 30 + 5 = 263.
 // Phase 1 Champions Pick: +5 if `predictions.champion_team_id` matches the actual M104 winner
 // (independent of the bracket Final pick).
 export const SCORING = {
-  maxGroupPoints: 150,
+  maxGroupPoints: 125,
   maxAdvancerPoints: 20,
   maxKnockoutPoints: 263,
   championPickBonus: 5,
-  maxTotalPoints: 438,
+  maxTotalPoints: 413,
 } as const;
 
 /**

--- a/supabase/migrations/0054_group_scoring_rebalance.sql
+++ b/supabase/migrations/0054_group_scoring_rebalance.sql
@@ -1,21 +1,23 @@
--- 0054_group_wrong_slot_scoring.sql
+-- 0054_group_scoring_rebalance.sql
 --
--- Restores a +2 "single team in the wrong slot" award to the group-stage
--- scoring. Scoring v4 (0051) zeroed this case; the product decision is to
--- bring it back as a consolation, mirroring the v3 behavior.
+-- Rebalances group-stage scoring to its final values, superseding scoring v4
+-- (0051). Per group, the predicted top 2 vs the actual top 2 score:
+--   exact pair      = 10  (15 for Group I "Group of Death")
+--   reversed pair   = 7
+--   single team in its correct slot = 5
+--   single team in the wrong slot   = 2   (v4 zeroed this; now a consolation)
+--   nothing correct = 0
+-- Max group total = 11×10 + 15 = 125 (all-exact, Group I premium).
 --
--- The award fires ONLY when the higher combinations all miss: a group is not
--- exact (12 / 18 for Group I) and not swapped (8). Inside that else branch the
--- predicted pair is neither exact nor swapped, so at most one of the two picks
--- can be in the actual top 2. The ordered CASE therefore returns 5 (single
--- team in its correct slot), else 2 (single team in the wrong slot), else 0 —
--- mutually exclusive, no double counting, and identical to 0051's output for
--- every non-wrong-slot case. Max group total is unchanged at 150 (all-exact).
+-- The wrong-slot award fires only inside the else branch (group not exact, not
+-- reversed). There at most one of the two picks can be in the actual top 2, so
+-- the ordered CASE returns 5 (correct slot), else 2 (wrong slot), else 0 —
+-- mutually exclusive, no double counting.
 --
 -- The group_scores CTE is inlined in both get_leaderboard and
--- get_leaderboard_rank, so both are re-emitted verbatim from 0051 with only
--- that CTE's else branch changed. admin_get_leaderboard (0042) wraps
--- get_leaderboard, so it inherits the change.
+-- get_leaderboard_rank, so both are re-emitted from 0051 with only that CTE's
+-- group CASE changed. admin_get_leaderboard (0042) wraps get_leaderboard, so it
+-- inherits the change.
 
 -- ========== get_leaderboard ==========
 
@@ -53,9 +55,9 @@ as $$
             coalesce(sum(
                 case
                     when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
-                        then case when gp.group_id = 'I' then 18 else 12 end
+                        then case when gp.group_id = 'I' then 15 else 10 end
                     when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
-                        then 8
+                        then 7
                     else
                         case
                             when gp.first_team_id = gs.first_team_id then 5   -- single team, correct slot
@@ -247,9 +249,9 @@ as $$
             coalesce(sum(
                 case
                     when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
-                        then case when gp.group_id = 'I' then 18 else 12 end
+                        then case when gp.group_id = 'I' then 15 else 10 end
                     when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
-                        then 8
+                        then 7
                     else
                         case
                             when gp.first_team_id = gs.first_team_id then 5   -- single team, correct slot

--- a/supabase/migrations/0054_group_wrong_slot_scoring.sql
+++ b/supabase/migrations/0054_group_wrong_slot_scoring.sql
@@ -1,0 +1,399 @@
+-- 0054_group_wrong_slot_scoring.sql
+--
+-- Restores a +2 "single team in the wrong slot" award to the group-stage
+-- scoring. Scoring v4 (0051) zeroed this case; the product decision is to
+-- bring it back as a consolation, mirroring the v3 behavior.
+--
+-- The award fires ONLY when the higher combinations all miss: a group is not
+-- exact (12 / 18 for Group I) and not swapped (8). Inside that else branch the
+-- predicted pair is neither exact nor swapped, so at most one of the two picks
+-- can be in the actual top 2. The ordered CASE therefore returns 5 (single
+-- team in its correct slot), else 2 (single team in the wrong slot), else 0 —
+-- mutually exclusive, no double counting, and identical to 0051's output for
+-- every non-wrong-slot case. Max group total is unchanged at 150 (all-exact).
+--
+-- The group_scores CTE is inlined in both get_leaderboard and
+-- get_leaderboard_rank, so both are re-emitted verbatim from 0051 with only
+-- that CTE's else branch changed. admin_get_leaderboard (0042) wraps
+-- get_leaderboard, so it inherits the change.
+
+-- ========== get_leaderboard ==========
+
+create or replace function public.get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    champion_pick_points int,
+    total_goals int,
+    total_count bigint
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 18 else 12 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 8
+                    else
+                        case
+                            when gp.first_team_id = gs.first_team_id then 5   -- single team, correct slot
+                            when gp.second_team_id = gs.second_team_id then 5 -- single team, correct slot
+                            when gp.first_team_id = gs.second_team_id then 2  -- single team, wrong slot
+                            when gp.second_team_id = gs.first_team_id then 2  -- single team, wrong slot
+                            else 0
+                        end
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 2.5
+                    when ta_team.team_id is not null then 2.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    knockout_round_totals as (
+        select s.prediction_id, coalesce(sum(s.round_points), 0)::int as round_points
+        from public.knockout_round_config() c
+        cross join lateral public.knockout_round_scores(
+            p_tournament_id, c.stage, c.correct_pts, c.wrong_pts
+        ) s
+        group by s.prediction_id
+    ),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_champion_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M104'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_third_place_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M103'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M103'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id
+                    then public.scoring_champion_pick_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(krt.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join knockout_round_totals krt on krt.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            pr.username::text as username,
+            coalesce(gsc.group_points, 0) as group_points,
+            coalesce(asc_.advancer_points, 0)::numeric as advancer_points,
+            coalesce(ksc.knockout_points, 0) as knockout_points,
+            coalesce(ksc.champion_pick_points, 0) as champion_pick_points,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            p.total_goals,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        join public.profiles pr on pr.id = p.user_id
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        rank,
+        prediction_id,
+        prediction_name,
+        username,
+        points,
+        group_points,
+        advancer_points,
+        knockout_points,
+        champion_pick_points,
+        total_goals,
+        count(*) over () as total_count
+    from ranked
+    order by rank
+    offset greatest(p_page - 1, 0) * greatest(p_page_size, 1)
+    limit greatest(p_page_size, 1);
+$$;
+
+grant execute on function public.get_leaderboard(uuid, int, int) to anon, authenticated;
+
+-- ========== get_leaderboard_rank ==========
+
+create or replace function public.get_leaderboard_rank(
+    p_tournament_id uuid,
+    p_user_id uuid,
+    p_page_size int default 25
+)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    rank int,
+    page int,
+    points numeric
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 18 else 12 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 8
+                    else
+                        case
+                            when gp.first_team_id = gs.first_team_id then 5   -- single team, correct slot
+                            when gp.second_team_id = gs.second_team_id then 5 -- single team, correct slot
+                            when gp.first_team_id = gs.second_team_id then 2  -- single team, wrong slot
+                            when gp.second_team_id = gs.first_team_id then 2  -- single team, wrong slot
+                            else 0
+                        end
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 2.5
+                    when ta_team.team_id is not null then 2.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    knockout_round_totals as (
+        select s.prediction_id, coalesce(sum(s.round_points), 0)::int as round_points
+        from public.knockout_round_config() c
+        cross join lateral public.knockout_round_scores(
+            p_tournament_id, c.stage, c.correct_pts, c.wrong_pts
+        ) s
+        group by s.prediction_id
+    ),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_champion_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M104'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_third_place_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M103'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M103'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id
+                    then public.scoring_champion_pick_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(krt.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join knockout_round_totals krt on krt.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            p.user_id,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        prediction_id,
+        prediction_name,
+        rank,
+        ((rank - 1) / greatest(p_page_size, 1) + 1)::int as page,
+        points
+    from ranked
+    where user_id = p_user_id
+    order by rank;
+$$;
+
+grant execute on function public.get_leaderboard_rank(uuid, uuid, int) to anon, authenticated;


### PR DESCRIPTION
## Summary
Rebalances group-stage scoring to its final values. The `group_scores` CTE is inlined in both `get_leaderboard` and `get_leaderboard_rank`, so migration `0054_group_scoring_rebalance.sql` re-emits both; `admin_get_leaderboard` wraps `get_leaderboard` and inherits the change.

| Outcome | Old | **New** |
|---|---|---|
| Exact top 2 (normal group) | 12 | **10** |
| Exact top 2 (Group I "Group of Death") | 18 | **15** |
| Correct top 2, reversed order | 8 | **7** |
| Single correct team, correct slot | 5 | **5** |
| Single correct team, wrong slot | 0 | **2** |

The wrong-slot **+2** (previously zeroed in v4) fires only when the group is neither exact nor reversed; in that branch at most one pick can be in the actual top 2, so it's mutually exclusive with the +5 correct-slot award (no stacking). Group I keeps its 1.5× premium (15 vs 10).

`maxGroupPoints` 150 → **125** (11×10 + 15), `maxTotalPoints` 438 → **413**. Rules breakdown + group-stage form copy updated to match.

## Test plan
- [x] `npm test` — 397 passed (incl. `constants.test.ts` sum check: 125+20+263+5=413)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (3 pre-existing warnings)
- [x] Re-applied `0054` functions to local DB — both recompile cleanly
- [x] SQL spot-check — all 8 scenarios pass (exact 10 / Group I 15 / reversed 7 / right-slot 5 / wrong-slot 2 / none 0)
- [x] `get_leaderboard` end-to-end — seeded perfect-group prediction now scores **125** (was 150)