### PR TITLE
feat(ux): green selection treatments, locked-create block, AuthMenu accent, tiebreaker copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
-> **Version:** 3.7.0
-> **Last Updated:** 2026-05-28
+> **Version:** 3.7.1
+> **Last Updated:** 2026-05-30
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -109,7 +109,7 @@ Plus flat bonuses: Final (M104) winner `+30` (this absorbs the legacy round + ch
 
 **Gut Feeling Champion (Phase 1)** — `+5` (from `scoring_champion_pick_pts()`) if `predictions.champion_team_id` matches the actual M104 winner. Independent of the bracket Final (M104) pick scoring (`+30`) — users can pick the same team for both (so a correct gut pick + correct bracket Final stacks to `+35`), or split between them. The pick is collected via a dropdown as the final Phase 1 wizard step (after Best 3rds), required at create time, and writable only while the tournament is in `phase1`; once `phase1_locked` (or later) it is frozen.
 
-**Tiebreaker** — closest prediction to the *champion's* total goals across all 8 of their tournament matches (regulation + extra time only; no penalty-shootout goals). Stored on `tournaments.champion_total_goals` (admin-entered when the tournament ends). `predictions.total_goals` is reused with a CHECK of `between 0 and 200`.
+**Tiebreaker (Champion's Total Playoff Goals)** — closest prediction to the *champion's* total goals across their 5 playoff matches (R32 → Final), including regulation, extra time, **and** penalty-shootout goals. Admin-entered on `tournaments.champion_total_goals` when the tournament ends. `predictions.total_goals` is reused with a CHECK of `between 0 and 200` (the wizard suggests a 1–50 range via the input placeholder; the hard bound stays 0–200). `get_leaderboard` / `get_leaderboard_rank` break a points tie by smallest `abs(total_goals − champion_total_goals)`, then earliest `submitted_at` — which is exactly what the user-facing copy (TiebreakerInput + Rules) describes ("closest prediction wins; if equally close, earliest submission wins").
 
 **Grand total max: 125 + 20 + 263 + 5 = 413.** (Group 125 + Advancers 20 + Knockout 263 + Champion Pick 5.)
 
@@ -172,7 +172,7 @@ Client-facing API surface is `/api/rewards/*` driven by `redeem_free_pick` + `ge
 - **Gut Feeling Champion** (Phase 1): one team picked from the 48 as your tournament champion. Required at prediction-creation time, collected as the final Phase 1 wizard step (after Best 3rds), and locked when Phase 1 ends. Independent of the bracket Final (M104) pick — both score separately.
 - Group stage: predict positions 1–4 for all 12 groups; only the top 2 finishers are scored (set-based 10/7/5/2/0 — exact / reversed / right-slot / wrong-slot / none — with Group I, the "Group of Death", paying 15 for an exact top-2 instead of 10)
 - Knockout: predict winners R32 → Final. Each correct match winner scores a flat per-round value (R32 +5, R16 +8, QF +12, SF +18); the Final (M104) winner pays +30 and the third-place (M103) winner +5
-- Tiebreaker: closest prediction to the champion's total tournament goals (regulation + extra time across their 8 matches; penalty-shootout goals excluded)
+- Tiebreaker — Champion's Total Playoff Goals: closest prediction to the champion's total goals across their 5 playoff matches (R32 → Final), including regulation, extra time, and penalty-shootout goals; broken by the closest prediction, then earliest submission
 
 ## Oracle Design
 

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -79,9 +79,15 @@ export function PredictionsListPage() {
     phase === 'phase2_locked' || (phase === 'phase1_locked' && advancersSet);
 
   const predictions = query.data?.predictions ?? [];
-  // Late-joiner block: new predictions can only be created during phase 1.
-  // Super admins bypass.
-  const canCreate = phase === 'phase1' || isSuperAdmin;
+  // New predictions are accepted only during phase 1 (super admins may also
+  // create while a later phase is still open). Once the tournament is LOCKED,
+  // no role — including super admin — can create a new entry.
+  const canCreate = !isLocked && (phase === 'phase1' || isSuperAdmin);
+  const createDisabledReason = isLocked
+    ? 'Predictions are locked — no new entries are being accepted'
+    : !canCreate
+      ? 'New predictions are only accepted during the group stage'
+      : undefined;
 
   const handleRedeem = async (prediction: ApiPrediction) => {
     if (redeemingId) return;
@@ -161,21 +167,38 @@ export function PredictionsListPage() {
               <ArrowRight className="ml-2 h-4 w-4" />
             </Link>
           </Button>
-          <Button asChild disabled={!canCreate} size="lg">
-            <Link
-              href={
-                canCreate ? `${ROUTES.predictions}/${NEW_PREDICTION_SENTINEL}` : '#'
-              }
-              aria-disabled={!canCreate}
-              title={
-                isLocked && !isSuperAdmin ? 'Predictions are locked' : undefined
-              }
-            >
-              <Plus className="mr-2 h-4 w-4" /> New prediction
-            </Link>
-          </Button>
+          {/* When locked, hide the New-prediction button entirely — a disabled
+              button alongside the "locked" banner just reads as confusing. The
+              late-joiner case (open, but past phase 1) keeps a disabled button
+              with an explanatory tooltip. */}
+          {!isLocked && (
+            <Button asChild disabled={!canCreate} size="lg">
+              <Link
+                href={
+                  canCreate ? `${ROUTES.predictions}/${NEW_PREDICTION_SENTINEL}` : '#'
+                }
+                aria-disabled={!canCreate}
+                title={createDisabledReason}
+              >
+                <Plus className="mr-2 h-4 w-4" /> New prediction
+              </Link>
+            </Button>
+          )}
         </div>
       </div>
+
+      {isLocked && (
+        <Card className="mb-6 border-amber-500/40 bg-amber-500/10">
+          <CardContent
+            role="status"
+            className="py-3 text-sm text-amber-900 dark:text-amber-200"
+          >
+            <span className="font-semibold">Predictions are locked.</span> No further
+            prediction submissions are being accepted. You can still view and preview your
+            existing entries.
+          </CardContent>
+        </Card>
+      )}
 
       <div className="mb-4">
         <FreePickBanner />
@@ -191,11 +214,15 @@ export function PredictionsListPage() {
         <Card>
           <CardContent className="flex flex-col items-center justify-center gap-3 py-12 text-center">
             <p className="text-muted-foreground">You haven&apos;t created any predictions yet.</p>
-            <Button asChild>
-              <Link href={`${ROUTES.predictions}/${NEW_PREDICTION_SENTINEL}`}>
-                <Plus className="mr-2 h-4 w-4" /> Create your first prediction
-              </Link>
-            </Button>
+            {canCreate ? (
+              <Button asChild>
+                <Link href={`${ROUTES.predictions}/${NEW_PREDICTION_SENTINEL}`}>
+                  <Plus className="mr-2 h-4 w-4" /> Create your first prediction
+                </Link>
+              </Button>
+            ) : (
+              <p className="text-muted-foreground text-sm">{createDisabledReason}</p>
+            )}
           </CardContent>
         </Card>
       ) : (

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -1163,6 +1163,33 @@ export function PredictionsPageContent({
     );
   }
 
+  // Once the tournament is locked, no role — including super admin — may
+  // create a NEW prediction on the user-facing route. (The admin-on-behalf
+  // editor passes a different apiBasePath and is intentionally exempt.) This
+  // backstops the disabled "New prediction" button on the hub against a direct
+  // deep-link to the create wizard. Editing existing predictions is unaffected.
+  if (mode === 'create' && isLocked && apiBasePath === '/api/predictions') {
+    return (
+      <PageLayout>
+        {breadcrumb}
+        <Card className="mt-6 border-amber-500/40 bg-amber-500/10">
+          <CardContent
+            role="status"
+            className="text-amber-900 dark:text-amber-200 flex flex-col items-center gap-3 py-10 text-center"
+          >
+            <p className="text-lg font-semibold">Predictions are locked</p>
+            <p className="text-sm">
+              No further prediction submissions are being accepted.
+            </p>
+            <Button variant="outline" onClick={() => router.push(ROUTES.predictions)}>
+              Back to your predictions
+            </Button>
+          </CardContent>
+        </Card>
+      </PageLayout>
+    );
+  }
+
   const stepIndex = STEP_ORDER.indexOf(currentStep);
   // Back / Continue target the nearest *unlocked* neighbour so a frozen phase
   // is stepped over rather than landed on.

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -448,13 +448,49 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(screen.getByRole('tab', { name: /Tiebreaker/ })).not.toBeDisabled();
   });
 
-  it('renders a read-only view when the tournament is locked', async () => {
-    // Regular users in a locked phase should still be able to *navigate*
-    // between steps to view past picks — only edits/saves are blocked.
-    // The submit/save card is hidden entirely and a read-only notice is
-    // surfaced so the user understands why.
+  it('blocks creating a new prediction when the tournament is locked (all roles)', async () => {
+    // Once locked, NO role may create a new entry — the create wizard shows a
+    // "submissions closed" notice instead of the form, backstopping the
+    // disabled "New prediction" button against a direct deep-link.
     configureQueries({ tournamentLockTime: new Date(Date.now() - 1000).toISOString() });
-    render(<PredictionsPageContent mode="create" />);
+    const { rerender } = render(<PredictionsPageContent mode="create" />);
+
+    expect(
+      await screen.findByText(/no further prediction submissions/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('fill-all-groups')).toBeNull();
+
+    // Super admin is blocked from CREATING too (they may still edit existing).
+    mockAuthProfile = { isSuperAdmin: true };
+    rerender(<PredictionsPageContent mode="create" />);
+    expect(
+      await screen.findByText(/no further prediction submissions/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders a read-only view when editing in a locked tournament', async () => {
+    // Editing an existing prediction in a locked phase: the user can still
+    // *navigate* between steps to view past picks — only edits/saves are
+    // blocked. The submit/save card is hidden and a read-only notice shows.
+    configureQueries({ tournamentLockTime: new Date(Date.now() - 1000).toISOString() });
+    render(
+      <PredictionsPageContent
+        mode="edit"
+        predictionId="pred-1"
+        initial={{
+          id: 'pred-1',
+          name: 'Main',
+          totalGoals: null,
+          championTeamId: 'arg',
+          submittedAt: new Date(Date.now() - 60_000).toISOString(),
+          isPaid: false,
+          paidAt: null,
+          groups: [],
+          knockout: [],
+          advancers: [],
+        }}
+      />
+    );
 
     await screen.findByText(/read-only view of your picks/i);
     const tabs = screen.getAllByRole('tab');
@@ -464,18 +500,36 @@ describe('PredictionsPageContent — stepper navigation', () => {
     expect(screen.queryByRole('button', { name: /Submit Prediction/ })).toBeNull();
   });
 
-  it('lets a super admin advance past Groups when the tournament is locked', async () => {
-    // Super admin keeps full write access through phase1_locked (admin
-    // RPC bypasses the lock check). The wizard nav must follow suit so
-    // they can actually reach Best 3rds + the knockout sub-steps when
-    // editing a user's bracket post-lock.
+  it('lets a super admin advance past Groups when editing in a locked tournament', async () => {
+    // Super admin keeps full write access through phase1_locked (admin RPC
+    // bypasses the lock check) when EDITING an existing prediction. The wizard
+    // nav must follow suit so they can reach Best 3rds + the knockout sub-steps.
     mockAuthProfile = { isSuperAdmin: true };
     configureQueries({
       tournamentLockTime: new Date(Date.now() - 1000).toISOString(),
       phase: 'phase1_locked',
     });
     const user = userEvent.setup();
-    render(<PredictionsPageContent mode="create" />);
+    render(
+      <PredictionsPageContent
+        mode="edit"
+        predictionId="pred-1"
+        initial={{
+          id: 'pred-1',
+          name: 'Main',
+          totalGoals: null,
+          // null champion → nav autosave is skipped (RPC requires it), so
+          // Continue navigates without needing a mocked fetch.
+          championTeamId: null,
+          submittedAt: null,
+          isPaid: false,
+          paidAt: null,
+          groups: [],
+          knockout: [],
+          advancers: [],
+        }}
+      />
+    );
 
     // Wait for the wizard to hydrate past the skeleton. The "Locked" badge
     // on the lock-time card is the stable signal — Submit/Save buttons no
@@ -613,7 +667,9 @@ describe('PredictionsPageContent — autosave', () => {
 
     render(<PredictionsPageContent mode="create" />);
 
-    await screen.findByText(/read-only view of your picks/i);
+    // Create is blocked when locked (submissions-closed notice), but the
+    // lock-clears-draft hygiene still runs in the hydrate effect.
+    await screen.findByText(/no further prediction submissions/i);
     expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull();
   });
 
@@ -1166,7 +1222,24 @@ describe('PredictionsPageContent — autosave', () => {
 
   it('does not render Save progress in a locked read-only view', async () => {
     configureQueries({ tournamentLockTime: new Date(Date.now() - 1000).toISOString() });
-    render(<PredictionsPageContent mode="create" />);
+    render(
+      <PredictionsPageContent
+        mode="edit"
+        predictionId="pred-1"
+        initial={{
+          id: 'pred-1',
+          name: 'Main',
+          totalGoals: null,
+          championTeamId: 'arg',
+          submittedAt: new Date(Date.now() - 60_000).toISOString(),
+          isPaid: false,
+          paidAt: null,
+          groups: [],
+          knockout: [],
+          advancers: [],
+        }}
+      />
+    );
 
     await screen.findByText(/read-only view of your picks/i);
     expect(screen.queryByRole('button', { name: /Save progress/i })).toBeNull();

--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -152,8 +152,8 @@ export default function RulesPage() {
                 </span>{' '}
                 Opens once the group results are in and the bracket is set. Until it passes
                 you can still edit your knockout bracket (Round of 32 through the Final,
-                including the third-place match) and your Total Goals tiebreaker. After it
-                locks, every pick is frozen.
+                including the third-place match) and your Champion&apos;s Total Playoff Goals
+                tiebreaker. After it locks, every pick is frozen.
               </li>
               <li>
                 <span className="text-foreground font-semibold">Between the two locks.</span>{' '}

--- a/frontend/src/components/layout/AuthMenu.tsx
+++ b/frontend/src/components/layout/AuthMenu.tsx
@@ -67,7 +67,12 @@ export function AuthMenu() {
   // (non-Radix) placeholder for the first paint sidesteps the issue.
   if (!mounted) {
     return (
-      <Button variant="outline" size="sm" className="gap-2" disabled>
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-2 border-indigo-500/40 bg-indigo-500/10 font-medium text-indigo-600 dark:text-indigo-400"
+        disabled
+      >
         <UserIcon className="h-4 w-4" />
         <span className="max-w-[120px] truncate">{displayName}</span>
       </Button>
@@ -77,7 +82,11 @@ export function AuthMenu() {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className="relative gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="relative gap-2 border-indigo-500/40 bg-indigo-500/10 font-medium text-indigo-600 hover:bg-indigo-500/20 hover:text-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-400"
+        >
           <UserIcon className="h-4 w-4" />
           <span className="max-w-[120px] truncate">{displayName}</span>
           {/* Unread-style indicator for available free-pick credits

--- a/frontend/src/components/marketing/ScoringBreakdown.tsx
+++ b/frontend/src/components/marketing/ScoringBreakdown.tsx
@@ -215,13 +215,19 @@ export function ScoringBreakdown() {
       <Card className="mt-6">
         <CardContent className="flex flex-col items-center justify-between gap-4 py-6 sm:flex-row">
           <div>
-            <p className="text-muted-foreground text-sm">Tiebreaker</p>
+            <p className="text-muted-foreground text-sm">
+              Tiebreaker: Champion&apos;s Total Playoff Goals
+            </p>
             <p className="font-medium">
-              Predict the total goals scored by the World Cup champion across all 8 of their
-              tournament matches. Closest to actual wins.
+              Predict how many total goals the World Cup champion will score across their 5
+              playoff matches (R32–Final).
             </p>
             <p className="text-muted-foreground mt-1 text-xs">
-              Regulation and extra time only — penalty-shootout goals don&apos;t count.
+              <strong>How it works:</strong> In the event of a tie, the closest prediction wins.
+              If two predictions are equally close, the earliest submission wins.
+            </p>
+            <p className="text-muted-foreground mt-1 text-xs">
+              <strong>Includes:</strong> Regulation, extra time, and penalty shootout goals.
             </p>
           </div>
           <div className="text-center sm:text-right">

--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -108,6 +108,15 @@ export function BracketPreviewDialog({
     groupsQuery.data &&
     standingsQuery.data;
 
+  // The user's predicted champion = the winner they picked in the Final
+  // (M104). Resolve it from their knockout picks so the meta bar can show it
+  // alongside the Gut Feeling Champion (TBD until the Final is picked).
+  const finalMatch = matchesQuery.data?.find((m) => m.stage === 'final') ?? null;
+  const bracketChampionTeamId =
+    finalMatch && predictionQuery.data
+      ? (predictionQuery.data.knockout.find((k) => k.matchId === finalMatch.id)?.winner ?? null)
+      : null;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] max-w-5xl overflow-y-auto">
@@ -157,6 +166,7 @@ export function BracketPreviewDialog({
             <PredictionMetaBar
               username={predictionQuery.data!.username}
               championTeamId={predictionQuery.data!.championTeamId}
+              bracketChampionTeamId={bracketChampionTeamId}
               totalGoals={predictionQuery.data!.totalGoals}
               teams={teamsQuery.data!}
             />
@@ -226,6 +236,8 @@ function PreviewSection({
 interface PredictionMetaBarProps {
   username: string | null;
   championTeamId: string | null;
+  /** The user's predicted Final (M104) winner — their bracket champion. */
+  bracketChampionTeamId: string | null;
   totalGoals: number | null;
   teams: Team[];
 }
@@ -233,15 +245,19 @@ interface PredictionMetaBarProps {
 function PredictionMetaBar({
   username,
   championTeamId,
+  bracketChampionTeamId,
   totalGoals,
   teams,
 }: PredictionMetaBarProps) {
   const championTeam = championTeamId
     ? (teams.find((t) => t.id === championTeamId) ?? null)
     : null;
+  const bracketChampionTeam = bracketChampionTeamId
+    ? (teams.find((t) => t.id === bracketChampionTeamId) ?? null)
+    : null;
 
   return (
-    <dl className="bg-muted/40 grid gap-3 rounded-md border px-4 py-3 text-sm sm:grid-cols-3">
+    <dl className="bg-muted/40 grid gap-3 rounded-md border px-4 py-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
       <div className="flex items-start gap-2">
         <UserIcon className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" aria-hidden />
         <div>
@@ -266,6 +282,22 @@ function PredictionMetaBar({
         </div>
       </div>
       <div className="flex items-start gap-2">
+        <Trophy className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+        <div>
+          <dt className="text-muted-foreground text-xs">Bracket Champion</dt>
+          <dd className="font-medium">
+            {bracketChampionTeam ? (
+              <span className="inline-flex items-center gap-1.5">
+                <TeamFlag code={bracketChampionTeam.code} className="h-4 w-6" />
+                {bracketChampionTeam.name}
+              </span>
+            ) : (
+              <span className="text-muted-foreground italic">TBD</span>
+            )}
+          </dd>
+        </div>
+      </div>
+      <div className="flex items-start gap-2">
         <span
           aria-hidden
           className="text-muted-foreground mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center text-base leading-none"
@@ -273,7 +305,7 @@ function PredictionMetaBar({
           ⚽
         </span>
         <div>
-          <dt className="text-muted-foreground text-xs">Champion total goals</dt>
+          <dt className="text-muted-foreground text-xs">Champion&apos;s Total Playoff Goals</dt>
           <dd className="font-medium">{totalGoals != null ? totalGoals : '—'}</dd>
         </div>
       </div>

--- a/frontend/src/components/predictions/BracketView.tsx
+++ b/frontend/src/components/predictions/BracketView.tsx
@@ -103,7 +103,7 @@ function MatchNode({
             key={idx}
             className={cn(
               'flex items-center gap-2 px-2 py-1.5',
-              slot.isWinner && 'bg-primary/10 font-semibold text-primary',
+              slot.isWinner && 'bg-green-500/10 font-semibold text-primary',
               idx === 0 && 'border-b'
             )}
           >

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -112,6 +112,14 @@ function describeSource(source: string): string {
   return formatSource(source);
 }
 
+// Selected-winner treatment for a team button: green tint + green font,
+// matching the match card's green winner state (replaces the solid
+// black/white `variant="default"` fill, which reads as low-signal in the
+// monochrome theme). Hover keeps the green so the outline button's default
+// gray hover doesn't wash it out.
+const SELECTED_TEAM_CLASS =
+  'border-green-500/50 bg-green-500/10 font-semibold text-green-700 hover:bg-green-500/20 hover:text-green-700 dark:text-green-400 dark:hover:text-green-400';
+
 // Single match card component
 function MatchCard({
   match,
@@ -171,8 +179,12 @@ function MatchCard({
       <CardContent className="space-y-2 p-3 pt-0">
         {/* Team 1 */}
         <Button
-          variant={effectiveWinnerId === team1Id && team1Id ? 'default' : 'outline'}
-          className={cn('h-auto w-full justify-start px-3 py-2', !team1 && 'text-muted-foreground')}
+          variant="outline"
+          className={cn(
+            'h-auto w-full justify-start px-3 py-2',
+            !team1 && 'text-muted-foreground',
+            effectiveWinnerId === team1Id && team1Id && SELECTED_TEAM_CLASS
+          )}
           disabled={!canSelect || !team1Id}
           onClick={() => onSelect(team1Id)}
         >
@@ -193,8 +205,12 @@ function MatchCard({
 
         {/* Team 2 */}
         <Button
-          variant={effectiveWinnerId === team2Id && team2Id ? 'default' : 'outline'}
-          className={cn('h-auto w-full justify-start px-3 py-2', !team2 && 'text-muted-foreground')}
+          variant="outline"
+          className={cn(
+            'h-auto w-full justify-start px-3 py-2',
+            !team2 && 'text-muted-foreground',
+            effectiveWinnerId === team2Id && team2Id && SELECTED_TEAM_CLASS
+          )}
           disabled={!canSelect || !team2Id}
           onClick={() => onSelect(team2Id)}
         >
@@ -389,9 +405,9 @@ export function KnockoutBracket({
         <span>·</span>
         <span>SF +18</span>
         <span>·</span>
-        <span>Final +30</span>
-        <span>·</span>
         <span>3rd +5</span>
+        <span>·</span>
+        <span>Final +30</span>
       </div>
 
       <StageSection

--- a/frontend/src/components/predictions/TiebreakerInput.tsx
+++ b/frontend/src/components/predictions/TiebreakerInput.tsx
@@ -8,11 +8,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 
-// Validation range for the champion's tournament-goal tally.
-// Champion plays 8 matches; realistic range is roughly 5-25.
-// Hard bound is generous (200) — matches the DB CHECK.
+// Hard validation bounds — generous, matches the DB CHECK (0–200).
 const MIN_GOALS = 0;
 const MAX_GOALS = 200;
+// Realistic range shown as the input placeholder hint. The champion plays 5
+// playoff matches (R32–Final), so a handful of goals is the expected range.
+const SUGGESTED_MIN_GOALS = 1;
+const SUGGESTED_MAX_GOALS = 50;
 
 interface TiebreakerInputProps {
   value: number | null;
@@ -69,19 +71,22 @@ export function TiebreakerInput({ value, onChange, disabled = false }: Tiebreake
       <CardHeader>
         <div className="flex items-center gap-2">
           <Target className="text-primary h-5 w-5" />
-          <CardTitle className="text-base">Tiebreaker: Champion&apos;s Total Goals</CardTitle>
+          <CardTitle className="text-base">
+            Tiebreaker: Champion&apos;s Total Playoff Goals
+          </CardTitle>
         </div>
         <CardDescription>
-          Predict the total goals the World Cup champion scores across their 8 tournament matches
+          Predict how many total goals the World Cup champion will score across their 5 playoff
+          matches (R32–Final).
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="total-goals">Champion&apos;s Total Goals</Label>
+          <Label htmlFor="total-goals">Champion&apos;s Total Playoff Goals</Label>
           <Input
             id="total-goals"
             type="number"
-            placeholder={`Enter a number (${MIN_GOALS}-${MAX_GOALS})`}
+            placeholder={`Enter a number (${SUGGESTED_MIN_GOALS}-${SUGGESTED_MAX_GOALS})`}
             value={inputValue}
             onChange={handleChange}
             disabled={disabled}
@@ -105,12 +110,11 @@ export function TiebreakerInput({ value, onChange, disabled = false }: Tiebreake
           <HelpCircle className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
           <div className="text-muted-foreground space-y-1">
             <p>
-              <strong>How it works:</strong> if two or more players are tied on total points, the
-              prediction closest to the champion&apos;s actual goal tally wins the tie.
+              <strong>How it works:</strong> In the event of a tie, the closest prediction wins.
+              If two predictions are equally close, the earliest submission wins.
             </p>
             <p className="text-xs">
-              Counts every goal the champion scores in regulation and extra time across all 8 of
-              their matches (group stage through final). Penalty-shootout goals don&apos;t count.
+              <strong>Includes:</strong> Regulation, extra time, and penalty shootout goals.
             </p>
           </div>
         </div>

--- a/frontend/src/components/predictions/__tests__/TiebreakerInput.test.tsx
+++ b/frontend/src/components/predictions/__tests__/TiebreakerInput.test.tsx
@@ -8,14 +8,14 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      expect(screen.getByText("Tiebreaker: Champion's Total Goals")).toBeInTheDocument();
+      expect(screen.getByText("Tiebreaker: Champion's Total Playoff Goals")).toBeInTheDocument();
     });
 
     it('should render label and input', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      expect(screen.getByLabelText("Champion's Total Goals")).toBeInTheDocument();
+      expect(screen.getByLabelText("Champion's Total Playoff Goals")).toBeInTheDocument();
     });
 
     it('should render description text', () => {
@@ -23,8 +23,9 @@ describe('TiebreakerInput', () => {
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
       expect(
-        screen.getByText(/Predict the total goals the World Cup champion scores/i)
+        screen.getByText(/Predict how many total goals the World Cup champion will score/i)
       ).toBeInTheDocument();
+      expect(screen.getByText(/5 playoff\s+matches \(R32–Final\)/i)).toBeInTheDocument();
     });
 
     it('should render help text', () => {
@@ -33,7 +34,11 @@ describe('TiebreakerInput', () => {
 
       expect(screen.getByText(/How it works:/i)).toBeInTheDocument();
       expect(
-        screen.getByText(/closest to the champion's actual goal tally/i)
+        screen.getByText(/the earliest submission wins/i)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Includes:/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Regulation, extra time, and penalty shootout goals/i)
       ).toBeInTheDocument();
     });
 
@@ -41,8 +46,8 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
-      expect(input).toHaveAttribute('placeholder', 'Enter a number (0-200)');
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
+      expect(input).toHaveAttribute('placeholder', 'Enter a number (1-50)');
     });
   });
 
@@ -51,7 +56,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       expect(input).toHaveValue(null);
     });
 
@@ -59,7 +64,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={18} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       expect(input).toHaveValue(18);
     });
   });
@@ -70,7 +75,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       await user.type(input, '18');
 
       expect(mockOnChange).toHaveBeenLastCalledWith(18);
@@ -82,7 +87,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       await user.type(input, '-1');
 
       expect(screen.getByText(/Goals must be between 0 and 200/i)).toBeInTheDocument();
@@ -94,7 +99,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       await user.type(input, '250');
 
       expect(screen.getByText(/Goals must be between 0 and 200/i)).toBeInTheDocument();
@@ -106,7 +111,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       await user.type(input, '120');
 
       expect(mockOnChange).toHaveBeenLastCalledWith(120);
@@ -118,7 +123,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       await user.clear(input);
       await user.type(input, '-10');
 
@@ -133,7 +138,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={18} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       await user.clear(input);
 
       // Clearing should call onChange with null
@@ -145,7 +150,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
 
       // Enter invalid value (above max)
       await user.type(input, '250');
@@ -162,7 +167,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} disabled={true} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       expect(input).toBeDisabled();
     });
 
@@ -170,7 +175,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} disabled={false} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       expect(input).not.toBeDisabled();
     });
   });
@@ -180,7 +185,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       expect(input).toHaveAttribute('aria-describedby', 'tiebreaker-help tiebreaker-error');
     });
 
@@ -189,7 +194,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={null} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       await user.type(input, '250');
 
       expect(input).toHaveAttribute('aria-invalid', 'true');
@@ -199,7 +204,7 @@ describe('TiebreakerInput', () => {
       const mockOnChange = jest.fn();
       render(<TiebreakerInput value={18} onChange={mockOnChange} />);
 
-      const input = screen.getByLabelText("Champion's Total Goals");
+      const input = screen.getByLabelText("Champion's Total Playoff Goals");
       expect(input).toHaveAttribute('aria-invalid', 'false');
     });
   });

--- a/frontend/src/components/results/GroupStandingsResults.tsx
+++ b/frontend/src/components/results/GroupStandingsResults.tsx
@@ -18,6 +18,12 @@ export interface GroupStandingsResultsProps {
    * (e.g. the bracket preview), where that results-only status has no meaning.
    */
   showStatusBadge?: boolean;
+  /**
+   * Background tint for the top-two (advancing) rows. Defaults to the green
+   * "advancing" tint used on both /results and the bracket preview; overridable
+   * if a caller needs a different highlight.
+   */
+  advanceClassName?: string;
 }
 
 const POSITIONS = [
@@ -32,6 +38,7 @@ export function GroupStandingsResults({
   teams,
   standings,
   showStatusBadge = true,
+  advanceClassName = 'bg-green-500/10',
 }: GroupStandingsResultsProps) {
   const teamById = React.useMemo(
     () => new Map(teams.map((t) => [t.id, t])),
@@ -75,7 +82,7 @@ export function GroupStandingsResults({
                     key={key}
                     className={cn(
                       'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm',
-                      advances && team && 'bg-primary/5'
+                      advances && team && advanceClassName
                     )}
                   >
                     <span className="text-muted-foreground w-7 shrink-0 text-xs font-medium">


### PR DESCRIPTION
A batch of UI/UX refinements plus a tiebreaker copy overhaul.

## Selection color treatments (grayscale theme → green)
- **Group standings** advancing (top-2) rows now use a green tint — applied to both `/results` and the preview dialog (`GroupStandingsResults` default).
- **Knockout winners**: read-only `BracketView` winner row + the editable wizard's selected team (`KnockoutBracket`) now use a green tint (replacing the solid black/white `default` fill, which read as low-signal in the monochrome theme). Font/trophy colors left as-is per request (row tint only on BracketView).

## AuthMenu (collapsed trigger)
- The account button gets an **indigo accent** (tint + text + border) so it's distinguishable from the otherwise grayscale header nav. Mirrored on the pre-hydration placeholder to avoid a color flash.

## Locked tournament → no new predictions (all roles)
- `/predictions`: the **New prediction** button is hidden when locked (was shown disabled → confusing), with a "submissions closed" banner; empty-state gated too.
- Create wizard backstops a direct deep-link: `mode=create` + locked shows a "Predictions are locked" notice for **all roles** including super admin (the admin-on-behalf editor uses a different `apiBasePath` and is exempt).

## Preview dialog
- Shows the user's **Bracket Champion** (their Final/M104 pick) beside the Gut Feeling Champion, with a **TBD** fallback when unset.

## Tiebreaker → "Champion's Total Playoff Goals"
- Renamed + re-explained across the wizard step, Rules page (`ScoringBreakdown`), and the preview dialog label.
- Copy aligned to the **actual** leaderboard ordering: closest prediction wins, then earliest submission (we chose to match copy→code rather than add a migration).
- Placeholder hint suggests 1–50 (hard validation bound stays 0–200 / DB CHECK).
- Knockout scoring hint reordered: `3rd +5` before `Final +30`.

## Docs
- `CLAUDE.md`: updated tiebreaker scoring + mechanics, version bump 3.7.0 → 3.7.1.

## Tests
- 430 tests pass; typecheck clean; lint warnings are pre-existing.
- Updated TiebreakerInput tests (new copy/label/placeholder) and PredictionsPageContent locked tests (locked read-only browse moved to edit mode; new create-block test for all roles).