### PR TITLE
Dark-mode default + no flicker, knockout results hydration fix, fetchJSON DRY

### DIFF
--- a/frontend/src/app/admin/AdminDashboard.tsx
+++ b/frontend/src/app/admin/AdminDashboard.tsx
@@ -24,6 +24,7 @@ import { TeamFlag } from '@/components/shared/TeamFlag';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { fetchJSON } from '@/lib/api/fetchJSON';
 import type { LeaderboardEntry, Team } from '@/types/tournament';
 
 interface AdminStats {
@@ -57,12 +58,6 @@ interface AdminStats {
 interface LeaderboardResponse {
   entries: LeaderboardEntry[];
   total: number;
-}
-
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
-  return res.json();
 }
 
 const CAD = new Intl.NumberFormat('en-CA', {

--- a/frontend/src/app/admin/advancers/AdvancersForm.tsx
+++ b/frontend/src/app/admin/advancers/AdvancersForm.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { TeamFlag } from '@/components/shared/TeamFlag';
+import { fetchJSON } from '@/lib/api/fetchJSON';
 import type {
   AdvancerPrediction,
   KnockoutMatch,
@@ -42,12 +43,6 @@ interface GroupStandingRow {
 }
 
 const CLEAR_VALUE = '__CLEAR__';
-
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
-  return res.json();
-}
 
 type R32SourceShape =
   | { kind: 'group'; position: 1 | 2 | 3; groupId: string }

--- a/frontend/src/app/admin/results/AdminResults.tsx
+++ b/frontend/src/app/admin/results/AdminResults.tsx
@@ -7,16 +7,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { GroupStandingsEditor } from './GroupStandingsEditor';
 import { KnockoutResultsEditor } from './KnockoutResultsEditor';
 import { AdvancersForm } from '../advancers/AdvancersForm';
+import { fetchJSON } from '@/lib/api/fetchJSON';
 import type { Group, KnockoutMatch, Team } from '@/types/tournament';
 
 interface TournamentInfo {
   id: string;
-}
-
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
-  return res.json();
 }
 
 export function AdminResults() {

--- a/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
+++ b/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
@@ -66,6 +66,9 @@ export function KnockoutResultsEditor({
 }) {
   const queryClient = useQueryClient();
 
+  // No `initialData` here — pairing it with the global `staleTime: 60s` makes
+  // React Query treat the empty seed as fresh and skip the mount fetch, so
+  // saved results never appear until a manual invalidation (e.g. after a save).
   const results = useQuery<KnockoutResultRow[]>({
     queryKey: ['knockout-results', tournamentId],
     queryFn: async () => {
@@ -75,7 +78,6 @@ export function KnockoutResultsEditor({
       if (res && res.ok) return res.json();
       return [];
     },
-    initialData: [],
   });
 
   const standings = useQuery<GroupStandingRow[]>({
@@ -87,7 +89,6 @@ export function KnockoutResultsEditor({
       if (res && res.ok) return res.json();
       return [];
     },
-    initialData: [],
   });
 
   const bracket = useQuery<BracketAssignmentsResponse>({

--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -26,6 +26,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useAuthContext } from '@/providers/AuthProvider';
+import { fetchJSON } from '@/lib/api/fetchJSON';
 import type { KnockoutMatch } from '@/types/tournament';
 
 interface TournamentInfo {
@@ -56,12 +57,6 @@ interface GroupStandingRow {
 }
 
 const STATUSES = ['upcoming', 'group_stage', 'knockout', 'completed'] as const;
-
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
-  return res.json();
-}
 
 function toDatetimeLocal(iso: string | null): string {
   if (!iso) return '';

--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -23,6 +23,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
+import { fetchJSON } from '@/lib/api/fetchJSON';
 
 interface AdminPrediction {
   id: string;
@@ -45,12 +46,6 @@ interface AdminPredictionsResponse {
   tournament: { id: string; lockTime: string };
   user?: AdminUserSummary;
   predictions: AdminPrediction[];
-}
-
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
-  return res.json();
 }
 
 function toLocalDatetimeInput(iso: string): string {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -56,7 +56,7 @@ export default async function RootLayout({
   }
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" style={{ colorScheme: 'dark' }} suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
         <ThemeProvider>
           <QueryProvider>

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -32,6 +32,7 @@ import {
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
 import { FreePickBanner } from '@/components/predictions/FreePickBanner';
 import { PRICING, ROUTES } from '@/lib/constants';
+import { fetchJSON } from '@/lib/api/fetchJSON';
 
 interface ApiPrediction {
   id: string;
@@ -46,12 +47,6 @@ interface ApiPrediction {
 interface ApiResponse {
   tournament: { id: string; lockTime: string };
   predictions: ApiPrediction[];
-}
-
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
-  return res.json();
 }
 
 function formatTime(value: string | null) {

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -45,6 +45,7 @@ import { ADVANCER_COUNT } from '@/lib/constants';
 import { autofillGroupPredictionsByFifaRanking } from '@/lib/fifaRankings';
 import { applyGroupPositionChange } from '@/lib/groupSwap';
 import { AdvancersForm } from '@/components/predictions/AdvancersForm';
+import { fetchJSON } from '@/lib/api/fetchJSON';
 
 type PositionKey = 'first' | 'second' | 'third' | 'fourth';
 
@@ -195,12 +196,6 @@ interface PredictionsPageContentProps {
   redirectAfterSave?: string;
   /** Optional breadcrumb rendered above the title (used by admin pages). */
   breadcrumb?: React.ReactNode;
-}
-
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
-  return res.json();
 }
 
 function formatTimeRemaining(lockTime: Date): string {

--- a/frontend/src/app/results/ResultsPageContent.tsx
+++ b/frontend/src/app/results/ResultsPageContent.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { BracketView } from '@/components/predictions/BracketView';
 import { GroupStandingsResults } from '@/components/results/GroupStandingsResults';
 import { AdvancersResults } from '@/components/results/AdvancersResults';
+import { fetchJSON } from '@/lib/api/fetchJSON';
 import type {
   Group,
   GroupStanding,
@@ -22,12 +23,6 @@ interface KnockoutResultRow {
   winnerTeamId: string | null;
   loserTeamId: string | null;
   totalGoals: number | null;
-}
-
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
-  return res.json();
 }
 
 function Section({

--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -15,6 +15,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { BracketView } from '@/components/predictions/BracketView';
 import { TeamFlag } from '@/components/shared/TeamFlag';
+import { fetchJSON } from '@/lib/api/fetchJSON';
 import type {
   Group,
   KnockoutMatch,
@@ -46,12 +47,6 @@ export interface BracketPreviewDialogProps {
   /** e.g. '/api/predictions' or `/api/admin/users/${userId}/predictions`. */
   apiBasePath: string;
   onOpenChange: (open: boolean) => void;
-}
-
-async function fetchJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
-  return res.json();
 }
 
 export function BracketPreviewDialog({

--- a/frontend/src/lib/api/fetchJSON.ts
+++ b/frontend/src/lib/api/fetchJSON.ts
@@ -1,0 +1,10 @@
+/**
+ * Fetch JSON from an internal API route, surfacing the route's `error` field
+ * (set by our handlers via `safeMessage`) as the thrown Error message so
+ * React Query / callers get a useful message instead of a generic one.
+ */
+export async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) throw new Error((await res.json())?.error ?? res.statusText);
+  return res.json();
+}

--- a/frontend/src/providers/ThemeProvider.tsx
+++ b/frontend/src/providers/ThemeProvider.tsx
@@ -11,7 +11,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme="system"
+      defaultTheme="dark"
       enableSystem
       disableTransitionOnChange
     >

--- a/frontend/src/stores/__tests__/useAppStore.test.ts
+++ b/frontend/src/stores/__tests__/useAppStore.test.ts
@@ -8,7 +8,6 @@ describe('useAppStore', () => {
         isLoading: false,
         activeModal: null,
         isMobileMenuOpen: false,
-        theme: 'system',
         hasSeenOnboarding: false,
       });
     });
@@ -26,11 +25,6 @@ describe('useAppStore', () => {
     expect(useAppStore.getState().activeModal).toBe('prediction');
     act(() => useAppStore.getState().closeModal());
     expect(useAppStore.getState().activeModal).toBeNull();
-  });
-
-  it('updates theme preference', () => {
-    act(() => useAppStore.getState().setTheme('dark'));
-    expect(useAppStore.getState().theme).toBe('dark');
   });
 
   it('marks onboarding as seen', () => {

--- a/frontend/src/stores/useAppStore.ts
+++ b/frontend/src/stores/useAppStore.ts
@@ -10,7 +10,6 @@ interface UIState {
 }
 
 interface PreferencesState {
-  theme: 'light' | 'dark' | 'system';
   hasSeenOnboarding: boolean;
 }
 
@@ -20,7 +19,6 @@ interface AppActions {
   closeModal: () => void;
   toggleMobileMenu: () => void;
   closeMobileMenu: () => void;
-  setTheme: (theme: PreferencesState['theme']) => void;
   setHasSeenOnboarding: (hasSeen: boolean) => void;
   resetUIState: () => void;
 }
@@ -34,7 +32,6 @@ const initialUIState: UIState = {
 };
 
 const initialPreferencesState: PreferencesState = {
-  theme: 'system',
   hasSeenOnboarding: false,
 };
 
@@ -55,7 +52,6 @@ export const useAppStore = create<AppState>()(
             'toggleMobileMenu'
           ),
         closeMobileMenu: () => set({ isMobileMenuOpen: false }, false, 'closeMobileMenu'),
-        setTheme: (theme) => set({ theme }, false, 'setTheme'),
         setHasSeenOnboarding: (hasSeen) =>
           set({ hasSeenOnboarding: hasSeen }, false, 'setHasSeenOnboarding'),
         resetUIState: () => set({ ...initialUIState }, false, 'resetUIState'),
@@ -63,7 +59,6 @@ export const useAppStore = create<AppState>()(
       {
         name: 'wc2026-app-store',
         partialize: (state) => ({
-          theme: state.theme,
           hasSeenOnboarding: state.hasSeenOnboarding,
         }),
       }
@@ -78,5 +73,4 @@ export const useAppStore = create<AppState>()(
 export const useIsLoading = () => useAppStore((state) => state.isLoading);
 export const useActiveModal = () => useAppStore((state) => state.activeModal);
 export const useIsMobileMenuOpen = () => useAppStore((state) => state.isMobileMenuOpen);
-export const useTheme = () => useAppStore((state) => state.theme);
 export const useHasSeenOnboarding = () => useAppStore((state) => state.hasSeenOnboarding);


### PR DESCRIPTION
## Summary

Addresses three site performance/quirk items:

1. **Knockout results form needed a save to hydrate** — `KnockoutResultsEditor` seeded its `results` and `group-standings` queries with `initialData: []`. Combined with the global `staleTime: 60s`, React Query treated the empty seed as fresh and **skipped the mount fetch**, so saved outcomes only appeared after re-saving one result. Removed `initialData` so the form fetches on mount (matches the pattern already documented in `GroupStandingsEditor`).

2. **Light → dark flicker on load + dark as default** — set `next-themes` `defaultTheme="dark"` and render the server `<html>` with `className="dark"` + `colorScheme: 'dark'` so the first painted frame is already dark. The light/dark/system toggle is unchanged.

3. **DRY cleanup (clear wins only)** — extracted 9 byte-for-byte copies of a local `fetchJSON<T>` helper into a single `lib/api/fetchJSON.ts`; removed the dead `theme` state from `useAppStore` (nothing read it — theming is owned by `next-themes`).

## Notes
- Pre-existing Prettier drift in the touched files was left as-is to avoid unrelated formatting churn; the new code is Prettier-clean.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (3 pre-existing warnings, unrelated)
- [x] `npm test` — 50 suites / 408 tests pass
- [ ] Manual: Admin → Results → Knockout tab shows existing saved winners immediately on load (no re-save needed)
- [ ] Manual: hard-refresh `/`, `/leaderboard`, `/predictions` — no light flash; dark is default for a fresh profile; toggle still cycles light → dark → system and persists