### PR TITLE
feat(header): priority+ nav with More menu, container queries & fluid sizing

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Menu } from 'lucide-react';
+import { ChevronDown, Menu } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { ROUTES } from '@/lib/constants';
@@ -16,19 +16,46 @@ import {
   NavigationMenuLink,
   navigationMenuTriggerStyle,
 } from '@/components/ui/navigation-menu';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 
-const navLinks = [
-  { label: 'Home', href: ROUTES.home },
-  { label: 'Predictions', href: ROUTES.predictions },
-  { label: 'Leaderboard', href: ROUTES.leaderboard },
-  { label: 'Results', href: ROUTES.results },
-  { label: 'Rules & Scoring', href: ROUTES.rules },
-  { label: 'About', href: ROUTES.about },
-  { label: 'Charities', href: ROUTES.charities },
-  { label: 'Audit', href: ROUTES.audit },
+/**
+ * Priority+ navigation tiers. `always` links stay inline from `md` up;
+ * `reveal-1`/`reveal-2` start inside the More menu and pop inline once the
+ * header container is wide enough (otherwise they stay grouped); `more` links
+ * always live under the More menu. The progressive reveal is pure CSS via
+ * Tailwind v4 `@container` queries — no JS measurement, no layout shift.
+ */
+type NavTier = 'always' | 'reveal-1' | 'reveal-2' | 'more';
+type NavLink = { label: string; href: string; tier: NavTier };
+
+const navLinks: NavLink[] = [
+  { label: 'Home', href: ROUTES.home, tier: 'always' },
+  { label: 'Predictions', href: ROUTES.predictions, tier: 'always' },
+  { label: 'Leaderboard', href: ROUTES.leaderboard, tier: 'always' },
+  { label: 'Results', href: ROUTES.results, tier: 'reveal-1' },
+  { label: 'Rules & Scoring', href: ROUTES.rules, tier: 'reveal-2' },
+  { label: 'About', href: ROUTES.about, tier: 'more' },
+  { label: 'Charities', href: ROUTES.charities, tier: 'more' },
+  { label: 'Audit', href: ROUTES.audit, tier: 'more' },
 ];
+
+// Reveal threshold per tier, keyed to the header container's inline size.
+// `reveal-1` (Results) pops inline at ≥52rem, `reveal-2` (Rules) at ≥64rem.
+// Each copy carries exactly one of these classes so the inline and More copies
+// are never visible at the same width.
+const INLINE_REVEAL_CLASS: Record<Exclude<NavTier, 'always' | 'more'>, string> = {
+  'reveal-1': 'hidden @min-[52rem]:inline-flex',
+  'reveal-2': 'hidden @min-[64rem]:inline-flex',
+};
+const MORE_HIDE_CLASS: Record<Exclude<NavTier, 'always' | 'more'>, string> = {
+  'reveal-1': '@min-[52rem]:hidden',
+  'reveal-2': '@min-[64rem]:hidden',
+};
+
+// Fluid type/spacing so the bar eases down before anything needs to collapse.
+const NAV_LINK_PADDING = 'px-[clamp(0.5rem,1.2vw,1rem)]';
 
 export function Header() {
   const pathname = usePathname();
@@ -41,34 +68,56 @@ export function Header() {
     return pathname.startsWith(href);
   };
 
+  // Links eligible for the More menu (everything that isn't always-inline),
+  // and whether the active route currently lives there. We only flag `more`
+  // links as "active under More" — `reveal-*` links light up inline at the
+  // widths where they're shown, so highlighting More for them would double up.
+  const moreLinks = navLinks.filter((link) => link.tier !== 'always');
+  const moreActive = navLinks.some((link) => link.tier === 'more' && isActive(link.href));
+
   return (
     <header className="border-border bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 w-full border-b backdrop-blur">
-      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+      <div className="@container mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href={ROUTES.home} className="flex items-center space-x-2">
-          <span className="text-foreground text-xl font-bold">soccer-pool 2026</span>
+          <span className="text-foreground text-[clamp(1rem,0.9rem+0.5vw,1.25rem)] font-bold">
+            soccer-pool 2026
+          </span>
         </Link>
 
         <NavigationMenu className="hidden md:flex">
-          <NavigationMenuList>
-            {navLinks.map((link) => (
-              <NavigationMenuItem key={link.href}>
-                <NavigationMenuLink asChild>
-                  <Link
-                    href={link.href}
-                    className={cn(
-                      navigationMenuTriggerStyle(),
-                      isActive(link.href) && 'bg-accent text-accent-foreground font-semibold'
-                    )}
-                  >
-                    {link.label}
-                  </Link>
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-            ))}
+          <NavigationMenuList className="space-x-0 gap-[clamp(0.125rem,0.4vw,0.5rem)]">
+            {navLinks
+              .filter((link) => link.tier === 'always' || link.tier === 'reveal-1' || link.tier === 'reveal-2')
+              .map((link) => (
+                <NavigationMenuItem
+                  key={link.href}
+                  className={
+                    link.tier === 'reveal-1' || link.tier === 'reveal-2'
+                      ? INLINE_REVEAL_CLASS[link.tier]
+                      : undefined
+                  }
+                >
+                  <NavigationMenuLink asChild>
+                    <Link
+                      href={link.href}
+                      className={cn(
+                        navigationMenuTriggerStyle(),
+                        NAV_LINK_PADDING,
+                        isActive(link.href) && 'bg-accent text-accent-foreground font-semibold'
+                      )}
+                    >
+                      {link.label}
+                    </Link>
+                  </NavigationMenuLink>
+                </NavigationMenuItem>
+              ))}
+            <NavigationMenuItem>
+              <MoreMenu links={moreLinks} isActive={isActive} active={moreActive} mounted={mounted} />
+            </NavigationMenuItem>
           </NavigationMenuList>
         </NavigationMenu>
 
-        <div className="hidden items-center gap-4 md:flex">
+        <div className="hidden items-center gap-[clamp(0.5rem,1.5vw,1rem)] md:flex">
           <ThemeToggle />
           <AuthMenu />
         </div>
@@ -121,5 +170,76 @@ export function Header() {
         </div>
       </div>
     </header>
+  );
+}
+
+/**
+ * The "More ▾" overflow menu for the desktop nav. Holds the lower-priority
+ * links; `reveal-*` links carry a `@container` hide class so they drop out of
+ * this list at the exact width their inline copy appears. Mirrors AuthMenu's
+ * hydration dodge — a plain disabled placeholder renders until mount so the
+ * Radix Popover's useId-driven aria-controls doesn't drift between SSR and
+ * client.
+ */
+function MoreMenu({
+  links,
+  isActive,
+  active,
+  mounted,
+}: {
+  links: NavLink[];
+  isActive: (href: string) => boolean;
+  active: boolean;
+  mounted: boolean;
+}) {
+  const triggerClass = cn(
+    navigationMenuTriggerStyle(),
+    NAV_LINK_PADDING,
+    'gap-1',
+    active && 'bg-accent text-accent-foreground font-semibold'
+  );
+
+  if (!mounted) {
+    return (
+      <button type="button" className={triggerClass} aria-label="More navigation" disabled>
+        More
+        <ChevronDown className="h-3 w-3" aria-hidden="true" />
+      </button>
+    );
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button type="button" className={cn(triggerClass, 'group')} aria-label="More navigation">
+          More
+          <ChevronDown
+            className="h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
+            aria-hidden="true"
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-52 p-2">
+        <nav className="flex flex-col">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={cn(
+                'hover:bg-accent hover:text-accent-foreground rounded-md px-3 py-2 text-sm transition-colors',
+                isActive(link.href)
+                  ? 'bg-accent text-accent-foreground font-semibold'
+                  : 'text-muted-foreground',
+                link.tier === 'reveal-1' || link.tier === 'reveal-2'
+                  ? MORE_HIDE_CLASS[link.tier]
+                  : undefined
+              )}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Header } from '../Header';
+
+// AuthMenu pulls in auth + rewards; stub them to a signed-out state so the
+// header renders without a provider tree. (jsdom doesn't apply the @container
+// reveal classes, so every priority+ copy is present in the DOM — queries that
+// could match duplicates use getAllByRole / scoped `within`.)
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: null, profile: null, signOut: jest.fn() }),
+}));
+jest.mock('@/hooks/useRewardsStatus', () => ({
+  useRewardsStatus: () => ({ status: { totalAvailable: 0 } }),
+}));
+jest.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'light', setTheme: jest.fn(), resolvedTheme: 'light' }),
+}));
+
+const ALL_DESTINATIONS: Array<[string, string]> = [
+  ['Home', '/'],
+  ['Predictions', '/predictions'],
+  ['Leaderboard', '/leaderboard'],
+  ['Results', '/results'],
+  ['Rules & Scoring', '/rules'],
+  ['About', '/about'],
+  ['Charities', '/charities'],
+  ['Audit', '/audit'],
+];
+
+/** True if any rendered link with this accessible name points at `href`. */
+function hasLinkTo(name: string, href: string): boolean {
+  return screen
+    .getAllByRole('link', { name })
+    .some((el) => el.getAttribute('href') === href);
+}
+
+describe('Header', () => {
+  it('renders the always-inline primary links plus a More overflow trigger', () => {
+    render(<Header />);
+
+    expect(hasLinkTo('Home', '/')).toBe(true);
+    expect(hasLinkTo('Predictions', '/predictions')).toBe(true);
+    expect(hasLinkTo('Leaderboard', '/leaderboard')).toBe(true);
+
+    expect(screen.getByRole('button', { name: /more navigation/i })).toBeInTheDocument();
+  });
+
+  it('exposes the secondary destinations through the More menu', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    await user.click(screen.getByRole('button', { name: /more navigation/i }));
+
+    // The Radix popover portals its content open; the secondary links live there
+    // (Results/Rules also keep their inline copies, hence the document-wide check).
+    for (const [name, href] of [
+      ['Results', '/results'],
+      ['Rules & Scoring', '/rules'],
+      ['About', '/about'],
+      ['Charities', '/charities'],
+      ['Audit', '/audit'],
+    ] as Array<[string, string]>) {
+      expect(hasLinkTo(name, href)).toBe(true);
+    }
+  });
+
+  it('lists every destination in the mobile drawer', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    await user.click(screen.getByRole('button', { name: /open menu/i }));
+
+    const drawer = screen.getByRole('dialog');
+    for (const [name, href] of ALL_DESTINATIONS) {
+      const link = within(drawer).getByRole('link', { name });
+      expect(link).toHaveAttribute('href', href);
+    }
+  });
+});


