### PR TITLE
fix(predictions): resolve bracket preview R32 from group standings

### DIFF
--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -18,6 +18,7 @@ import { TeamFlag } from '@/components/shared/TeamFlag';
 import { fetchJSON } from '@/lib/api/fetchJSON';
 import type {
   Group,
+  GroupStanding,
   KnockoutMatch,
   R32BracketAssignment,
   Team,
@@ -87,8 +88,22 @@ export function BracketPreviewDialog({
   });
   const bracketAssignments = bracketQuery.data?.assignments ?? [];
 
+  // Phase 2: the editor builds the bracket against admin-entered standings, so
+  // the R32 slots must resolve from the same standings here (with the user's
+  // group predictions as the Phase 1 fallback) or the stored winners won't line
+  // up with the slots and nothing highlights in the Round of 32.
+  const standingsQuery = useQuery<{ standings: GroupStanding[] }>({
+    queryKey: ['group-standings'],
+    enabled: open,
+    queryFn: () => fetchJSON('/api/group-standings'),
+  });
+
   const ready =
-    predictionQuery.data && matchesQuery.data && teamsQuery.data && groupsQuery.data;
+    predictionQuery.data &&
+    matchesQuery.data &&
+    teamsQuery.data &&
+    groupsQuery.data &&
+    standingsQuery.data;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -158,6 +173,7 @@ export function BracketPreviewDialog({
                 winnerId: k.winner,
               }))}
               bracketAssignments={bracketAssignments}
+              groupStandings={standingsQuery.data?.standings ?? []}
             />
           </>
         )}

