### PR TITLE
feat(charity): per-charity logo breakdown in pool stats bar

### DIFF
--- a/frontend/src/app/charities/[slug]/page.tsx
+++ b/frontend/src/app/charities/[slug]/page.tsx
@@ -79,7 +79,7 @@ export default async function CharityDetailPage({
       </div>
 
       <section className="py-8 text-center md:py-12">
-        <div className="bg-muted/30 mx-auto mb-6 flex h-40 w-full max-w-md items-center justify-center rounded-lg p-6">
+        <div className="border-border mx-auto mb-6 flex h-40 w-full max-w-md items-center justify-center rounded-lg border bg-white p-6">
           <Image
             src={charity.logo}
             alt={`${charity.name} logo`}

--- a/frontend/src/app/charities/page.tsx
+++ b/frontend/src/app/charities/page.tsx
@@ -43,7 +43,7 @@ export default function CharitiesPage() {
           {CHARITIES.map((charity) => (
             <Card key={charity.slug} className="flex flex-col">
               <CardHeader>
-                <div className="bg-muted/30 mb-4 flex h-32 items-center justify-center rounded-lg p-4">
+                <div className="border-border mb-4 flex h-32 items-center justify-center rounded-lg border bg-white p-4">
                   <Image
                     src={charity.logo}
                     alt={`${charity.name} logo`}

--- a/frontend/src/components/layout/PoolStatsBar.tsx
+++ b/frontend/src/components/layout/PoolStatsBar.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import Image from 'next/image';
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { CircleDollarSign, HeartHandshake } from 'lucide-react';
+import { CircleDollarSign } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
-import { ROUTES } from '@/lib/constants';
+import { CHARITIES, ROUTES } from '@/lib/constants';
 import { useAuthContext } from '@/providers/AuthProvider';
 
 interface TournamentSlice {
@@ -18,6 +20,20 @@ const POT_FORMATTER = new Intl.NumberFormat('en-CA', {
   currency: 'CAD',
   maximumFractionDigits: 0,
 });
+
+// Per-charity shares can be fractional when the entry count is odd (the $5/entry
+// charity portion splits to $2.50). Show cents only when present ($17.50) so the
+// shares sum back to the total instead of each rounding up; whole shares stay clean
+// ($103) via the pot formatter.
+const CHARITY_CENTS_FORMATTER = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const formatCharityShare = (value: number) =>
+  (Number.isInteger(value) ? POT_FORMATTER : CHARITY_CENTS_FORMATTER).format(value);
 
 // Tournament-facing pages where pool stats are contextually relevant.
 // Admin / account / auth / marketing pages stay clean.
@@ -39,8 +55,9 @@ export function isPoolStatsVisiblePath(pathname: string): boolean {
 
 /**
  * Slim sticky strip directly under the main Header showing the live pot total
- * and the charity-raised total. Shares the ['tournament'] React Query cache
- * key with HomePageContent so no extra request is issued when both mount on /.
+ * and the charity-raised total, broken down evenly across the supported
+ * charities. Shares the ['tournament'] React Query cache key with
+ * HomePageContent so no extra request is issued when both mount on /.
  */
 export function PoolStatsBar({ className }: { className?: string }) {
   const pathname = usePathname();
@@ -59,12 +76,14 @@ export function PoolStatsBar({ className }: { className?: string }) {
   if (!user || !query.data) return null;
 
   const pot = POT_FORMATTER.format(query.data.potTotalCAD);
-  const charity = POT_FORMATTER.format(query.data.charityTotalCAD);
+  const perCharity = formatCharityShare(query.data.charityTotalCAD / CHARITIES.length);
 
   return (
     <div
       role="status"
-      aria-label={`Pot total ${pot}, raised for charity ${charity}`}
+      aria-label={`Pot total ${pot}; charity total: ${CHARITIES.map(
+        (c) => `${c.name} ${perCharity}`
+      ).join(', ')}`}
       className={cn(
         'border-border bg-muted/40 supports-[backdrop-filter]:bg-muted/30 sticky top-16 z-40 w-full border-b backdrop-blur',
         className
@@ -78,12 +97,27 @@ export function PoolStatsBar({ className }: { className?: string }) {
             {pot}
           </span>
         </span>
-        <span className="flex items-center gap-1.5">
-          <HeartHandshake className="h-4 w-4" aria-hidden />
-          <span className="text-foreground font-medium">
-            <span className="hidden sm:inline">Charity </span>
-            {charity}
-          </span>
+        <span className="flex items-center gap-2 sm:gap-3">
+          <span className="text-foreground hidden font-medium sm:inline">Charity Total:</span>
+          {CHARITIES.map((charity) => (
+            <Link
+              key={charity.slug}
+              href={`${ROUTES.charities}/${charity.slug}`}
+              aria-label={`${charity.name}: ${perCharity} for charity`}
+              className="hover:text-foreground flex items-center gap-1.5"
+            >
+              <span className="border-border flex h-5 items-center justify-center rounded border bg-white px-1">
+                <Image
+                  src={charity.logo}
+                  alt={`${charity.name} logo`}
+                  width={48}
+                  height={20}
+                  className="h-3.5 w-auto max-w-[72px] object-contain sm:h-4"
+                />
+              </span>
+              <span className="text-foreground font-medium">{perCharity}</span>
+            </Link>
+          ))}
         </span>
       </div>
     </div>

--- a/frontend/src/components/layout/__tests__/PoolStatsBar.test.tsx
+++ b/frontend/src/components/layout/__tests__/PoolStatsBar.test.tsx
@@ -70,14 +70,36 @@ describe('isPoolStatsVisiblePath', () => {
 });
 
 describe('PoolStatsBar', () => {
-  it('renders pot and charity totals on a tournament-facing page', async () => {
+  it('renders the pot total and a per-charity breakdown on a tournament-facing page', async () => {
     mockPathname = '/predictions';
-    mockTournamentResponse(1240, 206);
+    mockTournamentResponse(1240, 206); // 206 / 2 charities = 103 each
     render(wrap(<PoolStatsBar />));
     await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
     const bar = screen.getByRole('status');
     expect(bar).toHaveTextContent(/\$1,240/);
-    expect(bar).toHaveTextContent(/\$206/);
+    expect(bar).toHaveTextContent('Charity Total:');
+
+    // Each charity's half-share shows (no standalone aggregate $206).
+    expect(bar).not.toHaveTextContent(/\$206/);
+    expect(screen.getAllByText('$103')).toHaveLength(2);
+
+    // Each logo carries alt text and links to its internal detail page.
+    expect(screen.getByAltText('Canadian Cancer Society logo')).toBeInTheDocument();
+    expect(screen.getByAltText('Islamic Relief Canada logo')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Canadian Cancer Society: \$103 for charity/ })
+    ).toHaveAttribute('href', '/charities/canadian-cancer-society');
+    expect(
+      screen.getByRole('link', { name: /Islamic Relief Canada: \$103 for charity/ })
+    ).toHaveAttribute('href', '/charities/islamic-relief-canada');
+  });
+
+  it('shows cents on the per-charity share when the total splits unevenly', async () => {
+    mockPathname = '/predictions';
+    mockTournamentResponse(210, 35); // 35 / 2 = 17.50 each
+    render(wrap(<PoolStatsBar />));
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    expect(screen.getAllByText('$17.50')).toHaveLength(2);
   });
 
   it('renders nothing on an admin route', () => {

--- a/frontend/src/components/marketing/DonationsToCharity.tsx
+++ b/frontend/src/components/marketing/DonationsToCharity.tsx
@@ -30,7 +30,7 @@ export function DonationsToCharity() {
                 key={charity.slug}
                 className="bg-muted/20 rounded-lg border p-4"
               >
-                <div className="bg-background mb-3 flex h-20 items-center justify-center rounded p-2">
+                <div className="border-border mb-3 flex h-20 items-center justify-center rounded border bg-white p-2">
                   <Image
                     src={charity.logo}
                     alt={`${charity.name} logo`}


### PR DESCRIPTION
## Summary
- Replaces the single aggregate "Charity $X" figure in the sticky pool stats strip (`PoolStatsBar`) with a `Charity Total:` label followed by each charity's logo and its even share of the charitable sum (50/50 today, generalized to `charityTotalCAD / CHARITIES.length`).
- Each logo carries alt text (`<Charity name> logo`) and links to its internal detail page (`/charities/<slug>`), with an `aria-label` on the link and an updated container `role="status"` label.
- Per-charity shares show cents only when the split is uneven (e.g. `$17.50`); whole shares stay clean (`$103`) so the two shares always sum to the total.
- No API, constants, route, or asset changes — `charityTotalCAD`, the `CHARITIES` constant, the logo assets, and the `/charities/[slug]` pages all already exist.

## Test plan
- [x] `npx jest PoolStatsBar` — updated unit test asserts the label, two per-charity shares, logo alt text, and the two `/charities/<slug>` links; added a case for the uneven-split cents formatting.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new warnings.
- [ ] Manual: log in, visit `/predictions` (or `/`, `/leaderboard`); confirm the strip shows `Pot $X` then `Charity Total:` with both charity logos + half amounts; logos legible in light/dark mode; clicking each navigates to the correct charity page; no mobile overflow.