### PR TITLE
feat(results): add logged-in Results page tracking admin-entered outcomes

### DIFF
--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -53,4 +53,19 @@ describe('middleware', () => {
     expect(location).toContain('/login');
     expect(location).toContain('next=%2Fadmin%2Fusers');
   });
+
+  it('redirects unauthenticated users from /results to /login', async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+    const res = await middleware(makeRequest('/results'));
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location')!;
+    expect(location).toContain('/login');
+    expect(location).toContain('next=%2Fresults');
+  });
+
+  it('allows authenticated users through /results', async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: 'abc' } } });
+    const res = await middleware(makeRequest('/results'));
+    expect(res.status).toBe(200);
+  });
 });

--- a/frontend/src/app/api/advancers/__tests__/route.test.ts
+++ b/frontend/src/app/api/advancers/__tests__/route.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+export {};
+
+const supabaseMock = {
+  from: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route');
+
+function mockData(
+  tournament: { id: string } | null,
+  rows: Array<Record<string, unknown>> | null,
+  rowsError: { message: string } | null = null
+) {
+  supabaseMock.from.mockImplementation((table: string) => {
+    if (table === 'tournaments') {
+      return {
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => ({ data: tournament, error: null }) }),
+        }),
+      };
+    }
+    // tournament_advancers: .select(...).eq(...).order(...) is awaited.
+    return {
+      select: () => ({
+        eq: () => ({ order: async () => ({ data: rows, error: rowsError }) }),
+      }),
+    };
+  });
+}
+
+describe('GET /api/advancers', () => {
+  beforeEach(() => {
+    supabaseMock.from.mockReset();
+  });
+
+  it('returns an empty list when there is no active tournament', async () => {
+    mockData(null, null);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ advancers: [] });
+  });
+
+  it('maps tournament_advancers rows into the camelCase response shape', async () => {
+    mockData({ id: 't1' }, [
+      { rank: 1, team_id: 'jpn' },
+      { rank: 2, team_id: 'mar' },
+    ]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      advancers: [
+        { rank: 1, teamId: 'jpn' },
+        { rank: 2, teamId: 'mar' },
+      ],
+    });
+  });
+
+  it('returns 500 when the query errors', async () => {
+    mockData({ id: 't1' }, null, { message: 'boom' });
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/frontend/src/app/api/advancers/route.ts
+++ b/frontend/src/app/api/advancers/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+
+export async function GET() {
+  const supabase = await getServerSupabase();
+  const { data: tournament } = await supabase
+    .from('tournaments')
+    .select('id')
+    .eq('is_active', true)
+    .maybeSingle();
+  if (!tournament) {
+    return NextResponse.json({ advancers: [] });
+  }
+
+  const { data, error } = await supabase
+    .from('tournament_advancers')
+    .select('rank, team_id')
+    .eq('tournament_id', tournament.id)
+    .order('rank', { ascending: true });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({
+    advancers: (data ?? []).map((r) => ({
+      rank: r.rank as number,
+      teamId: r.team_id as string,
+    })),
+  });
+}

--- a/frontend/src/app/api/knockout-results/__tests__/route.test.ts
+++ b/frontend/src/app/api/knockout-results/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment node
+ */
+export {};
+
+const supabaseMock = {
+  from: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route');
+
+function mockData(
+  tournament: { id: string } | null,
+  rows: Array<Record<string, unknown>> | null,
+  rowsError: { message: string } | null = null
+) {
+  supabaseMock.from.mockImplementation((table: string) => {
+    if (table === 'tournaments') {
+      return {
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => ({ data: tournament, error: null }) }),
+        }),
+      };
+    }
+    // knockout_results: .select(...).eq(...) is awaited directly.
+    return {
+      select: () => ({ eq: async () => ({ data: rows, error: rowsError }) }),
+    };
+  });
+}
+
+describe('GET /api/knockout-results', () => {
+  beforeEach(() => {
+    supabaseMock.from.mockReset();
+  });
+
+  it('returns an empty list when there is no active tournament', async () => {
+    mockData(null, null);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ results: [] });
+  });
+
+  it('maps knockout_results rows into the camelCase response shape', async () => {
+    mockData({ id: 't1' }, [
+      { match_id: 'M73', winner_team_id: 'esp', loser_team_id: 'mar', total_goals: 3 },
+      { match_id: 'M104', winner_team_id: 'fra', loser_team_id: 'bra', total_goals: null },
+    ]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      results: [
+        { matchId: 'M73', winnerTeamId: 'esp', loserTeamId: 'mar', totalGoals: 3 },
+        { matchId: 'M104', winnerTeamId: 'fra', loserTeamId: 'bra', totalGoals: null },
+      ],
+    });
+  });
+
+  it('returns 500 when the query errors', async () => {
+    mockData({ id: 't1' }, null, { message: 'boom' });
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/frontend/src/app/api/knockout-results/route.ts
+++ b/frontend/src/app/api/knockout-results/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+
+export async function GET() {
+  const supabase = await getServerSupabase();
+  const { data: tournament } = await supabase
+    .from('tournaments')
+    .select('id')
+    .eq('is_active', true)
+    .maybeSingle();
+  if (!tournament) {
+    return NextResponse.json({ results: [] });
+  }
+
+  const { data, error } = await supabase
+    .from('knockout_results')
+    .select('match_id, winner_team_id, loser_team_id, total_goals')
+    .eq('tournament_id', tournament.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({
+    results: (data ?? []).map((r) => ({
+      matchId: r.match_id as string,
+      winnerTeamId: (r.winner_team_id ?? null) as string | null,
+      loserTeamId: (r.loser_team_id ?? null) as string | null,
+      totalGoals: (r.total_goals ?? null) as number | null,
+    })),
+  });
+}

--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
-import { Search, Trophy, Users } from 'lucide-react';
+import { ArrowRight, Search, Trophy, Users } from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
@@ -163,25 +163,33 @@ export function LeaderboardPageContent() {
             )}
           </div>
         </div>
-        {user && !hasRankedEntry && !isLoading && !meQuery.isLoading && (
-          <Card className="border-dashed">
-            <CardContent className="py-3">
-              <p className="text-muted-foreground text-sm">
-                You haven&apos;t submitted predictions yet.
-              </p>
-            </CardContent>
-          </Card>
-        )}
-        {!user && !isLoading && (
-          <Card className="border-dashed">
-            <CardContent className="py-3 text-sm">
-              <Link href={ROUTES.login} className="text-primary hover:underline">
-                Sign in
-              </Link>{' '}
-              to see your rank.
-            </CardContent>
-          </Card>
-        )}
+        <div className="flex items-center gap-3">
+          <Button variant="outline" size="sm" asChild>
+            <Link href={ROUTES.results}>
+              View live results
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+          {user && !hasRankedEntry && !isLoading && !meQuery.isLoading && (
+            <Card className="border-dashed">
+              <CardContent className="py-3">
+                <p className="text-muted-foreground text-sm">
+                  You haven&apos;t submitted predictions yet.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+          {!user && !isLoading && (
+            <Card className="border-dashed">
+              <CardContent className="py-3 text-sm">
+                <Link href={ROUTES.login} className="text-primary hover:underline">
+                  Sign in
+                </Link>{' '}
+                to see your rank.
+              </CardContent>
+            </Card>
+          )}
+        </div>
       </div>
 
       <Card className="mb-6">

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, Clock, Eye, FileEdit, Gift, Plus, Trash2 } from 'lucide-react';
+import { ArrowRight, CheckCircle2, Clock, Eye, FileEdit, Gift, Plus, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -159,19 +159,27 @@ export function PredictionsListPage() {
             and click <strong>Use free credit</strong> on any unpaid entry to apply it.
           </p>
         </div>
-        <Button asChild disabled={!canCreate} size="lg">
-          <Link
-            href={
-              canCreate ? `${ROUTES.predictions}/${NEW_PREDICTION_SENTINEL}` : '#'
-            }
-            aria-disabled={!canCreate}
-            title={
-              isLocked && !isSuperAdmin ? 'Predictions are locked' : undefined
-            }
-          >
-            <Plus className="mr-2 h-4 w-4" /> New prediction
-          </Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button asChild variant="outline" size="lg">
+            <Link href={ROUTES.results}>
+              View live results
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+          <Button asChild disabled={!canCreate} size="lg">
+            <Link
+              href={
+                canCreate ? `${ROUTES.predictions}/${NEW_PREDICTION_SENTINEL}` : '#'
+              }
+              aria-disabled={!canCreate}
+              title={
+                isLocked && !isSuperAdmin ? 'Predictions are locked' : undefined
+              }
+            >
+              <Plus className="mr-2 h-4 w-4" /> New prediction
+            </Link>
+          </Button>
+        </div>
       </div>
 
       <div className="mb-4">

--- a/frontend/src/app/results/ResultsPageContent.tsx
+++ b/frontend/src/app/results/ResultsPageContent.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Skeleton } from '@/components/ui/skeleton';
+import { BracketView } from '@/components/predictions/BracketView';
+import { GroupStandingsResults } from '@/components/results/GroupStandingsResults';
+import { AdvancersResults } from '@/components/results/AdvancersResults';
+import type {
+  Group,
+  GroupStanding,
+  KnockoutMatch,
+  R32BracketAssignment,
+  Team,
+  TournamentAdvancer,
+} from '@/types/tournament';
+
+interface KnockoutResultRow {
+  matchId: string;
+  winnerTeamId: string | null;
+  loserTeamId: string | null;
+  totalGoals: number | null;
+}
+
+async function fetchJSON<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
+  return res.json();
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <p className="text-muted-foreground text-sm">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function ResultsPageContent() {
+  const teamsQuery = useQuery<Team[]>({
+    queryKey: ['teams'],
+    queryFn: () => fetchJSON('/api/teams'),
+  });
+  const groupsQuery = useQuery<Group[]>({
+    queryKey: ['groups'],
+    queryFn: () => fetchJSON('/api/groups'),
+  });
+  const matchesQuery = useQuery<KnockoutMatch[]>({
+    queryKey: ['knockout-matches'],
+    queryFn: () => fetchJSON('/api/knockout-matches'),
+  });
+  const standingsQuery = useQuery<{ standings: GroupStanding[] }>({
+    queryKey: ['group-standings'],
+    queryFn: () => fetchJSON('/api/group-standings'),
+  });
+  const advancersQuery = useQuery<{ advancers: TournamentAdvancer[] }>({
+    queryKey: ['advancers'],
+    queryFn: () => fetchJSON('/api/advancers'),
+  });
+  const resultsQuery = useQuery<{ results: KnockoutResultRow[] }>({
+    queryKey: ['knockout-results'],
+    queryFn: () => fetchJSON('/api/knockout-results'),
+  });
+  const bracketQuery = useQuery<{ assignments: R32BracketAssignment[] }>({
+    queryKey: ['r32-bracket'],
+    queryFn: () => fetchJSON('/api/r32-bracket'),
+  });
+
+  const teams = teamsQuery.data ?? [];
+  const groups = groupsQuery.data ?? [];
+  const matches = matchesQuery.data ?? [];
+  const standings = standingsQuery.data?.standings ?? [];
+  const advancers = advancersQuery.data?.advancers ?? [];
+  const bracketAssignments = bracketQuery.data?.assignments ?? [];
+
+  // The bracket reflects real outcomes: feed admin-entered standings as the
+  // group source and knockout_results as the match winners. resolveTeamSource
+  // reads 1A/2B group sources from groupPredictions, so the actual top-2 drive
+  // who appears in each Round-of-32 slot.
+  const groupPredictions = React.useMemo(
+    () =>
+      (standingsQuery.data?.standings ?? []).map((s) => ({
+        groupId: s.groupId,
+        positions: {
+          first: s.firstTeamId,
+          second: s.secondTeamId,
+          third: s.thirdTeamId,
+          fourth: s.fourthTeamId,
+        },
+      })),
+    [standingsQuery.data]
+  );
+  const knockoutPredictions = React.useMemo(
+    () =>
+      (resultsQuery.data?.results ?? []).map((r) => ({
+        matchId: r.matchId,
+        winnerId: r.winnerTeamId,
+      })),
+    [resultsQuery.data]
+  );
+
+  // Core metadata must load before anything can render meaningfully.
+  const ready = teamsQuery.data && groupsQuery.data && matchesQuery.data;
+  const isError = teamsQuery.isError || groupsQuery.isError || matchesQuery.isError;
+
+  return (
+    <PageLayout>
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl font-bold">Results</h1>
+        <p className="text-muted-foreground">
+          The official tournament outcomes as entered by the pool admin. This view is
+          read-only and updates as new results are posted.
+        </p>
+      </div>
+
+      {isError && (
+        <p className="text-destructive text-sm" role="alert">
+          Couldn&apos;t load the tournament results. Please try again.
+        </p>
+      )}
+
+      {!ready && !isError && (
+        <div className="space-y-4">
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+      )}
+
+      {ready && (
+        <div className="space-y-10">
+          <Section
+            title="Group stage"
+            description="Final standings for all 12 groups. The top two in each group advance to the Round of 32."
+          >
+            <GroupStandingsResults groups={groups} teams={teams} standings={standings} />
+          </Section>
+
+          <Section
+            title="Best 3rd-place advancers"
+            description="The 8 best third-placed teams that fill the remaining Round-of-32 spots, ranked best first."
+          >
+            <AdvancersResults advancers={advancers} teams={teams} />
+          </Section>
+
+          <Section
+            title="Knockout bracket"
+            description="Match winners from the Round of 32 through the final. Empty slots show as TBD until results are posted."
+          >
+            <BracketView
+              matches={matches}
+              teams={teams}
+              groupPredictions={groupPredictions}
+              knockoutPredictions={knockoutPredictions}
+              bracketAssignments={bracketAssignments}
+            />
+          </Section>
+        </div>
+      )}
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/results/loading.tsx
+++ b/frontend/src/app/results/loading.tsx
@@ -1,0 +1,25 @@
+import { PageLayout } from '@/components/layout/PageLayout';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ResultsLoading() {
+  return (
+    <PageLayout>
+      <div className="mb-8">
+        <Skeleton className="mb-2 h-9 w-48" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+      <div className="space-y-10">
+        {Array.from({ length: 3 }).map((_, section) => (
+          <div key={section} className="space-y-4">
+            <Skeleton className="h-6 w-56" />
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-40 w-full" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/results/page.tsx
+++ b/frontend/src/app/results/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+import { ResultsPageContent } from './ResultsPageContent';
+
+export const metadata: Metadata = {
+  title: 'Results | World Cup 2026',
+  description:
+    'Live tournament results: group standings, the best 3rd-place advancers, and the knockout bracket exactly as entered by the pool admin.',
+};
+
+export default function ResultsPage() {
+  return <ResultsPageContent />;
+}

--- a/frontend/src/components/layout/AuthMenu.tsx
+++ b/frontend/src/components/layout/AuthMenu.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Gift, LogOut, Settings, Trophy, User as UserIcon } from 'lucide-react';
+import { Gift, LogOut, Settings, Shield, Trophy, User as UserIcon } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -145,6 +145,19 @@ export function AuthMenu() {
               Account settings
             </Link>
           </Button>
+          {profile?.isAdmin && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full justify-start gap-2"
+              asChild
+            >
+              <Link href={ROUTES.admin}>
+                <Shield className="h-4 w-4" />
+                Admin
+              </Link>
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -8,7 +8,6 @@ import { cn } from '@/lib/utils';
 import { ROUTES } from '@/lib/constants';
 import { AuthMenu } from '@/components/layout/AuthMenu';
 import { ThemeToggle } from '@/components/shared/ThemeToggle';
-import { useAuthContext } from '@/providers/AuthProvider';
 import { useMounted } from '@/hooks/useMounted';
 import {
   NavigationMenu,
@@ -20,10 +19,11 @@ import {
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 
-const baseNavLinks = [
+const navLinks = [
   { label: 'Home', href: ROUTES.home },
   { label: 'Predictions', href: ROUTES.predictions },
   { label: 'Leaderboard', href: ROUTES.leaderboard },
+  { label: 'Results', href: ROUTES.results },
   { label: 'Rules & Scoring', href: ROUTES.rules },
   { label: 'About', href: ROUTES.about },
   { label: 'Charities', href: ROUTES.charities },
@@ -31,11 +31,7 @@ const baseNavLinks = [
 
 export function Header() {
   const pathname = usePathname();
-  const { profile } = useAuthContext();
   const mounted = useMounted();
-  const navLinks = profile?.isAdmin
-    ? [...baseNavLinks, { label: 'Admin', href: ROUTES.admin }]
-    : baseNavLinks;
 
   const isActive = (href: string) => {
     if (href === ROUTES.home) {

--- a/frontend/src/components/results/AdvancersResults.tsx
+++ b/frontend/src/components/results/AdvancersResults.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import * as React from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { TeamFlag } from '@/components/shared/TeamFlag';
+import { ADVANCER_COUNT, ADVANCER_RANK_LABELS } from '@/lib/constants';
+import { cn } from '@/lib/utils';
+import type { Team, TournamentAdvancer } from '@/types/tournament';
+
+export interface AdvancersResultsProps {
+  advancers: TournamentAdvancer[];
+  teams: Team[];
+}
+
+const RANKS = Array.from({ length: ADVANCER_COUNT }, (_, i) => i + 1);
+
+export function AdvancersResults({ advancers, teams }: AdvancersResultsProps) {
+  const teamById = React.useMemo(
+    () => new Map(teams.map((t) => [t.id, t])),
+    [teams]
+  );
+  const teamByRank = React.useMemo(
+    () => new Map(advancers.map((a) => [a.rank, a.teamId])),
+    [advancers]
+  );
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {RANKS.map((rank) => {
+        const teamId = teamByRank.get(rank) ?? null;
+        const team = teamId ? (teamById.get(teamId) ?? null) : null;
+
+        return (
+          <Card
+            key={rank}
+            className={cn(team && 'border-green-500/50 bg-green-500/5 dark:bg-green-500/10')}
+            data-testid={`advancer-result-${rank}`}
+          >
+            <CardHeader className="pb-2">
+              <div className="flex items-center justify-between gap-2">
+                <CardTitle className="text-sm">{ADVANCER_RANK_LABELS[rank - 1]}</CardTitle>
+                <Badge variant="secondary">#{rank}</Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {team ? (
+                <span className="flex items-center gap-2 text-sm">
+                  <TeamFlag code={team.code} />
+                  <span className="truncate font-medium">{team.name}</span>
+                  <span className="text-muted-foreground ml-auto text-xs">
+                    Group {team.group}
+                  </span>
+                </span>
+              ) : (
+                <span className="text-muted-foreground text-sm italic">Pending</span>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/results/GroupStandingsResults.tsx
+++ b/frontend/src/components/results/GroupStandingsResults.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import * as React from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { TeamFlag } from '@/components/shared/TeamFlag';
+import { cn } from '@/lib/utils';
+import type { Group, GroupStanding, Team } from '@/types/tournament';
+
+export interface GroupStandingsResultsProps {
+  groups: Group[];
+  teams: Team[];
+  standings: GroupStanding[];
+}
+
+const POSITIONS = [
+  { key: 'firstTeamId', label: '1st' },
+  { key: 'secondTeamId', label: '2nd' },
+  { key: 'thirdTeamId', label: '3rd' },
+  { key: 'fourthTeamId', label: '4th' },
+] as const;
+
+export function GroupStandingsResults({
+  groups,
+  teams,
+  standings,
+}: GroupStandingsResultsProps) {
+  const teamById = React.useMemo(
+    () => new Map(teams.map((t) => [t.id, t])),
+    [teams]
+  );
+  const standingByGroup = React.useMemo(
+    () => new Map(standings.map((s) => [s.groupId, s])),
+    [standings]
+  );
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {groups.map((group) => {
+        const standing = standingByGroup.get(group.id) ?? null;
+        const posted = !!standing;
+
+        return (
+          <Card key={group.id} data-testid={`group-result-${group.id}`}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-base">{group.name}</CardTitle>
+                {posted ? (
+                  <Badge variant="default" className="bg-green-600">
+                    Final
+                  </Badge>
+                ) : (
+                  <Badge variant="secondary">Pending</Badge>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {POSITIONS.map(({ key, label }, idx) => {
+                const teamId = standing ? standing[key] : null;
+                const team = teamId ? (teamById.get(teamId) ?? null) : null;
+                // Top two finishers advance straight to the Round of 32.
+                const advances = idx < 2;
+
+                return (
+                  <div
+                    key={key}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm',
+                      advances && team && 'bg-primary/5'
+                    )}
+                  >
+                    <span className="text-muted-foreground w-7 shrink-0 text-xs font-medium">
+                      {label}
+                    </span>
+                    {team ? (
+                      <>
+                        <TeamFlag code={team.code} />
+                        <span className="truncate font-medium">{team.name}</span>
+                        <span className="text-muted-foreground ml-auto font-mono text-xs">
+                          {team.code}
+                        </span>
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground italic">—</span>
+                    )}
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/results/__tests__/ResultsDisplays.test.tsx
+++ b/frontend/src/components/results/__tests__/ResultsDisplays.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+
+import { GroupStandingsResults } from '../GroupStandingsResults';
+import { AdvancersResults } from '../AdvancersResults';
+import { fixtureGroups, fixtureTeams } from '@/test-utils/fixtures';
+import type { GroupStanding, TournamentAdvancer } from '@/types/tournament';
+
+describe('GroupStandingsResults', () => {
+  it('renders all 12 group cards as pending when no standings are posted', () => {
+    render(
+      <GroupStandingsResults groups={fixtureGroups} teams={fixtureTeams} standings={[]} />
+    );
+    // One card per group, all pending.
+    expect(screen.getByTestId('group-result-A')).toBeInTheDocument();
+    expect(screen.getByTestId('group-result-L')).toBeInTheDocument();
+    expect(screen.getAllByText('Pending')).toHaveLength(12);
+  });
+
+  it('renders the posted finishers for a group', () => {
+    const standings: GroupStanding[] = [
+      {
+        groupId: 'A',
+        firstTeamId: 'mex',
+        secondTeamId: 'kor',
+        thirdTeamId: 'rsa',
+        fourthTeamId: 'cze',
+      },
+    ];
+    render(
+      <GroupStandingsResults
+        groups={fixtureGroups}
+        teams={fixtureTeams}
+        standings={standings}
+      />
+    );
+    const card = screen.getByTestId('group-result-A');
+    expect(card).toHaveTextContent('Final');
+    expect(card).toHaveTextContent('Mexico');
+    expect(card).toHaveTextContent('South Korea');
+    expect(card).toHaveTextContent('South Africa');
+    expect(card).toHaveTextContent('Czechia');
+  });
+});
+
+describe('AdvancersResults', () => {
+  it('renders 8 ranks all pending when none are posted', () => {
+    render(<AdvancersResults advancers={[]} teams={fixtureTeams} />);
+    expect(screen.getAllByText('Pending')).toHaveLength(8);
+    expect(screen.getByTestId('advancer-result-1')).toBeInTheDocument();
+    expect(screen.getByTestId('advancer-result-8')).toBeInTheDocument();
+  });
+
+  it('renders posted advancers with team name and group', () => {
+    const advancers: TournamentAdvancer[] = [
+      { rank: 1, teamId: 'jpn' },
+      { rank: 2, teamId: 'mar' },
+    ];
+    render(<AdvancersResults advancers={advancers} teams={fixtureTeams} />);
+    const first = screen.getByTestId('advancer-result-1');
+    expect(first).toHaveTextContent('Japan');
+    expect(first).toHaveTextContent('Group F');
+    const second = screen.getByTestId('advancer-result-2');
+    expect(second).toHaveTextContent('Morocco');
+    expect(second).toHaveTextContent('Group C');
+  });
+});

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -61,6 +61,7 @@ export const ROUTES = {
   home: '/',
   predictions: '/predictions',
   leaderboard: '/leaderboard',
+  results: '/results',
   login: '/login',
   register: '/register',
   forgotPassword: '/forgot-password',

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,7 +2,14 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { env } from '@/config/env';
 
-const PROTECTED_PREFIXES = ['/predictions', '/admin', '/account', '/referrals', '/rewards'];
+const PROTECTED_PREFIXES = [
+  '/predictions',
+  '/admin',
+  '/account',
+  '/referrals',
+  '/rewards',
+  '/results',
+];
 
 // Using the deprecated middleware.ts name (not Next 16's proxy.ts) because
 // @opennextjs/cloudflare doesn't yet support proxy. Track:


### PR DESCRIPTION
## Summary
- Adds a logged-in-only **`/results`** page that immutably tracks the real-world outcomes the admin enters: **group standings**, **best 3rd-place advancers**, and the **knockout bracket**. The bracket reuses the existing read-only `BracketView`, fed admin results (`group_standings` → group sources, `knockout_results` → match winners, `r32_bracket_assignments` → R32 3rd-place slots), so winners render with the trophy highlight. Updates live-on-load via React Query.
- **Nav reshuffle**: **Results** added to the main nav; **Admin** moved out of the main nav into the auth dropdown (admins only).
- **Quick access**: "View live results →" links added to the Predictions hub and Leaderboard headers so players can pop over and compare against their brackets.
- **Two new public read APIs** — `GET /api/knockout-results` and `GET /api/advancers` — mirroring the existing `/api/group-standings` route. No schema/RLS/RPC changes: all three result tables already have `SELECT USING (true)`.
- New purpose-built read-only display components (`GroupStandingsResults`, `AdvancersResults`) instead of disabled prediction forms, so the page reads as posted results rather than an inactive form.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (only pre-existing warnings)
- [x] `npm test` — 409 tests pass (added route tests for both new APIs, a display-component test covering populated + empty states, and `/results` middleware gating coverage)
- [x] `npm run build` — succeeds; `/results` + new APIs compile/SSR with no errors
- [x] Smoke test on dev: `/results` → `307 /login?next=/results` when signed out; both APIs return correctly-mapped data
- [ ] Visual check (reviewer): log in and visit `/results`; confirm group cards, ranked advancers, and bracket (winner trophies) reflect admin entries; confirm Admin link shows in the auth dropdown for an admin and Results shows in the nav