### PR TITLE
feat(leaderboard): restrict previewing others' brackets until Phase 2 locks

### DIFF
--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
-import { ArrowRight, Search, Trophy, Users } from 'lucide-react';
+import { ArrowRight, Lock, Search, Trophy, Users } from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
@@ -46,11 +46,19 @@ interface LeaderboardResponse {
 
 export function LeaderboardPageContent() {
   const { user, profile } = useAuth();
-  const { isLocked } = useTournamentLock();
+  const { isLocked, phase } = useTournamentLock();
   const [currentPage, setCurrentPage] = React.useState(1);
   const [highlightedRank, setHighlightedRank] = React.useState<number | null>(null);
 
   const currentUsername = profile?.username ?? null;
+  // Staff (admin or super-admin — the latter doesn't imply the former) can
+  // always preview every bracket. Everyone else is limited to their own
+  // entries until knockout picks are frozen (`phase2_locked`), so a player
+  // can't copy a still-editable rival's picks. Fails closed while the
+  // tournament query is loading (phase defaults to phase1 → restricted).
+  const isStaff = !!profile?.isAdmin || !!profile?.isSuperAdmin;
+  const previewOthersLocked = phase !== 'phase2_locked';
+  const canPreviewOthers = isStaff || !previewOthersLocked;
   // The leaderboard response shape depends on the viewer's identity:
   // admins get an extra `email` field, anon/auth users don't. Bake the
   // viewer kind into the cache key so logging in/out triggers a fresh
@@ -194,6 +202,17 @@ export function LeaderboardPageContent() {
         </div>
       </div>
 
+      {!isStaff && previewOthersLocked && !isLoading && (
+        <div className="border-muted-foreground/20 bg-muted/40 text-muted-foreground mb-6 flex items-start gap-2 rounded-md border px-4 py-3 text-sm">
+          <Lock className="mt-0.5 h-4 w-4 shrink-0" />
+          <p>
+            <span className="text-foreground font-medium">Heads up —</span> you can preview only
+            your own brackets for now. Everyone&apos;s brackets open for viewing once the knockout
+            bracket locks. This keeps picks private while they can still be edited.
+          </p>
+        </div>
+      )}
+
       <Card className="mb-6">
         <CardContent className="p-0">
           {isLoading ? (
@@ -204,6 +223,7 @@ export function LeaderboardPageContent() {
               currentUsername={currentUsername}
               highlightedRank={highlightedRank}
               enablePreview={!!user}
+              canPreviewOthers={canPreviewOthers}
               // Edit deep-link only while predictions are still editable.
               enableEdit={!!user && !isLocked}
             />

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -31,6 +31,13 @@ export interface LeaderboardTableProps {
    */
   enablePreview?: boolean;
   /**
+   * When true, the viewer may preview rows that aren't their own. When false,
+   * other players' Preview buttons render faded + disabled (own rows stay
+   * clickable). Gates copying picks while predictions are still editable —
+   * the RPC enforces the same rule, this is just the matching affordance.
+   */
+  canPreviewOthers?: boolean;
+  /**
    * When true, render an Edit button on the current user's own rows that
    * deep-links to the prediction editor. Callers should only pass this while
    * the tournament is unlocked (predictions are editable). Row ownership is
@@ -95,6 +102,7 @@ export function LeaderboardTable({
   highlightedRank,
   className,
   enablePreview = false,
+  canPreviewOthers = false,
   enableEdit = false,
 }: LeaderboardTableProps) {
   const [previewId, setPreviewId] = React.useState<string | null>(null);
@@ -123,6 +131,7 @@ export function LeaderboardTable({
             const isHighlighted = highlightedRank && entry.rank === highlightedRank;
             const rankBadge = getRankBadge(entry.rank);
             const isEvenRow = index % 2 === 0;
+            const canPreviewThisRow = isCurrentUser || canPreviewOthers;
 
             return (
               <TableRow
@@ -177,18 +186,32 @@ export function LeaderboardTable({
                 {showActions && (
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
-                      {enablePreview && (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setPreviewId(entry.predictionId)}
-                          aria-label={`Preview ${entry.predictionName}'s bracket`}
-                        >
-                          <Eye className="mr-1.5 h-4 w-4" />
-                          Preview
-                        </Button>
-                      )}
+                      {enablePreview &&
+                        (canPreviewThisRow ? (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setPreviewId(entry.predictionId)}
+                            aria-label={`Preview ${entry.predictionName}'s bracket`}
+                          >
+                            <Eye className="mr-1.5 h-4 w-4" />
+                            Preview
+                          </Button>
+                        ) : (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            disabled
+                            className="cursor-not-allowed opacity-50"
+                            aria-label={`Previewing ${entry.predictionName}'s bracket unlocks when the knockout bracket locks`}
+                            title="Previewing other players' brackets unlocks when the knockout bracket locks"
+                          >
+                            <Eye className="mr-1.5 h-4 w-4" />
+                            Preview
+                          </Button>
+                        ))}
                       {enableEdit && isCurrentUser && (
                         <Button
                           type="button"

--- a/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
+++ b/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
 import { LeaderboardTable } from '../LeaderboardTable';
 import type { LeaderboardEntry } from '@/types/tournament';
+
+// Enabling preview mounts BracketPreviewDialog, which calls useQuery.
+function wrap(children: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
 
 const entries: LeaderboardEntry[] = [
   {
@@ -103,5 +113,46 @@ describe('LeaderboardTable', () => {
   it('omits Edit links when enableEdit is not set', () => {
     render(<LeaderboardTable entries={entries} currentUsername="bob" />);
     expect(screen.queryByRole('link', { name: /^Edit / })).not.toBeInTheDocument();
+  });
+
+  it('enables Preview only on the own row and disables others when canPreviewOthers is false', () => {
+    render(
+      wrap(
+        <LeaderboardTable
+          entries={entries}
+          currentUsername="bob"
+          enablePreview
+          canPreviewOthers={false}
+        />
+      )
+    );
+    // bob owns p2 (Bracket A) → his Preview is clickable.
+    const ownPreview = screen.getByRole('button', { name: "Preview Bracket A's bracket" });
+    expect(ownPreview).toBeEnabled();
+    // Other players' Preview buttons are still rendered but disabled.
+    const lockedPreviews = screen.getAllByRole('button', {
+      name: /unlocks when the knockout bracket locks$/,
+    });
+    expect(lockedPreviews).toHaveLength(2);
+    lockedPreviews.forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it('enables every Preview button when canPreviewOthers is true', () => {
+    render(
+      wrap(
+        <LeaderboardTable
+          entries={entries}
+          currentUsername="bob"
+          enablePreview
+          canPreviewOthers
+        />
+      )
+    );
+    const previews = screen.getAllByRole('button', { name: /'s bracket$/ });
+    expect(previews).toHaveLength(3);
+    previews.forEach((btn) => expect(btn).toBeEnabled());
+    expect(
+      screen.queryByRole('button', { name: /unlocks when the knockout bracket locks$/ })
+    ).not.toBeInTheDocument();
   });
 });

--- a/supabase/migrations/0057_restrict_preview_until_phase2_lock.sql
+++ b/supabase/migrations/0057_restrict_preview_until_phase2_lock.sql
@@ -1,0 +1,95 @@
+-- Restrict previewing OTHER members' brackets until Phase 2 locks.
+--
+-- The leaderboard's Preview affordance fetches a bracket via the
+-- `get_public_prediction` RPC. Until knockout picks are frozen
+-- (`tournament_phase = 'phase2_locked'`) a non-admin should only be able to
+-- preview their OWN entries; otherwise a player could copy a stronger entry's
+-- still-editable picks verbatim. The UI fades+disables the button, but the
+-- dialog hits an API route, so the real guard lives here at the RPC (the
+-- trust boundary — "don't trust the client").
+--
+-- This re-emits the 0036 body verbatim and adds a single visibility predicate
+-- to the `elig` CTE:
+--   * the caller owns the prediction, OR
+--   * the caller is an admin or super-admin, OR
+--   * the tournament is already in `phase2_locked`.
+-- Admins/super-admins (is_admin does NOT imply is_super_admin, so both are
+-- checked) retain full preview access at all times. Rows that fail the
+-- predicate return nothing, which the route maps to 404.
+
+create or replace function public.get_public_prediction(p_prediction_id uuid)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    total_goals int,
+    champion_team_id text,
+    submitted_at timestamptz,
+    groups jsonb,
+    knockout jsonb,
+    advancers jsonb
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with elig as (
+        select p.id, p.user_id, p.tournament_id, p.prediction_name, p.total_goals,
+               p.champion_team_id, p.submitted_at
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        join public.tournaments t on t.id = p.tournament_id
+        where p.id = p_prediction_id
+          and auth.uid() is not null
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and tp.paid_at <= t.lock_time
+          and (
+              p.user_id = auth.uid()
+              or public.is_admin()
+              or public.is_super_admin()
+              or public.tournament_phase(p.tournament_id) = 'phase2_locked'
+          )
+    )
+    select
+        e.id as prediction_id,
+        e.prediction_name::text,
+        pr.username::text as username,
+        e.total_goals,
+        e.champion_team_id,
+        e.submitted_at,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'group_id', gp.group_id,
+                'first_team_id', gp.first_team_id,
+                'second_team_id', gp.second_team_id,
+                'third_team_id', gp.third_team_id,
+                'fourth_team_id', gp.fourth_team_id
+            ) order by gp.group_id)
+            from public.group_predictions gp
+            where gp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as groups,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'match_id', kp.match_id,
+                'winner_team_id', kp.winner_team_id
+            ) order by kp.match_id)
+            from public.knockout_predictions kp
+            where kp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as knockout,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'rank', ap.rank,
+                'team_id', ap.team_id
+            ) order by ap.rank)
+            from public.advancer_predictions ap
+            where ap.prediction_id = e.id),
+            '[]'::jsonb
+        ) as advancers
+    from elig e
+    join public.profiles pr on pr.id = e.user_id;
+$$;
+
+grant execute on function public.get_public_prediction(uuid) to authenticated;


### PR DESCRIPTION
## What

Until knockout picks freeze (`tournament_phase = 'phase2_locked'`), a non-admin can preview **only their own** brackets on the leaderboard. This stops players from copying a stronger, still-editable entry's picks verbatim.

- **Other members' Preview buttons** stay visible but render **faded + disabled** for non-staff while the bracket is still editable.
- **Temporary note** under the leaderboard title explains the rule (shown to non-staff while restricted).
- **Admins and super-admins** keep full preview access at all times (both flags checked — `is_super_admin` doesn't imply `is_admin`).
- Once Phase 2 locks (and thereafter, incl. a completed tournament), everyone can preview everyone.

## Server-side enforcement (trust boundary)

The preview dialog fetches over `GET /api/leaderboard/prediction/[id]`, so a UI-only gate is bypassable. Migration `0057` re-emits `get_public_prediction` with an added visibility predicate: rows are returned only when the caller owns the prediction, is an admin/super-admin, or the tournament is `phase2_locked`. A failed predicate returns 0 rows, which the route already maps to **404** — no route change needed.

## Unlock condition

```
canPreviewOthers = isAdmin || isSuperAdmin || phase === 'phase2_locked'
```

Fails **closed** while the tournament query is loading. Own-row preview is always allowed for the signed-in owner.

## Files

- `supabase/migrations/0057_restrict_preview_until_phase2_lock.sql` — RPC guard
- `src/components/leaderboard/LeaderboardTable.tsx` — `canPreviewOthers` prop + per-row faded/disabled button
- `src/app/leaderboard/LeaderboardPageContent.tsx` — wire flag + temporary note
- `src/components/leaderboard/__tests__/LeaderboardTable.test.tsx` — gating tests

## Testing

- `npm test` (427 passed), `npm run typecheck` (clean), `npm run lint` (0 errors; only pre-existing warnings).
- Migration verified by inspection (re-emits the 0036 body verbatim + one predicate). Not run against any Supabase instance per the no-prod-verification rule; reviewer should `supabase db reset` locally and exercise `get_public_prediction` as owner / non-owner non-admin / admin across phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)