### PR TITLE
feat(predictions): Phase 1 picks in bracket preview + drop group-pick fallback

### DIFF
--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -14,6 +14,8 @@ import {
 } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BracketView } from '@/components/predictions/BracketView';
+import { GroupStandingsResults } from '@/components/results/GroupStandingsResults';
+import { AdvancersResults } from '@/components/results/AdvancersResults';
 import { TeamFlag } from '@/components/shared/TeamFlag';
 import { fetchJSON } from '@/lib/api/fetchJSON';
 import type {
@@ -41,6 +43,7 @@ interface PredictionDetail {
     fourth: string | null;
   }>;
   knockout: Array<{ matchId: string; winner: string | null }>;
+  advancers: Array<{ rank: number; teamId: string }>;
 }
 
 export interface BracketPreviewDialogProps {
@@ -130,7 +133,8 @@ export function BracketPreviewDialog({
             )}
           </DialogTitle>
           <DialogDescription>
-            Read-only preview of the bracket as predicted. Empty slots show as TBD.
+            Read-only preview of this prediction — Phase 1 group-stage and best-3rd picks,
+            then the Phase 2 knockout bracket. Empty slots show as TBD.
           </DialogDescription>
         </DialogHeader>
 
@@ -156,29 +160,66 @@ export function BracketPreviewDialog({
               totalGoals={predictionQuery.data!.totalGoals}
               teams={teamsQuery.data!}
             />
-            <BracketView
-              matches={matchesQuery.data!}
-              teams={teamsQuery.data!}
-              groupPredictions={(predictionQuery.data!.groups ?? []).map((g) => ({
-                groupId: g.groupId,
-                positions: {
-                  first: g.first,
-                  second: g.second,
-                  third: g.third,
-                  fourth: g.fourth,
-                },
-              }))}
-              knockoutPredictions={(predictionQuery.data!.knockout ?? []).map((k) => ({
-                matchId: k.matchId,
-                winnerId: k.winner,
-              }))}
-              bracketAssignments={bracketAssignments}
-              groupStandings={standingsQuery.data?.standings ?? []}
-            />
+
+            <PreviewSection title="Phase 1 — Group Stage">
+              <GroupStandingsResults
+                groups={groupsQuery.data!}
+                teams={teamsQuery.data!}
+                standings={(predictionQuery.data!.groups ?? []).map((g) => ({
+                  groupId: g.groupId,
+                  firstTeamId: g.first,
+                  secondTeamId: g.second,
+                  thirdTeamId: g.third,
+                  fourthTeamId: g.fourth,
+                }))}
+                showStatusBadge={false}
+              />
+            </PreviewSection>
+
+            <PreviewSection title="Phase 1 — Best 3rd-Place Advancers">
+              <AdvancersResults
+                advancers={predictionQuery.data!.advancers ?? []}
+                teams={teamsQuery.data!}
+              />
+            </PreviewSection>
+
+            <PreviewSection title="Phase 2 — Knockout Bracket">
+              <BracketView
+                matches={matchesQuery.data!}
+                teams={teamsQuery.data!}
+                // The preview resolves the bracket strictly from the admin's
+                // standings (Phase 2). The user's Phase-1 group picks are shown
+                // in the section above, so we deliberately omit them here —
+                // group slots render as TBD until standings are posted rather
+                // than as a what-if shape derived from those picks.
+                groupPredictions={[]}
+                knockoutPredictions={(predictionQuery.data!.knockout ?? []).map((k) => ({
+                  matchId: k.matchId,
+                  winnerId: k.winner,
+                }))}
+                bracketAssignments={bracketAssignments}
+                groupStandings={standingsQuery.data?.standings ?? []}
+              />
+            </PreviewSection>
           </>
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function PreviewSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      {children}
+    </section>
   );
 }
 

--- a/frontend/src/components/results/GroupStandingsResults.tsx
+++ b/frontend/src/components/results/GroupStandingsResults.tsx
@@ -12,6 +12,12 @@ export interface GroupStandingsResultsProps {
   groups: Group[];
   teams: Team[];
   standings: GroupStanding[];
+  /**
+   * Show the per-group "Final"/"Pending" status badge. Defaults to true for
+   * the official /results view. Set false when rendering a user's predictions
+   * (e.g. the bracket preview), where that results-only status has no meaning.
+   */
+  showStatusBadge?: boolean;
 }
 
 const POSITIONS = [
@@ -25,6 +31,7 @@ export function GroupStandingsResults({
   groups,
   teams,
   standings,
+  showStatusBadge = true,
 }: GroupStandingsResultsProps) {
   const teamById = React.useMemo(
     () => new Map(teams.map((t) => [t.id, t])),
@@ -46,13 +53,14 @@ export function GroupStandingsResults({
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
                 <CardTitle className="text-base">{group.name}</CardTitle>
-                {posted ? (
-                  <Badge variant="default" className="bg-green-600">
-                    Final
-                  </Badge>
-                ) : (
-                  <Badge variant="secondary">Pending</Badge>
-                )}
+                {showStatusBadge &&
+                  (posted ? (
+                    <Badge variant="default" className="bg-green-600">
+                      Final
+                    </Badge>
+                  ) : (
+                    <Badge variant="secondary">Pending</Badge>
+                  ))}
               </div>
             </CardHeader>
             <CardContent className="space-y-2">

--- a/frontend/src/components/results/__tests__/ResultsDisplays.test.tsx
+++ b/frontend/src/components/results/__tests__/ResultsDisplays.test.tsx
@@ -40,6 +40,30 @@ describe('GroupStandingsResults', () => {
     expect(card).toHaveTextContent('South Africa');
     expect(card).toHaveTextContent('Czechia');
   });
+
+  it('hides the status badge when showStatusBadge is false (prediction view)', () => {
+    const standings: GroupStanding[] = [
+      {
+        groupId: 'A',
+        firstTeamId: 'mex',
+        secondTeamId: 'kor',
+        thirdTeamId: 'rsa',
+        fourthTeamId: 'cze',
+      },
+    ];
+    render(
+      <GroupStandingsResults
+        groups={fixtureGroups}
+        teams={fixtureTeams}
+        standings={standings}
+        showStatusBadge={false}
+      />
+    );
+    expect(screen.queryByText('Final')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+    // Finishers still render — only the results-only status badge is gone.
+    expect(screen.getByTestId('group-result-A')).toHaveTextContent('Mexico');
+  });
 });
 
 describe('AdvancersResults', () => {


### PR DESCRIPTION
## Summary
- **Show Phase 1 picks in the bracket preview.** `BracketPreviewDialog` now renders the prediction's group-stage standings and Best 3rd-place advancers above the Phase 2 knockout bracket, reusing `GroupStandingsResults` + `AdvancersResults`.
- **Drop the preview's group-pick fallback.** The preview no longer feeds the user's group predictions into the resolver — knockout slots resolve strictly from admin standings (TBD when absent), instead of a what-if shape derived from Phase 1 picks. The shared resolver, `/results`, and the live knockout editor are intentionally untouched.
- `GroupStandingsResults` gains an optional `showStatusBadge` prop (default `true`) so the preview can hide the results-only Final/Pending badge; `/results` behavior is unchanged.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (only pre-existing warnings in `coverage/` + `jest.setup.tsx`)
- [x] `npm test` — 410/410 passing, plus a new assertion that the status badge is hidden when `showStatusBadge={false}`
- [ ] Manual on prod: preview a paid prediction from the leaderboard and the admin user page — confirm Group Stage + Top 8 Thirds render above the bracket, Phase 2 still resolves from admin standings and highlights knockout winners. Note: a legacy prediction with no saved advancers shows the 8 thirds slots as "Pending".