### PR TITLE
feat(ux): leaderboard edit link, prediction breadcrumb, phase 2 preview, locked-step icons

### DIFF
--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/hooks/useAuth';
+import { useTournamentLock } from '@/hooks/useTournamentLock';
 import { ROUTES } from '@/lib/constants';
 import type { LeaderboardEntry, LeaderboardRankMatch } from '@/types/tournament';
 
@@ -45,6 +46,7 @@ interface LeaderboardResponse {
 
 export function LeaderboardPageContent() {
   const { user, profile } = useAuth();
+  const { isLocked } = useTournamentLock();
   const [currentPage, setCurrentPage] = React.useState(1);
   const [highlightedRank, setHighlightedRank] = React.useState<number | null>(null);
 
@@ -202,6 +204,8 @@ export function LeaderboardPageContent() {
               currentUsername={currentUsername}
               highlightedRank={highlightedRank}
               enablePreview={!!user}
+              // Edit deep-link only while predictions are still editable.
+              enableEdit={!!user && !isLocked}
             />
           )}
         </CardContent>

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -3,10 +3,11 @@
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, ArrowRight, Clock, Save } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Clock, Eye, Save } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { PageLayout } from '@/components/layout/PageLayout';
+import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
 import { ChampionPickForm } from '@/components/predictions/ChampionPickForm';
 import { GroupStageForm } from '@/components/predictions/GroupStageForm';
 import { KnockoutBracket } from '@/components/predictions/KnockoutBracket';
