### PR TITLE
feat(audit): color Net green/red by sign

### DIFF
--- a/frontend/src/app/audit/AuditPageContent.tsx
+++ b/frontend/src/app/audit/AuditPageContent.tsx
@@ -54,6 +54,10 @@ function LedgerRow({
         className={cn(
           'shrink-0 font-mono tabular-nums',
           variant === 'total' && 'text-lg font-bold',
+          variant === 'total' &&
+            (amount < 0
+              ? 'text-red-600 dark:text-red-400'
+              : 'text-green-700 dark:text-green-400'),
           variant === 'strong' && 'font-semibold'
         )}
       >

--- a/frontend/src/app/audit/__tests__/AuditPageContent.test.tsx
+++ b/frontend/src/app/audit/__tests__/AuditPageContent.test.tsx
@@ -9,6 +9,15 @@ jest.mock('@/components/layout/PageLayout', () => ({
 }));
 
 import { AuditPageContent } from '../AuditPageContent';
+import { computeAuditAccounting } from '@/lib/audit';
+import { OPERATING_COSTS, PRICING } from '@/lib/constants';
+import { formatCAD } from '@/lib/currency';
+
+function netDisplay(c: typeof counts): string {
+  const net = computeAuditAccounting(c, { pricing: PRICING, costs: OPERATING_COSTS }).netPayout;
+  const sign = net < 0 ? '−' : '';
+  return `${sign}${formatCAD(Math.abs(net), { cents: true })}`;
+}
 
 const counts = {
   tournament: { id: 't1', status: 'group_stage', lockTime: null },
@@ -41,6 +50,21 @@ describe('AuditPageContent', () => {
     expect(screen.getByText('Charity')).toBeInTheDocument();
     expect(screen.getByText('Total costs')).toBeInTheDocument();
     expect(screen.getByText('Net')).toBeInTheDocument();
+  });
+
+  it('colors Net green when positive and red when negative', () => {
+    // Healthy pool → positive net, green.
+    const positive = { ...counts, cashPaidCount: 200 };
+    mockUseQuery.mockReturnValue({ data: positive, isLoading: false, isError: false });
+    const { unmount } = render(<AuditPageContent />);
+    expect(screen.getByText(netDisplay(positive))).toHaveClass('text-green-700');
+    unmount();
+
+    // Tiny pool → costs exceed income, negative net, red.
+    const negative = { ...counts, cashPaidCount: 5 };
+    mockUseQuery.mockReturnValue({ data: negative, isLoading: false, isError: false });
+    render(<AuditPageContent />);
+    expect(screen.getByText(netDisplay(negative))).toHaveClass('text-red-600');
   });
 
   it('shows a loading state without crashing', () => {


### PR DESCRIPTION
On the /audit ledger, the **Net** total is now colored by sign — green (`text-green-700 dark:text-green-400`) when ≥ 0, red (`text-red-600 dark:text-red-400`) when negative — so the bottom line reads at a glance.

Only the `total` row is colored; other rows are unchanged.

Tests: added a sign-color assertion (positive → green, negative → red), computed from the live config so it won't drift if cost values change. Full suite green (422), typecheck + lint clean.