### PR TITLE
feat(leaderboard): preview others' brackets during Group Stage lock

### DIFF
--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -52,12 +52,15 @@ export function LeaderboardPageContent() {
 
   const currentUsername = profile?.username ?? null;
   // Staff (admin or super-admin — the latter doesn't imply the former) can
-  // always preview every bracket. Everyone else is limited to their own
-  // entries until knockout picks are frozen (`phase2_locked`), so a player
-  // can't copy a still-editable rival's picks. Fails closed while the
-  // tournament query is loading (phase defaults to phase1 → restricted).
+  // always preview every bracket. Everyone else can preview others' entries in
+  // two windows where picks are frozen: while the Group Stage is locked
+  // (`phase1_locked`) and once the knockout bracket locks (`phase2_locked`).
+  // It stays restricted while picks are still editable (`phase1` group picks,
+  // `phase2_open` knockout picks) so a player can't copy a rival's in-progress
+  // picks. Fails closed while the tournament query is loading (phase defaults
+  // to phase1 → restricted).
   const isStaff = !!profile?.isAdmin || !!profile?.isSuperAdmin;
-  const previewOthersLocked = phase !== 'phase2_locked';
+  const previewOthersLocked = !(phase === 'phase1_locked' || phase === 'phase2_locked');
   const canPreviewOthers = isStaff || !previewOthersLocked;
   // The leaderboard response shape depends on the viewer's identity:
   // admins get an extra `email` field, anon/auth users don't. Bake the
@@ -206,9 +209,20 @@ export function LeaderboardPageContent() {
         <div className="border-muted-foreground/20 bg-muted/40 text-muted-foreground mb-6 flex items-start gap-2 rounded-md border px-4 py-3 text-sm">
           <Lock className="mt-0.5 h-4 w-4 shrink-0" />
           <p>
-            <span className="text-foreground font-medium">Heads up —</span> you can preview only
-            your own brackets for now. Everyone&apos;s brackets open for viewing once the knockout
-            bracket locks. This keeps picks private while they can still be edited.
+            <span className="text-foreground font-medium">Heads up —</span>{' '}
+            {phase === 'phase2_open' ? (
+              <>
+                brackets are private again while knockout picks are being made. Everyone&apos;s
+                full bracket reopens for viewing once the knockout bracket locks. This keeps picks
+                private while they can still be edited.
+              </>
+            ) : (
+              <>
+                you can preview only your own brackets for now. Other players&apos; group-stage
+                picks open for viewing once the group stage locks. This keeps picks private while
+                they can still be edited.
+              </>
+            )}
           </p>
         </div>
       )}

--- a/supabase/migrations/0058_preview_during_phase1_lock.sql
+++ b/supabase/migrations/0058_preview_during_phase1_lock.sql
@@ -1,0 +1,104 @@
+-- Open up previewing OTHER members' brackets during the Group Stage lock.
+--
+-- `0057` restricted non-admins to previewing only their OWN entries until the
+-- knockout bracket froze (`phase2_locked`). We now also allow previewing other
+-- members' brackets while the Group Stage is locked (`phase1_locked`) so people
+-- can compare group-stage picks during the group-stage matches.
+--
+-- The visibility predicate in the `elig` CTE now permits a non-admin viewer in
+-- two windows:
+--   * the caller owns the prediction, OR
+--   * the caller is an admin or super-admin (full access at all times), OR
+--   * the tournament is in `phase1_locked` (group picks frozen, knockout not
+--     yet open), OR
+--   * the tournament is in `phase2_locked` (everything frozen).
+-- It deliberately EXCLUDES `phase1` (group picks still editable) and
+-- `phase2_open` (knockout picks still editable) so a player can't copy a
+-- rival's still-editable picks. No field-level redaction is needed: knockout
+-- predictions are only writable during `phase2_open`, which comes strictly
+-- after `phase1_locked`, so the `knockout` array is empty for every prediction
+-- while `phase1_locked` — there is nothing to leak.
+--
+-- Re-emits the `0057` body verbatim apart from that single predicate. Rows that
+-- fail the predicate return nothing, which the route maps to 404.
+
+create or replace function public.get_public_prediction(p_prediction_id uuid)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    total_goals int,
+    champion_team_id text,
+    submitted_at timestamptz,
+    groups jsonb,
+    knockout jsonb,
+    advancers jsonb
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with elig as (
+        select p.id, p.user_id, p.tournament_id, p.prediction_name, p.total_goals,
+               p.champion_team_id, p.submitted_at
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        join public.tournaments t on t.id = p.tournament_id
+        where p.id = p_prediction_id
+          and auth.uid() is not null
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and tp.paid_at <= t.lock_time
+          and (
+              p.user_id = auth.uid()
+              or public.is_admin()
+              or public.is_super_admin()
+              -- Other non-admin users may preview once the Group Stage is
+              -- locked (phase1_locked) and again once the knockout bracket
+              -- locks (phase2_locked). Excludes 'phase1' (group picks still
+              -- editable) and 'phase2_open' (knockout picks still editable).
+              or public.tournament_phase(p.tournament_id) in ('phase1_locked', 'phase2_locked')
+          )
+    )
+    select
+        e.id as prediction_id,
+        e.prediction_name::text,
+        pr.username::text as username,
+        e.total_goals,
+        e.champion_team_id,
+        e.submitted_at,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'group_id', gp.group_id,
+                'first_team_id', gp.first_team_id,
+                'second_team_id', gp.second_team_id,
+                'third_team_id', gp.third_team_id,
+                'fourth_team_id', gp.fourth_team_id
+            ) order by gp.group_id)
+            from public.group_predictions gp
+            where gp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as groups,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'match_id', kp.match_id,
+                'winner_team_id', kp.winner_team_id
+            ) order by kp.match_id)
+            from public.knockout_predictions kp
+            where kp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as knockout,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'rank', ap.rank,
+                'team_id', ap.team_id
+            ) order by ap.rank)
+            from public.advancer_predictions ap
+            where ap.prediction_id = e.id),
+            '[]'::jsonb
+        ) as advancers
+    from elig e
+    join public.profiles pr on pr.id = e.user_id;
+$$;
+
+grant execute on function public.get_public_prediction(uuid) to authenticated;

