### PR TITLE
feat(analytics): Google Tag Manager + curated interaction tracking

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,6 +6,11 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # App URL (used for auth redirects)
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# Google Tag Manager container ID (e.g. GTM-XXXXXXX).
+# Leave empty to disable GTM. GTM only loads in production builds
+# (NODE_ENV=production) AND when this is set — dev traffic is never tracked.
+NEXT_PUBLIC_GTM_ID=
+
 # Server-only (never expose to the client)
 # Required for admin API routes (result submission, etc.)
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/frontend/docs/analytics.md
+++ b/frontend/docs/analytics.md
@@ -1,0 +1,56 @@
+# Analytics (Google Tag Manager)
+
+This app loads **Google Tag Manager** via `@next/third-parties` and pushes a small set of
+high-value custom events to the GTM `dataLayer`. GA4 (or any other tag) is configured **inside the
+GTM web UI** — the app only emits the container script + `dataLayer` events; it does not talk to GA4
+directly.
+
+## How it's wired
+
+- **Container script:** `<GoogleTagManager>` is rendered in `src/app/layout.tsx`.
+  - Loaded with the `afterInteractive` strategy → does **not** block first paint / Core Web Vitals.
+  - Gated on `process.env.NODE_ENV === 'production'` **and** `NEXT_PUBLIC_GTM_ID` being set, so
+    local/dev traffic is never tracked.
+- **Container ID:** `NEXT_PUBLIC_GTM_ID` (e.g. `GTM-XXXXXXX`). Set it in the deployment environment.
+  Empty = GTM fully disabled.
+- **Event helper:** `src/lib/analytics.ts` exports `trackEvent(event, params)` and the
+  `ANALYTICS_EVENTS` name map. It is a safe no-op on the server and whenever `NEXT_PUBLIC_GTM_ID`
+  is unset, so call sites don't guard individually.
+- **CSP:** `next.config.ts` allows `googletagmanager.com` (script + frame) and
+  `*.google-analytics.com` / `*.analytics.google.com` (connect). Update there if you add more tags.
+
+## Custom events
+
+Pageviews / route changes are captured automatically by GTM — they are **not** in this list.
+No event carries PII (no email / username / raw input); only booleans, enums, and opaque ids.
+
+| `event` name           | Fires when…                                              | Params                          | Source file |
+|------------------------|---------------------------------------------------------|---------------------------------|-------------|
+| `sign_up`              | A new account is created (post-signup, genuine new user)| `has_referral: boolean`         | `src/app/register/RegisterForm.tsx` |
+| `login`                | A user signs in successfully                             | —                               | `src/app/login/LoginForm.tsx` |
+| `new_prediction`       | "New prediction" is clicked                             | —                               | `src/app/predictions/PredictionsListPage.tsx` |
+| `prediction_submitted` | The wizard submit succeeds                              | `mode: 'create' \| 'edit'`      | `src/app/predictions/PredictionsPageContent.tsx` |
+| `phase1_saved`         | The Phase 1 "save" action succeeds                     | —                               | `src/app/predictions/PredictionsPageContent.tsx` |
+| `free_pick_redeemed`   | A free pick is redeemed                                 | `source: 'referral' \| 'loyalty'` | `src/app/predictions/PredictionsListPage.tsx` |
+| `referral_shared`      | A referral code / link is copied or shared             | `method: 'code' \| 'link' \| 'native'` | `src/app/referrals/ReferralsPageContent.tsx` |
+| `find_my_rank`         | "Find my rank" is clicked on the leaderboard           | —                               | `src/app/leaderboard/LeaderboardPageContent.tsx` |
+| `set_user`             | Auth state changes (incl. initial load)                | `user_id: string \| null` (Supabase UUID) | `src/providers/AuthProvider.tsx` |
+
+## Configuring GA4 in the GTM UI
+
+For each event above, create a **Custom Event trigger** (Event name = the `event` value) and a
+**GA4 Event tag** that maps the params to GA4 event parameters. Suggested starting point:
+
+1. **GA4 Configuration tag** — fires on *All Pages* (Initialization) with your GA4 Measurement ID.
+   This gives you automatic pageviews from GTM's History Change handling.
+2. **One GA4 Event tag per custom event** — Event Name = the `event` value, with Event Parameters
+   pulled from `dataLayer` variables (e.g. a `dlv - method` variable for `referral_shared`).
+3. For `set_user`, set the GA4 **User ID** field (and/or a `user_id` user property) from the
+   `user_id` dataLayer variable to enable cross-session/cross-device stitching.
+
+## Follow-ups (not implemented)
+
+- **Cookie consent / Google Consent Mode v2** — recommended before serving EU traffic. Would add a
+  consent banner and default-denied consent signals so analytics respects opt-in. Tracked as a
+  separate task.
+- The app currently sets `robots: noindex` (pre-launch). Analytics is unaffected; revisit at launch.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -18,13 +18,26 @@ const devConnect = isDev
 // Note: Next.js App Router embeds inline scripts for hydration data, and
 // Radix UI / Tailwind use inline styles. 'unsafe-inline' is currently
 // required for both. Tightening with nonces is a separate workstream.
