### PR TITLE
feat(audit): logged-in transparency page with live stats + accounting ledger

### DIFF
--- a/frontend/src/app/admin/AdminDashboard.tsx
+++ b/frontend/src/app/admin/AdminDashboard.tsx
@@ -20,6 +20,7 @@ import {
 import { PageLayout } from '@/components/layout/PageLayout';
 import { AdminNav } from '@/components/admin/AdminNav';
 import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
+import { StatCard } from '@/components/shared/StatCard';
 import { TeamFlag } from '@/components/shared/TeamFlag';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -75,43 +76,6 @@ function formatTimeRemaining(lockMs: number, nowMs: number): string {
   if (days > 0) return `${days}d ${hours}h`;
   if (hours > 0) return `${hours}h ${minutes}m`;
   return `${minutes}m`;
-}
-
-function StatCard({
-  icon: Icon,
-  label,
-  value,
-  subtitle,
-  isLoading,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  value: React.ReactNode;
-  subtitle?: React.ReactNode;
-  isLoading?: boolean;
-}) {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardDescription className="flex items-center gap-2">
-          <Icon className="h-4 w-4" />
-          {label}
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {isLoading ? (
-          <Skeleton className="h-8 w-20" />
-        ) : (
-          <>
-            <div className="text-2xl font-bold">{value}</div>
-            {subtitle ? (
-              <p className="text-muted-foreground mt-1 text-xs">{subtitle}</p>
-            ) : null}
-          </>
-        )}
-      </CardContent>
-    </Card>
-  );
 }
 
 export function AdminDashboard() {

--- a/frontend/src/app/api/audit/stats/__tests__/route.test.ts
+++ b/frontend/src/app/api/audit/stats/__tests__/route.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route');
+
+function mockTournament(data: unknown) {
+  supabaseMock.from.mockReturnValue({
+    select: () => ({
+      eq: () => ({
+        maybeSingle: async () => ({ data, error: null }),
+      }),
+    }),
+  });
+}
+
+describe('GET /api/audit/stats', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns mapped aggregate counts for a signed-in user', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockTournament({ id: 't1', status: 'group_stage', lock_time: '2026-06-01T00:00:00Z' });
+    supabaseMock.rpc.mockResolvedValue({
+      data: [
+        {
+          total_registrations: 50,
+          users_with_paid_prediction: 20,
+          total_entries: 25,
+          cash_paid_count: 22,
+          free_entries: 3,
+          referral_credits_redeemed: 2,
+          loyalty_credits_redeemed: 1,
+        },
+      ],
+      error: null,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('get_audit_stats', { p_tournament_id: 't1' });
+    expect(body).toMatchObject({
+      tournament: { id: 't1', status: 'group_stage' },
+      totalRegistrations: 50,
+      usersWithPaidPrediction: 20,
+      totalEntries: 25,
+      cashPaidCount: 22,
+      freeEntries: 3,
+      referralCreditsRedeemed: 2,
+      loyaltyCreditsRedeemed: 1,
+    });
+    // No PII leaks through.
+    expect(JSON.stringify(body)).not.toMatch(/email|username|top_users/i);
+  });
+
+  it('returns 404 when there is no active tournament', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockTournament(null);
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+});

--- a/frontend/src/app/api/audit/stats/route.ts
+++ b/frontend/src/app/api/audit/stats/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+
+import { getServerSupabase } from '@/lib/supabase/server';
+
+/**
+ * Logged-in-only aggregate stats for the /audit transparency page. Returns
+ * PII-free counts (no usernames/emails) via the get_audit_stats RPC. The
+ * accounting math (revenue → costs → net payout) is computed client-side from
+ * these counts + OPERATING_COSTS so the figures stay configurable in one place.
+ */
+export async function GET() {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { data: tournament, error: tErr } = await supabase
+    .from('tournaments')
+    .select('id, status, lock_time')
+    .eq('is_active', true)
+    .maybeSingle();
+  if (tErr) return NextResponse.json({ error: tErr.message }, { status: 500 });
+  if (!tournament) return NextResponse.json({ error: 'No active tournament' }, { status: 404 });
+
+  const { data, error } = await supabase.rpc('get_audit_stats', {
+    p_tournament_id: tournament.id,
+  });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const row = (data?.[0] ?? {}) as {
+    total_registrations?: number;
+    users_with_paid_prediction?: number;
+    total_entries?: number;
+    cash_paid_count?: number;
+    free_entries?: number;
+    referral_credits_redeemed?: number;
+    loyalty_credits_redeemed?: number;
+  };
+
+  return NextResponse.json({
+    tournament: {
+      id: tournament.id,
+      status: tournament.status,
+      lockTime: tournament.lock_time,
+    },
+    totalRegistrations: row.total_registrations ?? 0,
+    usersWithPaidPrediction: row.users_with_paid_prediction ?? 0,
+    totalEntries: row.total_entries ?? 0,
+    cashPaidCount: row.cash_paid_count ?? 0,
+    freeEntries: row.free_entries ?? 0,
+    referralCreditsRedeemed: row.referral_credits_redeemed ?? 0,
+    loyaltyCreditsRedeemed: row.loyalty_credits_redeemed ?? 0,
+  });
+}

--- a/frontend/src/app/audit/AuditPageContent.tsx
+++ b/frontend/src/app/audit/AuditPageContent.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Banknote, Gift, ShieldCheck, UserCheck, Users } from 'lucide-react';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { StatCard } from '@/components/shared/StatCard';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { fetchJSON } from '@/lib/api/fetchJSON';
+import { OPERATING_COSTS, PRICING } from '@/lib/constants';
+import { computeAuditAccounting, type AuditCounts } from '@/lib/audit';
+import { formatCAD } from '@/lib/currency';
+import { cn } from '@/lib/utils';
+
+interface AuditStatsResponse extends AuditCounts {
+  tournament: { id: string; status: string; lockTime: string | null };
+}
+
+function LedgerRow({
+  label,
+  detail,
+  amount,
+  variant,
+}: {
+  label: string;
+  detail?: string;
+  amount: number;
+  variant?: 'strong' | 'total' | 'muted';
+}) {
+  const sign = amount < 0 ? '−' : '';
+  const display = `${sign}${formatCAD(Math.abs(amount), { cents: true })}`;
+  return (
+    <div
+      className={cn(
+        'flex items-baseline justify-between gap-4 py-2',
+        variant === 'total' && 'border-foreground/70 mt-1 border-t-2 pt-3'
+      )}
+    >
+      <div>
+        <p
+          className={cn(
+            'leading-tight',
+            variant === 'muted' ? 'font-normal' : 'font-medium',
+            (variant === 'strong' || variant === 'total') && 'font-semibold'
+          )}
+        >
+          {label}
+        </p>
+        {detail ? <p className="text-muted-foreground text-xs">{detail}</p> : null}
+      </div>
+      <p
+        className={cn(
+          'shrink-0 font-mono tabular-nums',
+          variant === 'total' && 'text-lg font-bold',
+          variant === 'strong' && 'font-semibold'
+        )}
+      >
+        {display}
+      </p>
+    </div>
+  );
+}
+
+export function AuditPageContent() {
+  const query = useQuery<AuditStatsResponse>({
+    queryKey: ['audit-stats'],
+    queryFn: () => fetchJSON('/api/audit/stats'),
+    // Real-time: always refetch on mount and poll while the page is open.
+    staleTime: 0,
+    refetchOnMount: 'always',
+    refetchInterval: 30_000,
+  });
+
+  const counts = query.data;
+  const accounting = counts
+    ? computeAuditAccounting(counts, { pricing: PRICING, costs: OPERATING_COSTS })
+    : null;
+
+  const isLoading = query.isLoading;
+  const appliedRewards = counts
+    ? counts.referralCreditsRedeemed + counts.loyaltyCreditsRedeemed
+    : 0;
+
+  return (
+    <PageLayout>
+      <div className="mb-8">
+        <h1 className="mb-2 flex items-center gap-2 text-3xl font-bold">
+          <ShieldCheck className="text-primary h-7 w-7" />
+          Audit &amp; Transparency
+        </h1>
+        <p className="text-muted-foreground max-w-3xl">
+          A live, open view of the pool&apos;s numbers — who&apos;s in, what&apos;s been paid, how
+          much goes to charity, what it costs to run, and what&apos;s left. Figures refresh
+          automatically.
+        </p>
+      </div>
+
+      {query.isError ? (
+        <Card className="border-destructive/40 bg-destructive/5">
+          <CardContent className="text-destructive py-6 text-sm" role="alert">
+            Couldn&apos;t load audit data. Please try again shortly.
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Dashboard: general stats */}
+          <div className="mb-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <StatCard
+              icon={Users}
+              label="Total members"
+              value={(counts?.totalRegistrations ?? 0).toLocaleString()}
+              subtitle="Registered accounts"
+              isLoading={isLoading}
+            />
+            <StatCard
+              icon={UserCheck}
+              label="Paid members"
+              value={(counts?.usersWithPaidPrediction ?? 0).toLocaleString()}
+              subtitle={`of ${(counts?.totalRegistrations ?? 0).toLocaleString()} members`}
+              isLoading={isLoading}
+            />
+            <StatCard
+              icon={Banknote}
+              label="Total revenue"
+              value={formatCAD(accounting?.grossIncome ?? 0)}
+              subtitle={`${(counts?.cashPaidCount ?? 0).toLocaleString()} paid entries × ${formatCAD(
+                PRICING.entryFeeCAD
+              )}`}
+              isLoading={isLoading}
+            />
+            <StatCard
+              icon={Gift}
+              label="Applied rewards"
+              value={appliedRewards.toLocaleString()}
+              subtitle={`Referral ${counts?.referralCreditsRedeemed ?? 0} · Loyalty ${
+                counts?.loyaltyCreditsRedeemed ?? 0
+              }`}
+              isLoading={isLoading}
+            />
+          </div>
+
+          {/* Formal accounting ledger */}
+          <Card className="mx-auto max-w-2xl">
+            <CardHeader>
+              <CardTitle>Tournament Accounting</CardTitle>
+              <CardDescription>
+                Charity is {formatCAD(PRICING.charityPortionCAD)} per paid entry. Operating costs
+                are billed across {OPERATING_COSTS.overheadMonths} months (the 2-year Euro / World
+                Cup prep cycle).
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {isLoading || !accounting ? (
+                <div className="space-y-3">
+                  {Array.from({ length: 6 }).map((_, i) => (
+                    <Skeleton key={i} className="h-8 w-full" />
+                  ))}
+                </div>
+              ) : (
+                <>
+                  <dl className="divide-border divide-y text-sm">
+                    <LedgerRow
+                      label="Gross income"
+                      detail={`${counts!.cashPaidCount.toLocaleString()} paid entries × ${formatCAD(
+                        PRICING.entryFeeCAD
+                      )}`}
+                      amount={accounting.grossIncome}
+                      variant="strong"
+                    />
+                    <LedgerRow
+                      label="Charity"
+                      detail={`${formatCAD(PRICING.charityPortionCAD)} per paid entry`}
+                      amount={-accounting.charity}
+                    />
+
+                    <div className="pt-3">
+                      <p className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+                        Operating costs
+                      </p>
+                    </div>
+                    {accounting.costLines.map((line) => (
+                      <LedgerRow
+                        key={line.label}
+                        label={line.label}
+                        detail={line.detail}
+                        amount={-line.amount}
+                        variant="muted"
+                      />
+                    ))}
+                    <LedgerRow
+                      label="Total costs"
+                      amount={-accounting.totalCosts}
+                      variant="strong"
+                    />
+
+                    <LedgerRow label="Net payout" amount={accounting.netPayout} variant="total" />
+                  </dl>
+                  <p className="text-muted-foreground mt-4 text-xs">
+                    Net payout is the surplus after charity and operating costs — the pool available
+                    to return to players, equivalently the operator&apos;s retained margin.
+                  </p>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/audit/AuditPageContent.tsx
+++ b/frontend/src/app/audit/AuditPageContent.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Banknote, Gift, ShieldCheck, UserCheck, Users } from 'lucide-react';
+import { Banknote, Gift, HeartHandshake, ShieldCheck, UserCheck, Users } from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { StatCard } from '@/components/shared/StatCard';
@@ -106,7 +106,7 @@ export function AuditPageContent() {
       ) : (
         <>
           {/* Dashboard: general stats */}
-          <div className="mb-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="mb-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
             <StatCard
               icon={Users}
               label="Total members"
@@ -131,6 +131,13 @@ export function AuditPageContent() {
               isLoading={isLoading}
             />
             <StatCard
+              icon={HeartHandshake}
+              label="Charity total"
+              value={formatCAD(accounting?.charity ?? 0)}
+              subtitle={`${formatCAD(PRICING.charityPortionCAD)} per paid entry`}
+              isLoading={isLoading}
+            />
+            <StatCard
               icon={Gift}
               label="Applied rewards"
               value={appliedRewards.toLocaleString()}
@@ -147,8 +154,7 @@ export function AuditPageContent() {
               <CardTitle>Tournament Accounting</CardTitle>
               <CardDescription>
                 Charity is {formatCAD(PRICING.charityPortionCAD)} per paid entry. Operating costs
-                are billed across {OPERATING_COSTS.overheadMonths} months (the 2-year Euro / World
-                Cup prep cycle).
+                are the flat costs of running this ~2-month tournament.
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -195,11 +201,11 @@ export function AuditPageContent() {
                       variant="strong"
                     />
 
-                    <LedgerRow label="Net payout" amount={accounting.netPayout} variant="total" />
+                    <LedgerRow label="Net" amount={accounting.netPayout} variant="total" />
                   </dl>
                   <p className="text-muted-foreground mt-4 text-xs">
-                    Net payout is the surplus after charity and operating costs — the pool available
-                    to return to players, equivalently the operator&apos;s retained margin.
+                    Net is the surplus after charity and operating costs — the pool available to
+                    return to players, equivalently the operator&apos;s retained margin.
                   </p>
                 </>
               )}

--- a/frontend/src/app/audit/__tests__/AuditPageContent.test.tsx
+++ b/frontend/src/app/audit/__tests__/AuditPageContent.test.tsx
@@ -40,7 +40,7 @@ describe('AuditPageContent', () => {
     expect(screen.getByText('Gross income')).toBeInTheDocument();
     expect(screen.getByText('Charity')).toBeInTheDocument();
     expect(screen.getByText('Total costs')).toBeInTheDocument();
-    expect(screen.getByText('Net payout')).toBeInTheDocument();
+    expect(screen.getByText('Net')).toBeInTheDocument();
   });
 
   it('shows a loading state without crashing', () => {

--- a/frontend/src/app/audit/__tests__/AuditPageContent.test.tsx
+++ b/frontend/src/app/audit/__tests__/AuditPageContent.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+
+const mockUseQuery = jest.fn();
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+}));
+jest.mock('@/components/layout/PageLayout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { AuditPageContent } from '../AuditPageContent';
+
+const counts = {
+  tournament: { id: 't1', status: 'group_stage', lockTime: null },
+  totalRegistrations: 50,
+  usersWithPaidPrediction: 20,
+  totalEntries: 25,
+  cashPaidCount: 22,
+  freeEntries: 3,
+  referralCreditsRedeemed: 2,
+  loyaltyCreditsRedeemed: 1,
+};
+
+describe('AuditPageContent', () => {
+  beforeEach(() => mockUseQuery.mockReset());
+
+  it('renders the dashboard stats and accounting ledger', () => {
+    mockUseQuery.mockReturnValue({ data: counts, isLoading: false, isError: false });
+    render(<AuditPageContent />);
+
+    // Dashboard cards
+    expect(screen.getByText('Total members')).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
+    expect(screen.getByText('Paid members')).toBeInTheDocument();
+    expect(screen.getByText('$660')).toBeInTheDocument(); // 22 × $30 revenue
+    // Applied rewards = referral 2 + loyalty 1
+    expect(screen.getByText(/Referral 2 · Loyalty 1/)).toBeInTheDocument();
+
+    // Formal ledger
+    expect(screen.getByText('Gross income')).toBeInTheDocument();
+    expect(screen.getByText('Charity')).toBeInTheDocument();
+    expect(screen.getByText('Total costs')).toBeInTheDocument();
+    expect(screen.getByText('Net payout')).toBeInTheDocument();
+  });
+
+  it('shows a loading state without crashing', () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    render(<AuditPageContent />);
+    expect(screen.getByText('Total members')).toBeInTheDocument();
+  });
+
+  it('shows an error state', () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    render(<AuditPageContent />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/audit/page.tsx
+++ b/frontend/src/app/audit/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+import { AuditPageContent } from './AuditPageContent';
+
+export const metadata: Metadata = {
+  title: 'Audit | World Cup 2026',
+  description:
+    'Transparent, real-time accounting for the World Cup 2026 Prediction Game: members, paid entries, charity, operating costs, and net payout.',
+};
+
+export default function AuditPage() {
+  return <AuditPageContent />;
+}

--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { ScoringBreakdown } from '@/components/marketing/ScoringBreakdown';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { PRICING } from '@/lib/constants';
+import { Button } from '@/components/ui/button';
+import { PRICING, ROUTES } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Rules | World Cup 2026',
@@ -156,6 +159,29 @@ export default function RulesPage() {
                 tiebreaker. After it locks, every pick is frozen.
               </li>
             </ul>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Transparency &amp; audit</CardTitle>
+            <CardDescription>See exactly where the money goes.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground mb-4 text-sm">
+              We keep a live audit page open to every member: total members, paid entries, the
+              charity contribution ({PRICING.charityPortionCAD} {PRICING.currency} of every entry),
+              the full operating-cost breakdown, and the resulting net payout. Nothing is hidden —
+              the figures update in real time as entries are paid.
+            </p>
+            <Button asChild>
+              <Link href={ROUTES.audit}>
+                View the audit page
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
           </CardContent>
         </Card>
       </section>

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -7,6 +7,7 @@ import { ROUTES } from '@/lib/constants';
 const footerLinks = [
   { label: 'About', href: ROUTES.about },
   { label: 'Rules & Scoring', href: ROUTES.rules },
+  { label: 'Audit', href: ROUTES.audit },
   { label: 'Terms', href: ROUTES.terms },
   { label: 'Privacy', href: ROUTES.privacy },
 ];

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -27,6 +27,7 @@ const navLinks = [
   { label: 'Rules & Scoring', href: ROUTES.rules },
   { label: 'About', href: ROUTES.about },
   { label: 'Charities', href: ROUTES.charities },
+  { label: 'Audit', href: ROUTES.audit },
 ];
 
 export function Header() {

--- a/frontend/src/components/layout/PoolStatsBar.tsx
+++ b/frontend/src/components/layout/PoolStatsBar.tsx
@@ -2,7 +2,6 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { CircleDollarSign } from 'lucide-react';
 
@@ -35,36 +34,18 @@ const CHARITY_CENTS_FORMATTER = new Intl.NumberFormat('en-CA', {
 const formatCharityShare = (value: number) =>
   (Number.isInteger(value) ? POT_FORMATTER : CHARITY_CENTS_FORMATTER).format(value);
 
-// Tournament-facing pages where pool stats are contextually relevant.
-// Admin / account / auth / marketing pages stay clean.
-export const POOL_STATS_VISIBLE_PATHS: readonly string[] = [
-  ROUTES.home,
-  ROUTES.predictions,
-  ROUTES.leaderboard,
-  ROUTES.rules,
-  ROUTES.charities,
-  ROUTES.rewards,
-  ROUTES.referrals,
-];
-
-export function isPoolStatsVisiblePath(pathname: string): boolean {
-  return POOL_STATS_VISIBLE_PATHS.some((path) =>
-    path === ROUTES.home ? pathname === path : pathname === path || pathname.startsWith(`${path}/`)
-  );
-}
-
 /**
  * Slim sticky strip directly under the main Header showing the live pot total
  * and the charity-raised total, broken down evenly across the supported
- * charities. Shares the ['tournament'] React Query cache key with
- * HomePageContent so no extra request is issued when both mount on /.
+ * charities. Shown on every page for a logged-in user; hidden when logged out.
+ * Shares the ['tournament'] React Query cache key with HomePageContent so no
+ * extra request is issued when both mount on /.
  */
 export function PoolStatsBar({ className }: { className?: string }) {
-  const pathname = usePathname();
   const { user, loading } = useAuthContext();
   const query = useQuery<TournamentSlice>({
     queryKey: ['tournament'],
-    enabled: !loading && !!user && isPoolStatsVisiblePath(pathname),
+    enabled: !loading && !!user,
     queryFn: async () => {
       const res = await fetch('/api/tournament');
       if (!res.ok) throw new Error('Failed to fetch tournament');
@@ -72,7 +53,6 @@ export function PoolStatsBar({ className }: { className?: string }) {
     },
   });
 
-  if (!isPoolStatsVisiblePath(pathname)) return null;
   if (!user || !query.data) return null;
 
   const pot = POT_FORMATTER.format(query.data.potTotalCAD);

--- a/frontend/src/components/layout/__tests__/Footer.test.tsx
+++ b/frontend/src/components/layout/__tests__/Footer.test.tsx
@@ -57,14 +57,22 @@ describe('Footer', () => {
       expect(privacyLink).toBeInTheDocument();
       expect(privacyLink).toHaveAttribute('href', '/privacy');
     });
+
+    it('should render Audit link', () => {
+      render(<Footer />);
+
+      const auditLink = screen.getByRole('link', { name: 'Audit' });
+      expect(auditLink).toBeInTheDocument();
+      expect(auditLink).toHaveAttribute('href', '/audit');
+    });
   });
 
   describe('structure', () => {
-    it('should contain all four footer links', () => {
+    it('should contain all footer links', () => {
       render(<Footer />);
 
       const links = screen.getAllByRole('link');
-      expect(links).toHaveLength(4);
+      expect(links).toHaveLength(5);
     });
 
     it('should have navigation element for links', () => {

--- a/frontend/src/components/layout/__tests__/PoolStatsBar.test.tsx
+++ b/frontend/src/components/layout/__tests__/PoolStatsBar.test.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as React from 'react';
 
-import { PoolStatsBar, isPoolStatsVisiblePath } from '../PoolStatsBar';
+import { PoolStatsBar } from '../PoolStatsBar';
 
 let mockPathname = '/';
 jest.mock('next/navigation', () => ({
@@ -42,33 +42,6 @@ function mockTournamentResponse(potTotalCAD: number, charityTotalCAD: number) {
   }) as unknown as typeof fetch;
 }
 
-describe('isPoolStatsVisiblePath', () => {
-  it.each([
-    ['/', true],
-    ['/predictions', true],
-    ['/predictions/abc-123', true],
-    ['/leaderboard', true],
-    ['/rules', true],
-    ['/charities', true],
-    ['/charities/canadian-cancer-society', true],
-    ['/rewards', true],
-    ['/referrals', true],
-    ['/admin', false],
-    ['/admin/users/123', false],
-    ['/account', false],
-    ['/login', false],
-    ['/register', false],
-    ['/about', false],
-    ['/terms', false],
-    ['/privacy', false],
-    ['/forgot-password', false],
-    ['/reset-password', false],
-    ['/auth/callback', false],
-  ])('pathname %s → %s', (path, expected) => {
-    expect(isPoolStatsVisiblePath(path)).toBe(expected);
-  });
-});
-
 describe('PoolStatsBar', () => {
   it('renders the pot total and a per-charity breakdown on a tournament-facing page', async () => {
     mockPathname = '/predictions';
@@ -102,22 +75,15 @@ describe('PoolStatsBar', () => {
     expect(screen.getAllByText('$17.50')).toHaveLength(2);
   });
 
-  it('renders nothing on an admin route', () => {
+  it('renders on every page for a logged-in user (incl. previously-excluded routes)', async () => {
     mockPathname = '/admin/users/abc';
     mockTournamentResponse(1240, 206);
-    const { container } = render(wrap(<PoolStatsBar />));
-    expect(container).toBeEmptyDOMElement();
-    expect(global.fetch).not.toHaveBeenCalled();
+    render(wrap(<PoolStatsBar />));
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    expect(screen.getByRole('status')).toHaveTextContent(/\$1,240/);
   });
 
-  it('renders nothing on /account', () => {
-    mockPathname = '/account';
-    mockTournamentResponse(1240, 206);
-    const { container } = render(wrap(<PoolStatsBar />));
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('renders nothing when the user is logged out, even on a visible path', () => {
+  it('renders nothing when the user is logged out', () => {
     mockPathname = '/';
     authState.user = null;
     mockTournamentResponse(1240, 206);

--- a/frontend/src/components/shared/StatCard.tsx
+++ b/frontend/src/components/shared/StatCard.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/**
+ * Compact metric card: icon + label header, large value, optional subtitle.
+ * Shared by the admin dashboard and the /audit transparency page.
+ */
+export function StatCard({
+  icon: Icon,
+  label,
+  value,
+  subtitle,
+  isLoading,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: React.ReactNode;
+  subtitle?: React.ReactNode;
+  isLoading?: boolean;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription className="flex items-center gap-2">
+          <Icon className="h-4 w-4" />
+          {label}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-8 w-20" />
+        ) : (
+          <>
+            <div className="text-2xl font-bold">{value}</div>
+            {subtitle ? (
+              <p className="text-muted-foreground mt-1 text-xs">{subtitle}</p>
+            ) : null}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/__tests__/audit.test.ts
+++ b/frontend/src/lib/__tests__/audit.test.ts
@@ -3,13 +3,12 @@ import { computeAuditAccounting, type AuditCounts, type CostsConfig } from '../a
 const pricing = { entryFeeCAD: 30, charityPortionCAD: 5 };
 
 const costs: CostsConfig = {
-  overheadMonths: 24,
   devPerSubmissionCAD: 0.5,
   recurring: [
-    { label: 'Hosting', amount: 5, cadence: 'monthly' },
-    { label: 'AI tooling', amount: 157.5, cadence: 'monthly', attributionPct: 0.5 },
-    { label: 'Email', amount: 40, cadence: 'yearly' },
-    { label: 'Domain', amount: 150, cadence: 'multiYear', years: 4 },
+    { label: 'Hosting', amount: 10 },
+    { label: 'AI tooling', amount: 157.5 },
+    { label: 'Email', amount: 7 },
+    { label: 'Domain', amount: 6 },
   ],
 };
 
@@ -31,12 +30,12 @@ describe('computeAuditAccounting', () => {
     expect(result.charity).toBe(500); // 100 × $5
   });
 
-  it('normalizes each recurring cost cadence and applies attribution + overhead months', () => {
+  it('uses each recurring cost as a flat amount', () => {
     const byLabel = Object.fromEntries(result.costLines.map((l) => [l.label, l.amount]));
-    expect(byLabel['Hosting']).toBe(120); // $5/mo × 24
-    expect(byLabel['AI tooling']).toBe(1890); // $157.50/mo × 50% × 24
-    expect(byLabel['Email']).toBe(80); // ($40/12)/mo × 24
-    expect(byLabel['Domain']).toBe(75); // ($150/48)/mo × 24
+    expect(byLabel['Hosting']).toBe(10);
+    expect(byLabel['AI tooling']).toBe(157.5);
+    expect(byLabel['Email']).toBe(7);
+    expect(byLabel['Domain']).toBe(6);
   });
 
   it('charges dev/management per paid submission', () => {
@@ -45,29 +44,17 @@ describe('computeAuditAccounting', () => {
     expect(dev?.detail).toBe('$0.50 × 100 paid');
   });
 
-  it('annotates each line with its derivation', () => {
-    const byLabel = Object.fromEntries(result.costLines.map((l) => [l.label, l.detail]));
-    expect(byLabel['AI tooling']).toBe('$157.50/mo × 50% × 24 mo');
-    expect(byLabel['Email']).toBe('$40.00/yr × 24 mo');
-    expect(byLabel['Domain']).toBe('$150.00/4yr × 24 mo');
-  });
-
   it('totals costs and derives net payout / retained margin', () => {
-    expect(result.totalCosts).toBe(2215); // 120 + 1890 + 80 + 75 + 50
-    expect(result.netPayout).toBe(285); // 3000 − 500 − 2215
-    expect(result.retainedMargin).toBe(285);
-    expect(result.monthlyOverhead).toBeCloseTo(90.2083, 3); // 5 + 78.75 + 3.333 + 3.125
+    expect(result.totalCosts).toBe(230.5); // 10 + 157.5 + 7 + 6 + 50
+    expect(result.netPayout).toBe(2269.5); // 3000 − 500 − 230.5
+    expect(result.retainedMargin).toBe(2269.5);
   });
 
-  it('handles an empty pool without dividing by zero', () => {
-    const zero = computeAuditAccounting(
-      { ...counts, cashPaidCount: 0 },
-      { pricing, costs }
-    );
+  it('handles an empty pool — only flat recurring costs remain', () => {
+    const zero = computeAuditAccounting({ ...counts, cashPaidCount: 0 }, { pricing, costs });
     expect(zero.grossIncome).toBe(0);
     expect(zero.charity).toBe(0);
-    // Recurring overhead is fixed regardless of entries; net payout goes negative.
-    expect(zero.totalCosts).toBe(2165);
-    expect(zero.netPayout).toBe(-2165);
+    expect(zero.totalCosts).toBe(180.5); // recurring only, dev = 0
+    expect(zero.netPayout).toBe(-180.5);
   });
 });

--- a/frontend/src/lib/__tests__/audit.test.ts
+++ b/frontend/src/lib/__tests__/audit.test.ts
@@ -1,0 +1,73 @@
+import { computeAuditAccounting, type AuditCounts, type CostsConfig } from '../audit';
+
+const pricing = { entryFeeCAD: 30, charityPortionCAD: 5 };
+
+const costs: CostsConfig = {
+  overheadMonths: 24,
+  devPerSubmissionCAD: 0.5,
+  recurring: [
+    { label: 'Hosting', amount: 5, cadence: 'monthly' },
+    { label: 'AI tooling', amount: 157.5, cadence: 'monthly', attributionPct: 0.5 },
+    { label: 'Email', amount: 40, cadence: 'yearly' },
+    { label: 'Domain', amount: 150, cadence: 'multiYear', years: 4 },
+  ],
+};
+
+const counts: AuditCounts = {
+  totalRegistrations: 120,
+  usersWithPaidPrediction: 60,
+  totalEntries: 110,
+  cashPaidCount: 100,
+  freeEntries: 10,
+  referralCreditsRedeemed: 4,
+  loyaltyCreditsRedeemed: 3,
+};
+
+describe('computeAuditAccounting', () => {
+  const result = computeAuditAccounting(counts, { pricing, costs });
+
+  it('computes revenue and charity from cash-paid entries', () => {
+    expect(result.grossIncome).toBe(3000); // 100 × $30
+    expect(result.charity).toBe(500); // 100 × $5
+  });
+
+  it('normalizes each recurring cost cadence and applies attribution + overhead months', () => {
+    const byLabel = Object.fromEntries(result.costLines.map((l) => [l.label, l.amount]));
+    expect(byLabel['Hosting']).toBe(120); // $5/mo × 24
+    expect(byLabel['AI tooling']).toBe(1890); // $157.50/mo × 50% × 24
+    expect(byLabel['Email']).toBe(80); // ($40/12)/mo × 24
+    expect(byLabel['Domain']).toBe(75); // ($150/48)/mo × 24
+  });
+
+  it('charges dev/management per paid submission', () => {
+    const dev = result.costLines.find((l) => l.label === 'Development / Management');
+    expect(dev?.amount).toBe(50); // $0.50 × 100
+    expect(dev?.detail).toBe('$0.50 × 100 paid');
+  });
+
+  it('annotates each line with its derivation', () => {
+    const byLabel = Object.fromEntries(result.costLines.map((l) => [l.label, l.detail]));
+    expect(byLabel['AI tooling']).toBe('$157.50/mo × 50% × 24 mo');
+    expect(byLabel['Email']).toBe('$40.00/yr × 24 mo');
+    expect(byLabel['Domain']).toBe('$150.00/4yr × 24 mo');
+  });
+
+  it('totals costs and derives net payout / retained margin', () => {
+    expect(result.totalCosts).toBe(2215); // 120 + 1890 + 80 + 75 + 50
+    expect(result.netPayout).toBe(285); // 3000 − 500 − 2215
+    expect(result.retainedMargin).toBe(285);
+    expect(result.monthlyOverhead).toBeCloseTo(90.2083, 3); // 5 + 78.75 + 3.333 + 3.125
+  });
+
+  it('handles an empty pool without dividing by zero', () => {
+    const zero = computeAuditAccounting(
+      { ...counts, cashPaidCount: 0 },
+      { pricing, costs }
+    );
+    expect(zero.grossIncome).toBe(0);
+    expect(zero.charity).toBe(0);
+    // Recurring overhead is fixed regardless of entries; net payout goes negative.
+    expect(zero.totalCosts).toBe(2165);
+    expect(zero.netPayout).toBe(-2165);
+  });
+});

--- a/frontend/src/lib/audit.ts
+++ b/frontend/src/lib/audit.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure accounting layer for the /audit transparency page. All configurable
+ * money math lives here (driven by PRICING + OPERATING_COSTS in constants.ts)
+ * so it can be unit-tested in isolation and the page stays a thin renderer.
+ */
+
+export interface AuditCounts {
+  totalRegistrations: number;
+  usersWithPaidPrediction: number;
+  totalEntries: number;
+  cashPaidCount: number;
+  freeEntries: number;
+  referralCreditsRedeemed: number;
+  loyaltyCreditsRedeemed: number;
+}
+
+export interface RecurringCost {
+  label: string;
+  amount: number;
+  cadence: 'monthly' | 'yearly' | 'multiYear';
+  /** Required for `multiYear` cadence. */
+  years?: number;
+  /** Share of a shared subscription billed to this project (default 1). */
+  attributionPct?: number;
+}
+
+export interface CostsConfig {
+  overheadMonths: number;
+  devPerSubmissionCAD: number;
+  recurring: ReadonlyArray<RecurringCost>;
+}
+
+export interface PricingConfig {
+  entryFeeCAD: number;
+  charityPortionCAD: number;
+}
+
+export interface CostLine {
+  label: string;
+  amount: number;
+  /** Human-readable derivation, e.g. "$157.50/mo × 50% × 24 mo". */
+  detail: string;
+}
+
+export interface AuditAccounting {
+  grossIncome: number;
+  charity: number;
+  overheadMonths: number;
+  /** Effective combined overhead per month (recurring only, dev excluded). */
+  monthlyOverhead: number;
+  costLines: CostLine[];
+  totalCosts: number;
+  netPayout: number;
+  /** Same surplus as netPayout, framed as operator-retained rather than paid out. */
+  retainedMargin: number;
+}
+
+/** Normalize a recurring cost to a per-month rate before attribution. */
+function monthlyEquivalent(c: RecurringCost): number {
+  switch (c.cadence) {
+    case 'monthly':
+      return c.amount;
+    case 'yearly':
+      return c.amount / 12;
+    case 'multiYear':
+      return c.amount / ((c.years ?? 1) * 12);
+  }
+}
+
+function cadenceLabel(c: RecurringCost): string {
+  switch (c.cadence) {
+    case 'monthly':
+      return `$${c.amount.toFixed(2)}/mo`;
+    case 'yearly':
+      return `$${c.amount.toFixed(2)}/yr`;
+    case 'multiYear':
+      return `$${c.amount.toFixed(2)}/${c.years ?? 1}yr`;
+  }
+}
+
+export function computeAuditAccounting(
+  counts: AuditCounts,
+  config: { pricing: PricingConfig; costs: CostsConfig }
+): AuditAccounting {
+  const { pricing, costs } = config;
+  const { entryFeeCAD, charityPortionCAD } = pricing;
+  const { overheadMonths } = costs;
+
+  const grossIncome = counts.cashPaidCount * entryFeeCAD;
+  const charity = counts.cashPaidCount * charityPortionCAD;
+
+  let monthlyOverhead = 0;
+  const recurringLines: CostLine[] = costs.recurring.map((c) => {
+    const pct = c.attributionPct ?? 1;
+    const effectiveMonthly = monthlyEquivalent(c) * pct;
+    monthlyOverhead += effectiveMonthly;
+    const pctPart = pct === 1 ? '' : ` × ${Math.round(pct * 100)}%`;
+    return {
+      label: c.label,
+      amount: effectiveMonthly * overheadMonths,
+      detail: `${cadenceLabel(c)}${pctPart} × ${overheadMonths} mo`,
+    };
+  });
+
+  const dev = costs.devPerSubmissionCAD * counts.cashPaidCount;
+  const devLine: CostLine = {
+    label: 'Development / Management',
+    amount: dev,
+    detail: `$${costs.devPerSubmissionCAD.toFixed(2)} × ${counts.cashPaidCount} paid`,
+  };
+
+  const costLines = [...recurringLines, devLine];
+  const totalCosts = costLines.reduce((sum, l) => sum + l.amount, 0);
+  const netPayout = grossIncome - charity - totalCosts;
+
+  return {
+    grossIncome,
+    charity,
+    overheadMonths,
+    monthlyOverhead,
+    costLines,
+    totalCosts,
+    netPayout,
+    retainedMargin: netPayout,
+  };
+}

--- a/frontend/src/lib/audit.ts
+++ b/frontend/src/lib/audit.ts
@@ -2,6 +2,8 @@
  * Pure accounting layer for the /audit transparency page. All configurable
  * money math lives here (driven by PRICING + OPERATING_COSTS in constants.ts)
  * so it can be unit-tested in isolation and the page stays a thin renderer.
+ *
+ * Costs are flat per-tournament totals (no per-month / per-year normalization).
  */
 
 export interface AuditCounts {
@@ -16,16 +18,11 @@ export interface AuditCounts {
 
 export interface RecurringCost {
   label: string;
+  /** Flat dollar cost for the tournament. */
   amount: number;
-  cadence: 'monthly' | 'yearly' | 'multiYear';
-  /** Required for `multiYear` cadence. */
-  years?: number;
-  /** Share of a shared subscription billed to this project (default 1). */
-  attributionPct?: number;
 }
 
 export interface CostsConfig {
-  overheadMonths: number;
   devPerSubmissionCAD: number;
   recurring: ReadonlyArray<RecurringCost>;
 }
@@ -38,44 +35,18 @@ export interface PricingConfig {
 export interface CostLine {
   label: string;
   amount: number;
-  /** Human-readable derivation, e.g. "$157.50/mo × 50% × 24 mo". */
-  detail: string;
+  /** Optional human-readable derivation (e.g. dev cost per submission). */
+  detail?: string;
 }
 
 export interface AuditAccounting {
   grossIncome: number;
   charity: number;
-  overheadMonths: number;
-  /** Effective combined overhead per month (recurring only, dev excluded). */
-  monthlyOverhead: number;
   costLines: CostLine[];
   totalCosts: number;
   netPayout: number;
   /** Same surplus as netPayout, framed as operator-retained rather than paid out. */
   retainedMargin: number;
-}
-
-/** Normalize a recurring cost to a per-month rate before attribution. */
-function monthlyEquivalent(c: RecurringCost): number {
-  switch (c.cadence) {
-    case 'monthly':
-      return c.amount;
-    case 'yearly':
-      return c.amount / 12;
-    case 'multiYear':
-      return c.amount / ((c.years ?? 1) * 12);
-  }
-}
-
-function cadenceLabel(c: RecurringCost): string {
-  switch (c.cadence) {
-    case 'monthly':
-      return `$${c.amount.toFixed(2)}/mo`;
-    case 'yearly':
-      return `$${c.amount.toFixed(2)}/yr`;
-    case 'multiYear':
-      return `$${c.amount.toFixed(2)}/${c.years ?? 1}yr`;
-  }
 }
 
 export function computeAuditAccounting(
@@ -84,23 +55,14 @@ export function computeAuditAccounting(
 ): AuditAccounting {
   const { pricing, costs } = config;
   const { entryFeeCAD, charityPortionCAD } = pricing;
-  const { overheadMonths } = costs;
 
   const grossIncome = counts.cashPaidCount * entryFeeCAD;
   const charity = counts.cashPaidCount * charityPortionCAD;
 
-  let monthlyOverhead = 0;
-  const recurringLines: CostLine[] = costs.recurring.map((c) => {
-    const pct = c.attributionPct ?? 1;
-    const effectiveMonthly = monthlyEquivalent(c) * pct;
-    monthlyOverhead += effectiveMonthly;
-    const pctPart = pct === 1 ? '' : ` × ${Math.round(pct * 100)}%`;
-    return {
-      label: c.label,
-      amount: effectiveMonthly * overheadMonths,
-      detail: `${cadenceLabel(c)}${pctPart} × ${overheadMonths} mo`,
-    };
-  });
+  const recurringLines: CostLine[] = costs.recurring.map((c) => ({
+    label: c.label,
+    amount: c.amount,
+  }));
 
   const dev = costs.devPerSubmissionCAD * counts.cashPaidCount;
   const devLine: CostLine = {
@@ -116,8 +78,6 @@ export function computeAuditAccounting(
   return {
     grossIncome,
     charity,
-    overheadMonths,
-    monthlyOverhead,
     costLines,
     totalCosts,
     netPayout,

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -44,32 +44,20 @@ export const PRICING = {
  * Operating-cost model for the /audit transparency page. Every value here is
  * meant to be edited directly when costs change.
  *
- * - `overheadMonths`: the window of recurring overhead attributed to one
- *   tournament. The pool runs ~2 months, but prep runs on a 2-year
- *   (Euro/World-Cup) cadence, so recurring costs are billed across 24 months.
- * - `recurring[]`: each cost is normalized to a monthly rate, multiplied by its
- *   `attributionPct` (share of a shared subscription billed to this project —
- *   default 1), then by `overheadMonths`. Cadences:
- *     monthly  → amount
- *     yearly   → amount / 12
- *     multiYear→ amount / (years * 12)
+ * Flat totals for one tournament (~2 months) — no per-month / per-year
+ * normalization. Just set each line to the dollar amount it costs to run this
+ * tournament.
+ *
+ * - `recurring[]`: one-time/flat cost lines for the tournament.
  * - `devPerSubmissionCAD`: development / management cost, charged per paid
- *   submission (entry). `devFlatCAD` is kept as the alternative basis.
+ *   submission (entry).
  */
 export const OPERATING_COSTS = {
-  overheadMonths: 24,
   devPerSubmissionCAD: 0.5,
-  devFlatCAD: 300,
   recurring: [
-    { label: 'Hosting', amount: 5, cadence: 'monthly' },
-    {
-      label: 'Claude (Anthropic) + JetBrains',
-      amount: 157.5,
-      cadence: 'monthly',
-      attributionPct: 0.5,
-    },
-    { label: 'Email service', amount: 40, cadence: 'yearly' },
-    { label: 'Domain', amount: 150, cadence: 'multiYear', years: 4 },
+    { label: 'Domain', amount: 150 },
+    { label: 'Hosting / Email', amount: 124 },
+    { label: 'Software Services (AI / tooling)', amount: 78.5 },
   ],
 } as const;
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -41,6 +41,39 @@ export const PRICING = {
 } as const;
 
 /**
+ * Operating-cost model for the /audit transparency page. Every value here is
+ * meant to be edited directly when costs change.
+ *
+ * - `overheadMonths`: the window of recurring overhead attributed to one
+ *   tournament. The pool runs ~2 months, but prep runs on a 2-year
+ *   (Euro/World-Cup) cadence, so recurring costs are billed across 24 months.
+ * - `recurring[]`: each cost is normalized to a monthly rate, multiplied by its
+ *   `attributionPct` (share of a shared subscription billed to this project —
+ *   default 1), then by `overheadMonths`. Cadences:
+ *     monthly  → amount
+ *     yearly   → amount / 12
+ *     multiYear→ amount / (years * 12)
+ * - `devPerSubmissionCAD`: development / management cost, charged per paid
+ *   submission (entry). `devFlatCAD` is kept as the alternative basis.
+ */
+export const OPERATING_COSTS = {
+  overheadMonths: 24,
+  devPerSubmissionCAD: 0.5,
+  devFlatCAD: 300,
+  recurring: [
+    { label: 'Hosting', amount: 5, cadence: 'monthly' },
+    {
+      label: 'Claude (Anthropic) + JetBrains',
+      amount: 157.5,
+      cadence: 'monthly',
+      attributionPct: 0.5,
+    },
+    { label: 'Email service', amount: 40, cadence: 'yearly' },
+    { label: 'Domain', amount: 150, cadence: 'multiYear', years: 4 },
+  ],
+} as const;
+
+/**
  * Labels for the 8 ranked 3rd-place advancer slots, shown in the wizard
  * and admin UI. Rank 1 = "best" 3rd-place team, rank 8 = "8th best".
  */
@@ -70,6 +103,7 @@ export const ROUTES = {
   account: '/account',
   about: '/about',
   charities: '/charities',
+  audit: '/audit',
   rules: '/rules',
   terms: '/terms',
   privacy: '/privacy',

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared CAD currency formatting. Consolidates the `Intl.NumberFormat('en-CA',
+ * …)` pattern that's otherwise duplicated across PoolStatsBar / AdminDashboard /
+ * HomePageContent.
+ *
+ * By default whole-dollar (no cents) to match the existing pot/charity display;
+ * pass `{ cents: true }` for two-decimal amounts (fractional cost lines, etc.).
+ */
+const WHOLE = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+  maximumFractionDigits: 0,
+});
+
+const CENTS = new Intl.NumberFormat('en-CA', {
+  style: 'currency',
+  currency: 'CAD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export function formatCAD(value: number, opts?: { cents?: boolean }): string {
+  return (opts?.cents ? CENTS : WHOLE).format(value);
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -9,6 +9,7 @@ const PROTECTED_PREFIXES = [
   '/referrals',
   '/rewards',
   '/results',
+  '/audit',
 ];
 
 // Using the deprecated middleware.ts name (not Next 16's proxy.ts) because

--- a/supabase/migrations/0056_audit_stats.sql
+++ b/supabase/migrations/0056_audit_stats.sql
@@ -1,0 +1,76 @@
+-- 0056_audit_stats.sql
+--
+-- Public-facing (logged-in) transparency RPC for the /audit page. Returns the
+-- PII-free subset of admin_get_dashboard_stats (0043): aggregate counts only,
+-- no usernames / emails / top users / champion picks.
+--
+-- SECURITY DEFINER + granted to `authenticated` (NOT anon): regular users
+-- can't aggregate tournament_payments / *_redemptions directly because RLS on
+-- those tables is owner-scoped, so the aggregation has to run as definer.
+-- The function exposes only counts, so it's safe for any signed-in user.
+--
+-- "Applied rewards" = redeemed free-pick credits (referral + loyalty), i.e.
+-- the rows in referral_redemptions / loyalty_redemptions.
+
+drop function if exists public.get_audit_stats(uuid);
+
+create or replace function public.get_audit_stats(p_tournament_id uuid)
+returns table (
+    total_registrations int,
+    users_with_paid_prediction int,
+    total_entries int,
+    cash_paid_count int,
+    free_entries int,
+    referral_credits_redeemed int,
+    loyalty_credits_redeemed int
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+    v_lock_time timestamptz;
+begin
+    if auth.uid() is null then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    select t.lock_time into v_lock_time
+    from public.tournaments t
+    where t.id = p_tournament_id;
+
+    return query
+    with paid_per_user as (
+        -- Per-user count of paid entries (cash + free, paid before lock).
+        -- Mirrors admin_get_dashboard_stats so the two surfaces agree.
+        select p.user_id, count(*)::int as paid_count
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and tp.paid_at <= v_lock_time
+        group by p.user_id
+    ),
+    cash_per_user as (
+        -- Per-user count of CASH-paid entries (is_free = false) — drives revenue.
+        select p.user_id, count(*)::int as cash_count
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and tp.is_free = false
+        group by p.user_id
+    )
+    select
+        (select count(*)::int from public.profiles)                          as total_registrations,
+        (select count(*)::int from paid_per_user)                            as users_with_paid_prediction,
+        (select coalesce(sum(paid_count), 0)::int from paid_per_user)        as total_entries,
+        (select coalesce(sum(cash_count), 0)::int from cash_per_user)        as cash_paid_count,
+        (select coalesce(sum(paid_count), 0)::int from paid_per_user)
+            - (select coalesce(sum(cash_count), 0)::int from cash_per_user)  as free_entries,
+        (select count(*)::int from public.referral_redemptions)              as referral_credits_redeemed,
+        (select count(*)::int from public.loyalty_redemptions lr
+            where lr.tournament_id = p_tournament_id)                        as loyalty_credits_redeemed;
+end;
+$$;
+
+grant execute on function public.get_audit_stats(uuid) to authenticated;


### PR DESCRIPTION
Adds a dedicated **Audit** page (logged-in only) showing real-time aggregate stats and a formal, configurable accounting breakdown — revenue → charity → operating costs → net payout.

## Data
- **Migration `0056_audit_stats.sql`** — new `get_audit_stats(p_tournament_id)` `SECURITY DEFINER` RPC granted to `authenticated`. Returns the **PII-free** subset of `admin_get_dashboard_stats` (counts only; no usernames/emails/top-users). Required because RLS on payments/redemptions is owner-scoped.
- **`GET /api/audit/stats`** — auth-required (401 otherwise); returns raw camelCase counts + tournament meta. No money math here.

## Accounting (pure + configurable)
- **`lib/audit.ts` `computeAuditAccounting`** — normalizes each recurring cost to monthly (`monthly` / `yearly`/12 / `multiYear`/(years×12)), applies a per-line `attributionPct` (Claude/JetBrains = 50%), × `overheadMonths`, plus dev `$0.50 × paid submissions`. Derives `totalCosts`, `netPayout = gross − charity − costs`, and the same value as `retainedMargin`.
- **`OPERATING_COSTS` in `constants.ts`** — all costs editable in one place (hosting, Claude/JetBrains @50%, email/yr, domain $150/4yr, dev/submission, `overheadMonths = 24` for the 2-year Euro/WC prep cycle). Charity stays flat `$5/entry`.
- **`lib/currency.ts` `formatCAD`** consolidates the duplicated CAD formatter. Shared `StatCard` extracted (now used by both the audit page and `AdminDashboard`).

## UI + wiring
- **`/audit`** — dashboard cards (total members, paid members, revenue, applied rewards) + a formal ledger; 30s real-time refetch.
- Nav link after **Charities**, footer link, `/audit` added to `PROTECTED_PREFIXES`, and a **Transparency & audit** section on the Rules page linking to it.

## Tests
- `computeAuditAccounting` unit (cadence/attribution/dev/net math, empty-pool), API route (401 / mapped counts / no-PII / 404), and page component (cards + ledger render, loading, error).
- Full suite green: 443 passing; typecheck + lint clean.

## Note / not yet verified
- The migration hasn't been applied to a database in this branch (no prod verification per repo policy). Apply locally via `supabase db reset` (or push `0056`) before deploy; figures should agree with `/admin` dashboard counts.

## Open assumption
- `overheadMonths = 24` drives Total Costs and dominates Net Payout (AI tooling at 50% = $78.75/mo × 24 ≈ $1,890). One-line change in `OPERATING_COSTS` if a different window is preferred.