--- a/supabase/tests/public_prediction_preview.test.sql
+++ b/supabase/tests/public_prediction_preview.test.sql
@@ -1,0 +1,199 @@
+-- supabase/tests/public_prediction_preview.test.sql
+--
+-- Locks down the access gate of get_public_prediction (migrations 0057 +
+-- 0058). A non-admin user may preview ANOTHER member's prediction only while
+-- picks are frozen: during the Group Stage lock (phase1_locked) and once the
+-- knockout bracket locks (phase2_locked). It stays hidden while picks are
+-- editable (phase1 group picks, phase2_open knockout picks). Owners always see
+-- their own; admins + super-admins always see everything. The paid +
+-- (submitted OR phase1-complete) eligibility is preserved across all phases.
+--
+-- Phase is driven by mutating the tournament's lock_time / knockout_unlocked /
+-- knockout_lock_time between assertion blocks (see tournament_phase in
+-- migration 0022). The caller is impersonated via a transaction-local
+-- request.jwt.claims so auth.uid() / is_admin() / is_super_admin() resolve.
+
+begin;
+create extension if not exists pgtap with schema extensions;
+set search_path to public, extensions;
+\ir lib/_fixtures.psql
+
+select plan(15);
+
+-- ----- Helpers shared by this file only.
+
+create or replace function pg_temp.fill_all_groups(p_prediction uuid) returns void
+language sql as $$
+    insert into public.group_predictions
+        (prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id)
+    select p_prediction, g.id,
+           pg_temp.team_at(g.id, 0), pg_temp.team_at(g.id, 1),
+           pg_temp.team_at(g.id, 2), pg_temp.team_at(g.id, 3)
+    from public.groups g;
+$$;
+
+create or replace function pg_temp.fill_all_advancers(p_prediction uuid) returns void
+language sql as $$
+    insert into public.advancer_predictions (prediction_id, rank, team_id)
+    select p_prediction, gs.rn, gs.third_team_id
+    from (
+        select row_number() over (order by group_id) as rn, third_team_id
+        from public.group_predictions
+        where prediction_id = p_prediction
+        order by group_id
+        limit 8
+    ) gs;
+$$;
+
+-- Impersonate a caller for auth.uid()/is_admin()/is_super_admin().
+create or replace function pg_temp.set_caller(p_uid uuid) returns void
+language plpgsql as $$
+begin
+    perform set_config(
+        'request.jwt.claims',
+        json_build_object('sub', p_uid::text, 'role', 'authenticated')::text,
+        true);
+end $$;
+
+-- Returns the single previewed row as jsonb (column names as keys), or NULL
+-- when the access gate hides it (the route maps that to 404).
+create or replace function pg_temp.preview_as(p_caller uuid, p_pred uuid) returns jsonb
+language plpgsql as $$
+declare r record;
+begin
+    perform pg_temp.set_caller(p_caller);
+    select * into r from public.get_public_prediction(p_pred);
+    if not found then return null; end if;
+    return to_jsonb(r);
+end $$;
+
+-- Phase setters (mutate the single test tournament).
+create or replace function pg_temp.go_phase(p_tid uuid, p_phase text) returns void
+language plpgsql as $$
+begin
+    if p_phase = 'phase1' then
+        update public.tournaments
+           set lock_time = now() + interval '7 days',
+               knockout_unlocked = false, knockout_lock_time = null
+         where id = p_tid;
+    elsif p_phase = 'phase1_locked' then
+        update public.tournaments
+           set lock_time = now() - interval '1 hour',
+               knockout_unlocked = false, knockout_lock_time = null
+         where id = p_tid;
+    elsif p_phase = 'phase2_open' then
+        update public.tournaments
+           set lock_time = now() - interval '1 hour',
+               knockout_unlocked = true, knockout_lock_time = now() + interval '1 day'
+         where id = p_tid;
+    elsif p_phase = 'phase2_locked' then
+        update public.tournaments
+           set lock_time = now() - interval '1 hour',
+               knockout_unlocked = true, knockout_lock_time = now() - interval '1 hour'
+         where id = p_tid;
+    end if;
+end $$;
+
+-- ----- Fixtures.
+do $$
+declare
+    v_owner uuid;
+    v_other uuid;
+    v_admin uuid;
+    v_super uuid;
+    v_tid   uuid;
+begin
+    v_owner := pg_temp.mk_user('preview_owner');
+    v_other := pg_temp.mk_user('preview_other');   -- plain non-admin
+    v_admin := pg_temp.mk_user('preview_admin');
+    v_super := pg_temp.mk_user('preview_super');
+    v_tid   := pg_temp.mk_tournament('preview gate', interval '-1 hour');
+
+    perform pg_temp.put_id('owner', v_owner);
+    perform pg_temp.put_id('other', v_other);
+    perform pg_temp.put_id('admin', v_admin);
+    perform pg_temp.put_id('super', v_super);
+    perform pg_temp.put_id('t', v_tid);
+
+    -- Both is_admin and is_super_admin flips are guarded by triggers that fire
+    -- here because auth.uid() is null during setup (is_admin() -> false).
+    -- Disable both for the seed, then re-enable.
+    alter table public.profiles disable trigger profiles_block_admin_self_elevation;
+    alter table public.profiles disable trigger profiles_block_super_admin_change;
+    update public.profiles set is_admin = true where id = v_admin;
+    update public.profiles set is_super_admin = true where id = v_super;
+    alter table public.profiles enable trigger profiles_block_super_admin_change;
+    alter table public.profiles enable trigger profiles_block_admin_self_elevation;
+
+    -- Main prediction: paid (well in the past), submitted, full Phase 1 data,
+    -- a champion pick, a tiebreaker, and a couple of knockout picks.
+    perform pg_temp.put_id('p_main', pg_temp.mk_prediction(
+        v_tid, v_owner, 'main pred', 12,
+        now() - interval '20 days', true, now() - interval '30 days'));
+    perform pg_temp.fill_all_groups(pg_temp.tid('p_main'));
+    perform pg_temp.fill_all_advancers(pg_temp.tid('p_main'));
+    update public.predictions
+       set champion_team_id = pg_temp.team_at('A', 0)
+     where id = pg_temp.tid('p_main');
+    insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+    select pg_temp.tid('p_main'), km.id, pg_temp.team_at('A', 0)
+      from public.knockout_matches km order by km.id limit 2;
+
+    -- Unpaid but otherwise complete -> payment gate must still hide it.
+    perform pg_temp.put_id('p_unpaid', pg_temp.mk_prediction(
+        v_tid, v_owner, 'unpaid pred', 9,
+        now() - interval '20 days', false));
+    perform pg_temp.fill_all_groups(pg_temp.tid('p_unpaid'));
+    perform pg_temp.fill_all_advancers(pg_temp.tid('p_unpaid'));
+
+    -- Paid but incomplete draft (no groups/advancers, submitted_at null)
+    -- -> eligibility filter must still hide it.
+    perform pg_temp.put_id('p_incomplete', pg_temp.mk_prediction(
+        v_tid, v_owner, 'incomplete pred', null,
+        null, true, now() - interval '30 days'));
+end $$;
+
+-- ===== phase1: group picks still editable -> others hidden =====
+select pg_temp.go_phase(pg_temp.tid('t'), 'phase1');
+select ok(pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_main')) is null,
+          'other user, phase1 -> hidden (404)');
+select ok(pg_temp.preview_as(pg_temp.tid('owner'), pg_temp.tid('p_main')) is not null,
+          'owner, phase1 -> sees own prediction');
+select ok(pg_temp.preview_as(pg_temp.tid('admin'), pg_temp.tid('p_main')) is not null,
+          'admin, phase1 -> staff bypass sees other prediction');
+
+-- ===== phase1_locked: group stage frozen -> others may preview (NEW) =====
+select pg_temp.go_phase(pg_temp.tid('t'), 'phase1_locked');
+select ok(pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_main')) is not null,
+          'other user, phase1_locked -> CAN preview (new behavior)');
+select is(jsonb_array_length(pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_main'))->'groups'),
+          12, 'other user, phase1_locked -> all 12 group picks visible');
+select is(jsonb_array_length(pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_main'))->'advancers'),
+          8, 'other user, phase1_locked -> all 8 advancer picks visible');
+select ok((pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_main'))->>'champion_team_id') is not null,
+          'other user, phase1_locked -> gut-feeling champion visible');
+select ok(pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_unpaid')) is null,
+          'other user, phase1_locked, unpaid prediction -> hidden (payment gate)');
+select ok(pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_incomplete')) is null,
+          'other user, phase1_locked, incomplete draft -> hidden (eligibility)');
+
+-- ===== phase2_open: knockout editable -> others restricted again (KEY) =====
+select pg_temp.go_phase(pg_temp.tid('t'), 'phase2_open');
+select ok(pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_main')) is null,
+          'other user, phase2_open -> hidden again (knockout editable)');
+select ok(pg_temp.preview_as(pg_temp.tid('owner'), pg_temp.tid('p_main')) is not null,
+          'owner, phase2_open -> still sees own prediction');
+select ok(pg_temp.preview_as(pg_temp.tid('super'), pg_temp.tid('p_main')) is not null,
+          'super-admin, phase2_open -> staff bypass sees other prediction');
+
+-- ===== phase2_locked: everything frozen -> full preview for all =====
+select pg_temp.go_phase(pg_temp.tid('t'), 'phase2_locked');
+select ok(pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_main')) is not null,
+          'other user, phase2_locked -> can preview');
+select ok(jsonb_array_length(pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_main'))->'knockout') > 0,
+          'other user, phase2_locked -> knockout bracket visible');
+select is((pg_temp.preview_as(pg_temp.tid('other'), pg_temp.tid('p_main'))->>'total_goals')::int,
+          12, 'other user, phase2_locked -> tiebreaker visible');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## What
Lets **non-admin** users preview *other* members' brackets on the leaderboard once the **Group Stage is locked** (`phase1_locked`), so people can compare group-stage picks during the group matches. Preview becomes restricted again once knockout editing opens (`phase2_open`), then reopens when the knockout bracket locks (`phase2_locked`, already configured).

| Phase | Other-user preview (non-admin) |
|-------|--------------------------------|
| `phase1` (group picks editable) | No |
| `phase1_locked` (group stage frozen) | **Yes** ← new |
| `phase2_open` (knockout editable) | No (re-restricted) |
| `phase2_locked` (all frozen) | Yes (unchanged) |

Owners always preview their own; admins/super-admins always preview everything; logged-out visitors still cannot preview (auth required).

## How
- **`0058_preview_during_phase1_lock.sql`** — widens the `get_public_prediction` access gate (the trust boundary) from `= 'phase2_locked'` to `in ('phase1_locked', 'phase2_locked')`. Re-emits the `0057` body otherwise verbatim.
- **`LeaderboardPageContent.tsx`** — matching frontend gate (`previewOthersLocked = !(phase1_locked || phase2_locked)`) + phase-aware banner copy.

No knockout/field redaction is needed: knockout picks are only writable during `phase2_open` (strictly after `phase1_locked`), so the `knockout` array is empty for every prediction while `phase1_locked` — nothing to leak. The API route and preview dialog are unchanged.

## Tests
- New pgTAP suite `supabase/tests/public_prediction_preview.test.sql` (15 assertions) covering the gate across all four phases — including the **`phase2_open → hidden`** regression guard, the payment/eligibility gates, and owner/admin/super-admin bypass. Passes locally.
- `npm test` (427 pass), `npm run typecheck`, `npm run lint` (0 errors) all green.

Note: the pre-existing `scoring_*` pgTAP files fail locally (stale scoring expectations + `M1` knockout-id FK mismatch in seed) — unrelated to this change; this branch doesn't touch those tests, the scoring RPCs, or the seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)