@@ -118,6 +119,16 @@ const TOP_STEP_LABELS: Record<TopStep, string> = {
   champion_pick: 'Gut Feeling',
   knockout: 'Knockout',
   tiebreaker: 'Tiebreaker',
+};
+
+// A representative concrete Step for each top tab, used to test whether the
+// tab's phase is locked (the Knockout tab fans out into per-stage sub-steps).
+const TOP_STEP_REP: Record<TopStep, Step> = {
+  groups: 'groups',
+  best_thirds: 'best_thirds',
+  champion_pick: 'champion_pick',
+  knockout: 'round_of_32',
+  tiebreaker: 'tiebreaker',
 };
 
 function isKnockoutStage(step: Step): step is KnockoutStage {
@@ -313,6 +324,27 @@ export function PredictionsPageContent({
   // stranding super admin on the Groups step in the admin editor.
   const bypassLockNav = isSuperAdmin;
 
+  // A step is "locked" when its phase's edit window is closed for this user.
+  // Phase 1 steps (Group Stage / Best 3rds / Gut Feeling) freeze once Phase 2
+  // opens; Phase 2 steps (Knockout / Tiebreaker) stay locked until Phase 2
+  // opens. Super admin edits any field in any phase, so nothing locks for
+  // them. In the fully-locked read-only phases (phase1_locked / phase2_locked)
+  // nothing is step-locked either — users keep browsing every section via the
+  // stepper and Back / Continue (the forms themselves render read-only).
+  const isStepLocked = React.useCallback(
+    (step: Step): boolean => {
+      if (isSuperAdmin) return false;
+      const top = topOf(step);
+      const isPhase1Step =
+        top === 'groups' || top === 'best_thirds' || top === 'champion_pick';
+      const isPhase2Step = top === 'knockout' || top === 'tiebreaker';
+      if (phase === 'phase2_open' && isPhase1Step) return true;
+      if (phase === 'phase1' && isPhase2Step) return true;
+      return false;
+    },
+    [isSuperAdmin, phase]
+  );
+
   const tournamentQuery = useQuery<{
     id: string;
     slug: string;
@@ -385,6 +417,7 @@ export function PredictionsPageContent({
   // visible — distinct from the localStorage draft time (`lastSavedAt`).
   const [lastServerSaveAt, setLastServerSaveAt] = React.useState<Date | null>(null);
   const [autoCommitFailed, setAutoCommitFailed] = React.useState(false);
+  const [previewOpen, setPreviewOpen] = React.useState(false);
 
   // Once we know the phase and have hydrated, jump straight to Round of 32
   // when phase 2 is open — group + advancer + champion picks are frozen at
@@ -649,14 +682,12 @@ export function PredictionsPageContent({
 
   const topValue: TopStep = topOf(currentStep);
 
-  // In Phase 1 regular users can't edit Phase 2 fields, so the Knockout
-  // and Tiebreaker tabs are visually locked. Super admin can edit any
-  // field in any phase, so they keep full access.
-  const phase2TabsLocked = phase === 'phase1' && !isSuperAdmin;
-
+  // Tabs whose phase is closed for this user render a lock icon and become
+  // non-interactive (see `isStepLocked`): Phase 2 tabs during Phase 1, and the
+  // Phase 1 tabs once Phase 2 is open. Super admin keeps full access.
   const topSteps: StepperStep[] = TOP_STEPS.map((value) => {
     let status: StepperStep['status'];
-    if (phase2TabsLocked && (value === 'knockout' || value === 'tiebreaker')) {
+    if (isStepLocked(TOP_STEP_REP[value])) {
       status = 'locked';
     } else if (value === topValue) {
       status = 'current';
@@ -827,16 +858,29 @@ export function PredictionsPageContent({
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [currentStep]);
 
+  // Walk STEP_ORDER from the current step in `dir`, skipping locked steps so
+  // Back / Continue never strand the user on a frozen phase (e.g. Back from
+  // Round of 32 in Phase 2 skips the locked Phase 1 steps and finds nothing
+  // before it, disabling Back).
+  const findAdjacentUnlockedStep = (dir: 1 | -1): Step | null => {
+    let idx = STEP_ORDER.indexOf(currentStep) + dir;
+    while (idx >= 0 && idx < STEP_ORDER.length) {
+      if (!isStepLocked(STEP_ORDER[idx])) return STEP_ORDER[idx];
+      idx += dir;
+    }
+    return null;
+  };
+
   const goToNextStep = () => {
-    const idx = STEP_ORDER.indexOf(currentStep);
-    if (idx < 0 || idx >= STEP_ORDER.length - 1) return;
-    navigateWithAutosave(() => goToStep(STEP_ORDER[idx + 1]));
+    const target = findAdjacentUnlockedStep(1);
+    if (!target) return;
+    navigateWithAutosave(() => goToStep(target));
   };
 
   const goToPreviousStep = () => {
-    const idx = STEP_ORDER.indexOf(currentStep);
-    if (idx <= 0) return;
-    navigateWithAutosave(() => goToStep(STEP_ORDER[idx - 1]));
+    const target = findAdjacentUnlockedStep(-1);
+    if (!target) return;
+    navigateWithAutosave(() => goToStep(target));
   };
 
   const persist = async ({
@@ -1062,6 +1106,16 @@ export function PredictionsPageContent({
     })();
   };
 
+  // Open the full read-only preview. The dialog fetches from the server, so
+  // flush any pending edits first (when a save is warranted) — otherwise the
+  // preview would show the last-saved snapshot, not what's on screen.
+  const handleOpenPreview = async () => {
+    if (canAutosave()) {
+      await persist({ markSubmitted: false, silent: true });
+    }
+    setPreviewOpen(true);
+  };
+
   // Auto-commit edits to an ALREADY-submitted prediction. A draft lives in
   // localStorage until the user navigates/submits, but a submitted prediction
   // is live on the leaderboard and shown in the preview dialog, so its edits
@@ -1110,11 +1164,15 @@ export function PredictionsPageContent({
   }
 
   const stepIndex = STEP_ORDER.indexOf(currentStep);
-  const isFirstStep = stepIndex === 0;
+  // Back / Continue target the nearest *unlocked* neighbour so a frozen phase
+  // is stepped over rather than landed on.
+  const nextUnlockedStep = findAdjacentUnlockedStep(1);
+  const prevUnlockedStep = findAdjacentUnlockedStep(-1);
+  const isFirstStep = prevUnlockedStep === null;
   const isLastStep = stepIndex === STEP_ORDER.length - 1;
   const currentStepComplete = stepStatus[currentStep];
-  const nextStepLabel = !isLastStep ? STEP_LABELS[STEP_ORDER[stepIndex + 1]] : null;
-  const previousStepLabel = !isFirstStep ? STEP_LABELS[STEP_ORDER[stepIndex - 1]] : null;
+  const nextStepLabel = nextUnlockedStep ? STEP_LABELS[nextUnlockedStep] : null;
+  const previousStepLabel = prevUnlockedStep ? STEP_LABELS[prevUnlockedStep] : null;
   // Bottom-nav action layout for the Gut Feeling Champion step in Phase 1
   // (the final Phase-1 step):
   //   - Regular users: "Save Phase 1 Picks" only. Knockout steps are
@@ -1143,6 +1201,11 @@ export function PredictionsPageContent({
   // locked read-only view. Reuses persist()'s name + champion validation.
   const showSaveProgressInline =
     !showSavePhase1 && !showReviewSubmit && !lockedReadOnly;
+  // Phase 2 only: let the user pull up the FULL prediction (both phases,
+  // read-only) at any point in the knockout flow. Needs a persisted prediction
+  // to fetch, so it's edit-mode + an existing id.
+  const isPhase2 = phase === 'phase2_open' || phase === 'phase2_locked';
+  const showPreview = isPhase2 && mode === 'edit' && !!predictionId;
 
   return (
     <PageLayout>
@@ -1336,6 +1399,18 @@ export function PredictionsPageContent({
             <ArrowLeft className="mr-2 h-4 w-4" />
             {previousStepLabel ? `Back: ${previousStepLabel}` : 'Back'}
           </Button>
+          {showPreview && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleOpenPreview}
+              disabled={isSubmitting || isSavingProgress}
+              className="sm:w-auto"
+            >
+              <Eye className="mr-2 h-4 w-4" />
+              Preview prediction
+            </Button>
+          )}
           <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
             {showSaveProgressInline && (
               <Button
@@ -1397,6 +1472,13 @@ export function PredictionsPageContent({
         </div>
       </div>
 
+      {showPreview && (
+        <BracketPreviewDialog
+          predictionId={previewOpen ? (predictionId ?? null) : null}
+          apiBasePath={effectiveApiBasePath}
+          onOpenChange={setPreviewOpen}
+        />
+      )}
     </PageLayout>
   );
 }

--- a/frontend/src/app/predictions/[id]/page.tsx
+++ b/frontend/src/app/predictions/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from 'next/navigation';
 
 import { getServerSupabase } from '@/lib/supabase/server';
 import { ROUTES } from '@/lib/constants';
+import { AdminBreadcrumb } from '@/components/admin/AdminBreadcrumb';
 import { PredictionsPageContent, type InitialPrediction } from '../PredictionsPageContent';
 
 export const metadata: Metadata = {
@@ -87,5 +88,19 @@ export default async function EditPredictionPage({ params }: PageProps) {
     })),
   };
 
-  return <PredictionsPageContent mode="edit" predictionId={id} initial={initial} />;
+  return (
+    <PredictionsPageContent
+      mode="edit"
+      predictionId={id}
+      initial={initial}
+      breadcrumb={
+        <AdminBreadcrumb
+          items={[
+            { label: 'My Predictions', href: ROUTES.predictions },
+            { label: p.prediction_name },
+          ]}
+        />
+      }
+    />
+  );
 }

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -287,6 +287,10 @@ describe('PredictionsPageContent — stepper navigation', () => {
   });
 
   it('advances Groups → Best 3rds → Gut Feeling Champion → Round of 32 via Continue (phase 2 open)', async () => {
+    // Regular users have the Phase 1 tabs locked once Phase 2 opens, so the
+    // full cross-phase Continue chain is exercised as super admin (the only
+    // role that keeps editing every phase through the locks).
+    mockAuthProfile = { isSuperAdmin: true };
     configureQueries({ phase: 'phase2_open' });
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
@@ -391,6 +395,9 @@ describe('PredictionsPageContent — stepper navigation', () => {
   });
 
   it('walks through every step with Continue and reaches the tiebreaker (phase 2 open)', async () => {
+    // As above: the full Phase 1 → knockout → tiebreaker chain is super-admin
+    // only in Phase 2, since regular users have the Phase 1 tabs locked.
+    mockAuthProfile = { isSuperAdmin: true };
     configureQueries({ phase: 'phase2_open' });
     const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
@@ -425,6 +432,20 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(
       screen.getAllByRole('button', { name: /Submit Prediction/i }).length
     ).toBeGreaterThan(0);
+  });
+
+  it('locks the Phase 1 tabs for a regular user once Phase 2 is open', async () => {
+    // Phase 1 picks (Group Stage / Best 3rds / Gut Feeling) freeze when Phase 2
+    // opens, so those tabs render a lock icon and become non-interactive. The
+    // Phase 2 tabs (Knockout / Tiebreaker) stay open.
+    configureQueries({ phase: 'phase2_open' });
+    render(<PredictionsPageContent mode="create" />);
+
+    expect(await screen.findByRole('tab', { name: /Group Stage/ })).toBeDisabled();
+    expect(screen.getByRole('tab', { name: /Best 3rds/ })).toBeDisabled();
+    expect(screen.getByRole('tab', { name: /Gut Feeling/ })).toBeDisabled();
+    expect(screen.getByRole('tab', { name: /Knockout/ })).not.toBeDisabled();
+    expect(screen.getByRole('tab', { name: /Tiebreaker/ })).not.toBeDisabled();
   });
 
   it('renders a read-only view when the tournament is locked', async () => {

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import * as React from 'react';
-import { Eye, TrendingDown, TrendingUp, Minus, Trophy } from 'lucide-react';
+import Link from 'next/link';
+import { Eye, Pencil, TrendingDown, TrendingUp, Minus, Trophy } from 'lucide-react';
 import {
   Table,
   TableBody,
@@ -13,6 +14,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
+import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 import type { LeaderboardEntry } from '@/types/tournament';
 
@@ -28,6 +30,13 @@ export interface LeaderboardTableProps {
    * The route requires auth; gate the column visually too.
    */
   enablePreview?: boolean;
+  /**
+   * When true, render an Edit button on the current user's own rows that
+   * deep-links to the prediction editor. Callers should only pass this while
+   * the tournament is unlocked (predictions are editable). Row ownership is
+   * still gated on `currentUsername` so other players' rows never get one.
+   */
+  enableEdit?: boolean;
 }
 
 function formatUpdated(value?: string | null): string | null {
@@ -86,10 +95,14 @@ export function LeaderboardTable({
   highlightedRank,
   className,
   enablePreview = false,
+  enableEdit = false,
 }: LeaderboardTableProps) {
   const [previewId, setPreviewId] = React.useState<string | null>(null);
 
-  const colCount = enablePreview ? 5 : 4;
+  // One shared trailing actions column holds Preview (all rows) and Edit
+  // (the current user's own rows). Render it whenever either is enabled.
+  const showActions = enablePreview || enableEdit;
+  const colCount = showActions ? 5 : 4;
 
   return (
     <>
@@ -100,7 +113,7 @@ export function LeaderboardTable({
             <TableHead>Player</TableHead>
             <TableHead className="text-right">Points</TableHead>
             <TableHead className="w-24 text-right">Change</TableHead>
-            {enablePreview && <TableHead className="w-24 text-right">Bracket</TableHead>}
+            {showActions && <TableHead className="w-36 text-right">Actions</TableHead>}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -161,18 +174,36 @@ export function LeaderboardTable({
                 <TableCell className="text-right">
                   <ChangeIndicator change={entry.change} />
                 </TableCell>
-                {enablePreview && (
+                {showActions && (
                   <TableCell className="text-right">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setPreviewId(entry.predictionId)}
-                      aria-label={`Preview ${entry.predictionName}'s bracket`}
-                    >
-                      <Eye className="mr-1.5 h-4 w-4" />
-                      Preview
-                    </Button>
+                    <div className="flex items-center justify-end gap-1">
+                      {enablePreview && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setPreviewId(entry.predictionId)}
+                          aria-label={`Preview ${entry.predictionName}'s bracket`}
+                        >
+                          <Eye className="mr-1.5 h-4 w-4" />
+                          Preview
+                        </Button>
+                      )}
+                      {enableEdit && isCurrentUser && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          asChild
+                          aria-label={`Edit ${entry.predictionName}`}
+                        >
+                          <Link href={`${ROUTES.predictions}/${entry.predictionId}`}>
+                            <Pencil className="mr-1.5 h-4 w-4" />
+                            Edit
+                          </Link>
+                        </Button>
+                      )}
+                    </div>
                   </TableCell>
                 )}
               </TableRow>

--- a/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
+++ b/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
@@ -89,4 +89,19 @@ describe('LeaderboardTable', () => {
     render(<LeaderboardTable entries={entries} />);
     expect(screen.queryByText(/^Updated /)).not.toBeInTheDocument();
   });
+
+  it('renders an Edit link only on the current user row when enableEdit is set', () => {
+    render(
+      <LeaderboardTable entries={entries} currentUsername="bob" enableEdit />
+    );
+    const editLinks = screen.getAllByRole('link', { name: /^Edit / });
+    expect(editLinks).toHaveLength(1);
+    // bob owns the p2 prediction → deep-links to its editor.
+    expect(editLinks[0]).toHaveAttribute('href', '/predictions/p2');
+  });
+
+  it('omits Edit links when enableEdit is not set', () => {
+    render(<LeaderboardTable entries={entries} currentUsername="bob" />);
+    expect(screen.queryByRole('link', { name: /^Edit / })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/predictions/PredictionStepper.tsx
+++ b/frontend/src/components/predictions/PredictionStepper.tsx
@@ -76,6 +76,10 @@ function StepperRow({
               data-status={step.status}
               className={cn(
                 'relative flex h-auto flex-col items-center gap-2 rounded-none bg-transparent shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none',
+                // Desktop affordance: these steps are clickable tabs. Locked
+                // steps are `disabled`, which already sets pointer-events-none,
+                // so the pointer cursor only ever shows on navigable steps.
+                'cursor-pointer',
                 isSm ? 'px-1 py-1' : 'px-2 py-1'
               )}
             >


### PR DESCRIPTION
Five UI enhancements across the leaderboard and prediction wizard.

## Changes
1. **Leaderboard edit link** — current user's own rows get an **Edit** deep-link to `/predictions/{id}`, shown only while the tournament is unlocked. Lives in a shared trailing **Actions** cell alongside Preview.
2. **Breadcrumb on `/predictions/[id]`** — reuses the generic breadcrumb (**My Predictions › {name}**) to return to the listing.
3. **Phase 2 preview button** — centered between Back and the right-hand button group; flushes pending edits then opens the existing `BracketPreviewDialog` with the full read-only prediction (both phases). Edit-mode + existing prediction only.
4. **Locked-step icons** — Phase 1 tabs (Group Stage / Best 3rds / Gut Feeling) lock once Phase 2 opens (and vice-versa during Phase 1); super admin exempt; fully-locked read-only phases stay browsable. Back/Continue skip locked steps so users aren't stranded on a frozen phase.
5. **Pointer cursor** — navigable wizard steps now show `cursor-pointer` on hover (locked steps stay non-interactive).

## Behavior note
With #4, regular users in Phase 2 can no longer navigate to the Phase 1 tabs inline — the new Phase 2 Preview button (#3) covers reviewing those frozen picks.

## Tests
- 429 tests pass; typecheck + lint clean.
- Updated the two phase-2 Continue-chain tests to run as super admin (full cross-phase chain is now super-admin-only) and added tests for the leaderboard Edit link and Phase 1 tab locking in Phase 2.