+// Google Tag Manager / Analytics endpoints. GTM serves gtm.js from
+// googletagmanager.com; GA4 beacons go to *.google-analytics.com /
+// *.analytics.google.com. The GTM <noscript> fallback embeds an iframe from
+// googletagmanager.com, hence the frame-src entry. img-src already allows
+// https: so the GA collect pixel is covered.
+const gtmScript = ['https://www.googletagmanager.com'];
+const gtmConnect = [
+  'https://www.googletagmanager.com',
+  'https://*.google-analytics.com',
+  'https://*.analytics.google.com',
+];
+
 const csp = [
   "default-src 'self'",
-  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} ${gtmScript.join(' ')}`,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https:",
-  `connect-src 'self' ${[...supabaseConnect, ...devConnect].join(' ')}`,
+  `connect-src 'self' ${[...supabaseConnect, ...devConnect, ...gtmConnect].join(' ')}`,
   "font-src 'self' data:",
+  "frame-src 'self' https://www.googletagmanager.com",
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'self'",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "1.3.0",
       "dependencies": {
+        "@next/third-parties": "^16.2.6",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-navigation-menu": "^1.2.14",
@@ -4103,6 +4104,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.6.tgz",
+      "integrity": "sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -14019,6 +14033,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.4.tgz",
       "integrity": "sha512-gKSecROqisnV7Buen5BfjmXAm7Xlpx9o2ueVQRo5DxQcjC8d330dOM1xiGWc2k3Dcnz0In3VybyRPOsudwgiqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.4",
         "@swc/helpers": "0.5.15",
@@ -16133,6 +16148,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@next/third-parties": "^16.2.6",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-navigation-menu": "^1.2.14",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
+import { GoogleTagManager } from '@next/third-parties/google';
 import './globals.css';
 
 import { QueryProvider } from '@/providers/QueryProvider';
@@ -55,8 +56,15 @@ export default async function RootLayout({
       : null;
   }
 
+  // GTM loads only in production builds AND when a container ID is configured,
+  // so local/dev traffic is never tracked. Loaded with the afterInteractive
+  // strategy by @next/third-parties — does not block first paint.
+  const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
+  const gtmEnabled = process.env.NODE_ENV === 'production';
+
   return (
     <html lang="en" className="dark" style={{ colorScheme: 'dark' }} suppressHydrationWarning>
+      {gtmEnabled && gtmId && <GoogleTagManager gtmId={gtmId} />}
       <body className={`${inter.variable} font-sans antialiased`}>
         {/*
           Turbopack instruments functions with an esbuild-style `__name` keep-names helper that

--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -17,6 +17,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/hooks/useAuth';
 import { useTournamentLock } from '@/hooks/useTournamentLock';
 import { ROUTES } from '@/lib/constants';
+import { ANALYTICS_EVENTS, trackEvent } from '@/lib/analytics';
 import type { LeaderboardEntry, LeaderboardRankMatch } from '@/types/tournament';
 
 function LeaderboardSkeleton() {
@@ -153,6 +154,7 @@ export function LeaderboardPageContent() {
 
   const handleFindMyRank = React.useCallback(() => {
     if (!bestMatch) return;
+    trackEvent(ANALYTICS_EVENTS.findMyRank);
     const { rank, page } = bestMatch;
     if (currentPage !== page) setCurrentPage(page);
     setHighlightedRank(rank);

--- a/frontend/src/app/login/LoginForm.tsx
+++ b/frontend/src/app/login/LoginForm.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { FieldError } from '@/components/ui/field-error';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { ROUTES, EMAIL_REGEX } from '@/lib/constants';
+import { ANALYTICS_EVENTS, trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 
 interface LoginFormProps {
@@ -88,6 +89,7 @@ export function LoginForm({ redirectTo }: LoginFormProps) {
     }
 
     toast.success('Signed in');
+    trackEvent(ANALYTICS_EVENTS.login);
     router.push(redirectTo);
     router.refresh();
   };

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -33,6 +33,7 @@ import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDia
 import { FreePickBanner } from '@/components/predictions/FreePickBanner';
 import { UnpaidPaymentNotice } from '@/components/predictions/UnpaidPaymentNotice';
 import { PRICING, ROUTES } from '@/lib/constants';
+import { ANALYTICS_EVENTS, trackEvent } from '@/lib/analytics';
 import { fetchJSON } from '@/lib/api/fetchJSON';
 import { needsPayment } from '@/lib/predictions/paymentStatus';
 import { cn } from '@/lib/utils';
@@ -115,6 +116,7 @@ export function PredictionsListPage() {
         throw new Error(String(body.error ?? 'Failed to redeem credit'));
       }
       toast.success(`Free credit applied to "${prediction.name}"`);
+      trackEvent(ANALYTICS_EVENTS.freePickRedeemed, { source: body.source });
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['predictions'] }),
         queryClient.invalidateQueries({ queryKey: REWARDS_STATUS_QUERY_KEY }),
@@ -191,6 +193,9 @@ export function PredictionsListPage() {
                 }
                 aria-disabled={!canCreate}
                 title={createDisabledReason}
+                onClick={() => {
+                  if (canCreate) trackEvent(ANALYTICS_EVENTS.newPrediction);
+                }}
               >
                 <Plus className="mr-2 h-4 w-4" /> New prediction
               </Link>

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -22,6 +22,7 @@ import { FieldError } from '@/components/ui/field-error';
 import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthContext } from '@/providers/AuthProvider';
+import { ANALYTICS_EVENTS, trackEvent } from '@/lib/analytics';
 import { useTournamentLock } from '@/hooks/useTournamentLock';
 import {
   NEW_PREDICTION_SENTINEL,
@@ -1086,6 +1087,15 @@ export function PredictionsPageContent({
       ]);
       if (!silent) {
         toast.success(markSubmitted ? 'Prediction submitted' : 'Progress saved');
+      }
+
+      // Reached only on a successful save. `markSubmitted` is the full submit;
+      // `redirectTo` (set only by handleSavePhase1) marks the Phase 1 save —
+      // distinct from silent autosaves and plain save-progress.
+      if (markSubmitted) {
+        trackEvent(ANALYTICS_EVENTS.predictionSubmitted, { mode });
+      } else if (redirectTo) {
+        trackEvent(ANALYTICS_EVENTS.phase1Saved);
       }
 
       if (markSubmitted) {

--- a/frontend/src/app/referrals/ReferralsPageContent.tsx
+++ b/frontend/src/app/referrals/ReferralsPageContent.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useRewardsStatus } from '@/hooks/useRewardsStatus';
 import { ROUTES } from '@/lib/constants';
+import { ANALYTICS_EVENTS, trackEvent } from '@/lib/analytics';
 
 /**
  * "Refer a friend" share page. Single job: show the user's code + share
@@ -38,6 +39,9 @@ export function ReferralsPageContent() {
     try {
       await navigator.clipboard.writeText(value);
       toast.success(`${label} copied to clipboard`);
+      trackEvent(ANALYTICS_EVENTS.referralShared, {
+        method: label === 'Code' ? 'code' : 'link',
+      });
     } catch {
       toast.error('Copy failed — long-press to select');
     }
@@ -52,6 +56,7 @@ export function ReferralsPageContent() {
           text: 'Join my World Cup 2026 prediction pool — use my referral link:',
           url: shareUrl,
         });
+        trackEvent(ANALYTICS_EVENTS.referralShared, { method: 'native' });
         return;
       } catch {
         // user cancelled or share unavailable — fall through to copy

--- a/frontend/src/app/register/RegisterForm.tsx
+++ b/frontend/src/app/register/RegisterForm.tsx
@@ -16,6 +16,7 @@ import {
   PASSWORD_MIN_LENGTH,
   REFERRAL_CODE_REGEX,
 } from '@/lib/constants';
+import { ANALYTICS_EVENTS, trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 
 type FieldName = 'email' | 'password' | 'confirmPassword';
@@ -240,12 +241,14 @@ export function RegisterForm({ initialReferralCode }: RegisterFormProps = {}) {
       // but also swap the form for a persistent "Check your email" view so
       // users can't miss the next step.
       toast.success('Account created — check your email to confirm.');
+      trackEvent(ANALYTICS_EVENTS.signUp, { has_referral: !!passthroughRef });
       setSubmittedEmail(email.trim());
       setIsSubmitting(false);
       return;
     }
 
     toast.success('Account created');
+    trackEvent(ANALYTICS_EVENTS.signUp, { has_referral: !!passthroughRef });
     router.push(ROUTES.predictions);
     router.refresh();
   };

--- a/frontend/src/lib/__tests__/analytics.test.ts
+++ b/frontend/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+// Mock the GTM bridge so we can assert whether trackEvent forwards to it.
+const sendGTMEvent = jest.fn();
+jest.mock('@next/third-parties/google', () => ({
+  sendGTMEvent: (...args: unknown[]) => sendGTMEvent(...args),
+}));
+
+import { ANALYTICS_EVENTS, trackEvent } from '../analytics';
+
+describe('trackEvent', () => {
+  const original = process.env.NEXT_PUBLIC_GTM_ID;
+
+  beforeEach(() => {
+    sendGTMEvent.mockClear();
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_GTM_ID = original;
+  });
+
+  it('is a no-op when NEXT_PUBLIC_GTM_ID is not configured', () => {
+    delete process.env.NEXT_PUBLIC_GTM_ID;
+    trackEvent(ANALYTICS_EVENTS.login);
+    expect(sendGTMEvent).not.toHaveBeenCalled();
+  });
+
+  it('forwards the event and params to the dataLayer when GTM is configured', () => {
+    process.env.NEXT_PUBLIC_GTM_ID = 'GTM-TEST123';
+    trackEvent(ANALYTICS_EVENTS.referralShared, { method: 'link' });
+    expect(sendGTMEvent).toHaveBeenCalledWith({
+      event: 'referral_shared',
+      method: 'link',
+    });
+  });
+});

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,0 +1,42 @@
+/**
+ * Analytics — thin, typed wrapper over Google Tag Manager's dataLayer.
+ *
+ * GTM itself is loaded once in the root layout (`src/app/layout.tsx`) via
+ * `@next/third-parties`. This module is the single place client components push
+ * custom events from. It is a safe no-op when GTM is not configured (local dev,
+ * or any environment without `NEXT_PUBLIC_GTM_ID`), so call sites don't need to
+ * guard each call.
+ *
+ * Conventions:
+ * - Event names are snake_case and live in {@link ANALYTICS_EVENTS}.
+ * - Never pass PII (email, username, raw input). Booleans, enums, and opaque
+ *   ids only — e.g. `has_referral`, `source`, `prediction_id`.
+ *
+ * Pageviews / route changes are captured automatically by GTM; only custom
+ * interaction events flow through here.
+ */
+import { sendGTMEvent } from '@next/third-parties/google';
+
+export const ANALYTICS_EVENTS = {
+  signUp: 'sign_up',
+  login: 'login',
+  newPrediction: 'new_prediction',
+  predictionSubmitted: 'prediction_submitted',
+  phase1Saved: 'phase1_saved',
+  freePickRedeemed: 'free_pick_redeemed',
+  referralShared: 'referral_shared',
+  findMyRank: 'find_my_rank',
+  setUser: 'set_user',
+} as const;
+
+export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];
+
+/**
+ * Push a custom event to the GTM dataLayer. No-op on the server and when GTM is
+ * unconfigured (so dev and unconfigured envs stay silent).
+ */
+export function trackEvent(event: AnalyticsEvent, params?: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return;
+  if (!process.env.NEXT_PUBLIC_GTM_ID) return;
+  sendGTMEvent({ event, ...params });
+}

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import type { User } from '@supabase/supabase-js';
 import { useQueryClient } from '@tanstack/react-query';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { ANALYTICS_EVENTS, trackEvent } from '@/lib/analytics';
 import { clearAllDrafts } from '@/hooks/useDraftPersistence';
 import type { Profile } from '@/types/tournament';
 
@@ -27,6 +28,12 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
   const [user, setUser] = React.useState<User | null>(initialUser);
   const [profile, setProfile] = React.useState<Profile | null>(initialProfile);
   const [loading, setLoading] = React.useState(false);
+
+  // Push a pseudonymous user_id (Supabase UUID, never email/username) to the
+  // GTM dataLayer so GA4 can stitch sessions across auth. No-op when GTM is off.
+  React.useEffect(() => {
+    trackEvent(ANALYTICS_EVENTS.setUser, { user_id: user?.id ?? null });
+  }, [user]);
 
   const supabase = React.useMemo(() => createSupabaseBrowserClient(), []);
   const queryClient = useQueryClient();


### PR DESCRIPTION
## What

Adds **Google Tag Manager** to the app and emits a curated set of high-value, PII-free interaction events.

The Next.js-specific dependency is **`@next/third-parties`** (official package). Its `<GoogleTagManager>` loads with the `afterInteractive` strategy, so it **does not block first paint / Core Web Vitals**. GTM is purely client-side, so the Cloudflare Workers runtime is unaffected — only the CSP needed updating.

## How it works

- `<GoogleTagManager>` rendered in `src/app/layout.tsx`, gated on `NODE_ENV === 'production'` **and** `NEXT_PUBLIC_GTM_ID` being set — dev/local traffic is never tracked.
- CSP in `next.config.ts` updated to allow `googletagmanager.com` (script + frame) and `*.google-analytics.com` / `*.analytics.google.com` (connect).
- `src/lib/analytics.ts` — typed `trackEvent()` + `ANALYTICS_EVENTS` map; safe no-op when GTM is unconfigured, so call sites don't guard individually. No PII (ids/enums/booleans only).

## Curated events

`sign_up`, `login`, `new_prediction`, `prediction_submitted`, `phase1_saved`, `free_pick_redeemed`, `referral_shared`, `find_my_rank`, plus a `set_user` dataLayer push for GA4 session stitching. Pageviews/route changes are captured automatically by GTM. Full event → GA4 tag/trigger mapping in `docs/analytics.md`.

## Config

Set `NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX` in the production environment to enable. Documented in `.env.example`.

## Out of scope (deferred)

- **Cookie consent / Google Consent Mode v2** — recommended before EU traffic; separate task.

## Testing

- `npm run typecheck` ✅  `npm run lint` ✅  `npm test` ✅ (incl. new `analytics.test.ts` covering the no-op + forwarding behaviour)
- Not verified against production (per repo policy).