### PR DESCRIPTION
## Problem
The header had a single `md` (768px) breakpoint that flipped between **all 8 nav links inline** and a hamburger drawer. In the ~768–1024px zone (small tablets, split-screen, browser zoom) the 8 links — Home, Predictions, Leaderboard, Results, Rules & Scoring, About, Charities, Audit — plus logo, theme toggle, and auth menu fought over one 64px row, so items wrapped or got clipped. No fluid sizing, no overflow handling.

## Approach (CSS-first priority+ navigation)
- **Always inline (from `md`):** Home · Predictions · Leaderboard
- **Progressive reveal** via Tailwind v4 `@container` queries: **Results** pops inline at container ≥52rem, **Rules & Scoring** at ≥64rem
- **Grouped under More ▾:** About · Charities · Audit (plus Results/Rules while too narrow)
- **`clamp()`** fluidly shrinks nav gap, link padding, logo, and the control-cluster gap so the bar eases down before anything collapses

At full width: `Home Predictions Leaderboard Results Rules · More▾(About, Charities, Audit) · [☀][User]` — never 8 flat links, never clipped.

## Implementation notes
- **No JS measurement** — a pure-CSS "duplicate-and-toggle" technique: only Results & Rules render twice (an inline copy + a More copy), and `@container` classes guarantee exactly one is visible at any width. Zero layout shift, SSR-safe.
- **More ▾ reuses the existing Radix `Popover`** (no new dep), gated behind `useMounted()` exactly like `AuthMenu` to avoid the known `useId`/`aria-controls` hydration mismatch.
- **More trigger highlights** when the active route is one of its `more`-tier items.
- Shared `navigation-menu.tsx` / `popover.tsx` primitives are untouched — all changes scoped to `Header.tsx`. Mobile drawer unchanged.

## Tests
- New `src/components/layout/Header.test.tsx`: asserts the primary links + More trigger render, the secondary destinations are reachable via the More menu, and the mobile drawer still lists all 8.
- `npm test` (425 passed) · `npm run typecheck` clean · `npm run lint` 0 errors.
- Dev-server smoke: `/` returns 200 with the new header markup compiling cleanly.

> Note: `@container` reveal thresholds (52rem / 64rem) query the whole header row, not the nav's leftover space, so they may want a quick eyeball-tune in the running app. Local-only verification per CLAUDE.md — not tested against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)