### PR TITLE
docs: remove redundant 'Between the two locks' copy on Rules page

### DIFF
--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -155,11 +155,6 @@ export default function RulesPage() {
                 including the third-place match) and your Champion&apos;s Total Playoff Goals
                 tiebreaker. After it locks, every pick is frozen.
               </li>
-              <li>
-                <span className="text-foreground font-semibold">Between the two locks.</span>{' '}
-                Your group picks, advancers, Gut Feeling Champion, and prediction name stay
-                frozen — only your knockout bracket and tiebreaker remain editable.
-              </li>
             </ul>
           </CardContent>
         </Card>


### PR DESCRIPTION
Removes the third bullet on the Rules page that restated what Phase 1 and Phase 2 locks already cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)