### PR TITLE
chore: track pre-push hook blocking direct pushes to main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Block direct pushes to protected branches. All changes go through a PR.
+# Bypass intentionally with: git push --no-verify  (don't make a habit of it)
+#
+# This hook is tracked in the repo. Activate it once per clone with:
+#     git config core.hooksPath .githooks
+
+protected="main"
+remote="$1"
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+	case "$remote_ref" in
+	refs/heads/*)
+		branch=${remote_ref#refs/heads/}
+		for p in $protected; do
+			if [ "$branch" = "$p" ]; then
+				echo >&2 "✋ pre-push: direct push to '$p' on '$remote' is blocked."
+				echo >&2 "   Create a feature branch and open a PR instead:"
+				echo >&2 "     git switch -c my-feature"
+				echo >&2 "     git push -u origin my-feature"
+				echo >&2 "   (override with --no-verify if you really must)"
+				exit 1
+			fi
+		done
+		;;
+	esac
+done
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ SUPABASE_SERVICE_ROLE_KEY=
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 ```
 
+### Git hooks (one-time, per clone)
+
+This repo ships a tracked `pre-push` hook that blocks accidental direct pushes to `main`
+(all changes go through a PR). Git hooks aren't enabled automatically on clone — activate
+them once with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Bypass intentionally with `git push --no-verify`. `main` is also protected server-side on
+GitHub, so this is just for faster local feedback.
+
 ## Frontend scripts
 
 Run from `frontend/`:


### PR DESCRIPTION
## What

Adds a tracked `pre-push` git hook so the "no direct pushes to `main`" rule has a guard that survives re-clones (it lives in the repo, not `.git/hooks/`).

- `.githooks/pre-push` (executable, `100755`) — aborts any push whose remote ref is `refs/heads/main` with a message pointing to the branch + PR flow. Bypassable with `--no-verify`.
- `README.md` — documents the one-time per-clone activation: `git config core.hooksPath .githooks`.

## Why

Direct pushes to `main` slipped through. `main` is now protected server-side on GitHub (PR required, `enforce_admins: true`); this hook is the faster local guard that catches the mistake before it leaves the machine.

## Verified

- Hook returns exit 1 for `refs/heads/main`, exit 0 for feature branches.
- Executable bit is tracked in the index, so it works on fresh clones (after the `core.hooksPath` step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)