--- a/frontend/src/components/predictions/BracketView.tsx
+++ b/frontend/src/components/predictions/BracketView.tsx
@@ -9,6 +9,7 @@ import { formatSourcePair } from '@/lib/matchLabel';
 import { cn } from '@/lib/utils';
 import type {
   GroupPrediction,
+  GroupStanding,
   KnockoutMatch,
   KnockoutMatchPrediction,
   KnockoutStage,
@@ -22,6 +23,7 @@ interface BracketViewProps {
   groupPredictions: GroupPrediction[];
   knockoutPredictions: KnockoutMatchPrediction[];
   bracketAssignments?: R32BracketAssignment[];
+  groupStandings?: GroupStanding[];
 }
 
 const COLUMN_STAGES: Array<{ stage: KnockoutStage; label: string }> = [
@@ -51,6 +53,7 @@ function MatchNode({
   groupPredictions,
   knockoutPredictions,
   bracketAssignments,
+  groupStandings,
 }: {
   match: KnockoutMatch;
   matches: KnockoutMatch[];
@@ -58,20 +61,23 @@ function MatchNode({
   groupPredictions: GroupPrediction[];
   knockoutPredictions: KnockoutMatchPrediction[];
   bracketAssignments: R32BracketAssignment[];
+  groupStandings: GroupStanding[];
 }) {
   const team1Id = resolveTeamSource(
     match.team1Source,
     matches,
     groupPredictions,
     knockoutPredictions,
-    bracketAssignments
+    bracketAssignments,
+    groupStandings
   );
   const team2Id = resolveTeamSource(
     match.team2Source,
     matches,
     groupPredictions,
     knockoutPredictions,
-    bracketAssignments
+    bracketAssignments,
+    groupStandings
   );
   const winnerId =
     knockoutPredictions.find((p) => p.matchId === match.id)?.winnerId ?? null;
@@ -125,6 +131,7 @@ export function BracketView({
   groupPredictions,
   knockoutPredictions,
   bracketAssignments = [],
+  groupStandings = [],
 }: BracketViewProps) {
   const matchesByStage = React.useMemo(() => {
     const grouped: Record<KnockoutStage, KnockoutMatch[]> = {
@@ -171,6 +178,7 @@ export function BracketView({
                   groupPredictions={groupPredictions}
                   knockoutPredictions={knockoutPredictions}
                   bracketAssignments={bracketAssignments}
+                  groupStandings={groupStandings}
                 />
               ))}
             </div>
@@ -186,6 +194,7 @@ export function BracketView({
                   groupPredictions={groupPredictions}
                   knockoutPredictions={knockoutPredictions}
                   bracketAssignments={bracketAssignments}
+                  groupStandings={groupStandings}
                 />
               </div>
             )}

--- a/frontend/src/components/predictions/__tests__/BracketView.test.tsx
+++ b/frontend/src/components/predictions/__tests__/BracketView.test.tsx
@@ -63,4 +63,73 @@ describe('BracketView', () => {
     expect(within(m1).getByText('Mexico')).toBeInTheDocument();
     expect(within(m1).getByText('Qatar')).toBeInTheDocument();
   });
+
+  it('highlights the winner against the user group predictions when no standings are given', () => {
+    // M73 = "1A vs 2B": first of A (mex) vs second of B (qat). Winner mex.
+    const groupPredictions = [
+      { groupId: 'A', positions: { first: 'mex', second: 'kor', third: 'rsa', fourth: 'cze' } },
+      { groupId: 'B', positions: { first: 'sui', second: 'qat', third: 'bih', fourth: 'can' } },
+    ];
+
+    render(
+      <BracketView
+        matches={fixtureKnockoutMatches}
+        teams={fixtureTeams}
+        groupPredictions={groupPredictions}
+        knockoutPredictions={[{ matchId: 'M73', winnerId: 'mex' }]}
+      />
+    );
+
+    const m73 = screen.getByTestId('bracket-match-M73');
+    const winnerRow = within(m73).getByText('Mexico').closest('div');
+    expect(winnerRow).toHaveClass('text-primary');
+  });
+
+  it('resolves R32 slots from groupStandings when provided, highlighting the stored winner', () => {
+    // The bug: in Phase 2 the editor builds the bracket against admin standings,
+    // so a stored R32 winner is a standings-derived team. If the preview resolves
+    // R32 from the user's *predicted* standings instead, the winner matches no
+    // slot and nothing highlights. Passing groupStandings fixes it.
+    const groupPredictions = [
+      { groupId: 'A', positions: { first: 'mex', second: 'rsa', third: 'cze', fourth: 'kor' } },
+      { groupId: 'B', positions: { first: 'can', second: 'qat', third: 'bih', fourth: 'sui' } },
+    ];
+    // Actual standings differ: A first = kor, B second = sui. M73 = "1A vs 2B".
+    const groupStandings = [
+      {
+        groupId: 'A',
+        firstTeamId: 'kor',
+        secondTeamId: 'mex',
+        thirdTeamId: 'rsa',
+        fourthTeamId: 'cze',
+      },
+      {
+        groupId: 'B',
+        firstTeamId: 'can',
+        secondTeamId: 'sui',
+        thirdTeamId: 'qat',
+        fourthTeamId: 'bih',
+      },
+    ];
+    const knockoutPredictions = [{ matchId: 'M73', winnerId: 'kor' }];
+
+    render(
+      <BracketView
+        matches={fixtureKnockoutMatches}
+        teams={fixtureTeams}
+        groupPredictions={groupPredictions}
+        knockoutPredictions={knockoutPredictions}
+        groupStandings={groupStandings}
+      />
+    );
+
+    const m73 = screen.getByTestId('bracket-match-M73');
+    // Slots reflect the actual standings, not the user's predicted standings.
+    expect(within(m73).getByText('South Korea')).toBeInTheDocument();
+    expect(within(m73).getByText('Switzerland')).toBeInTheDocument();
+    expect(within(m73).queryByText('Mexico')).not.toBeInTheDocument();
+    // The stored winner (kor) now matches a slot and is highlighted.
+    const winnerRow = within(m73).getByText('South Korea').closest('div');
+    expect(winnerRow).toHaveClass('text-primary');
+  });
 });


### PR DESCRIPTION
## Summary
- The read-only bracket preview dialog showed **no highlighted picks in the Round of 32** while R16→Final rendered their selected winners correctly (reported for prediction `7d6cb778-c118-472c-8b38-407868307031`).
- Root cause: in Phase 2 the editor (`KnockoutBracket`) resolves R32 group slots (`"1E"`, `"2I"`, …) against the **admin's actual group standings**, so stored R32 winners are standings-derived teams. The preview (`BracketView`) called `resolveTeamSource` **without** `groupStandings`, rebuilding R32 from the user's *predicted* standings — different teams — so the stored winners matched no slot and nothing highlighted. Downstream rounds resolve straight from stored winners, so they looked fine.
- Fix: add an optional `groupStandings` prop to `BracketView` and have `BracketPreviewDialog` fetch `/api/group-standings` and pass it, mirroring the editor. `resolveTeamSource` falls back to the user's group predictions when standings are absent, so Phase 1 previews are unchanged. No DB/RPC/migration changes.

This also keeps the preview consistent with scoring, which evaluates knockout picks against the actual standings-based bracket.

## Test plan
- [x] `npm test` — 410 passing, incl. new `BracketView` cases:
  - standings differ from predictions + stored winner matches the standings-derived slot → slot highlighted
  - no `groupStandings` → winner still highlights against group predictions (fallback unchanged)
- [x] `npm run typecheck` clean
- [x] `npm run lint` — no new warnings/errors
- [ ] Manual: open the preview for a Phase-2 prediction whose predicted standings differ from admin standings; confirm R32 now shows the standings-based matchups with the user's winners highlighted, and R16 feeders line up with the R32 winners. (Needs Phase-2 data — verify on a preview deploy.)