### PR TITLE
fix(auth): load profile on INITIAL_SESSION when SSR resolved none

### DIFF
--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -31,6 +31,11 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
   const supabase = React.useMemo(() => createSupabaseBrowserClient(), []);
   const queryClient = useQueryClient();
 
+  // Whose profile (if any) SSR resolved at mount. Drives whether the
+  // INITIAL_SESSION handler below still needs to fetch the profile client-side.
+  // A ref (not a dep) so the auth listener effect stays mounted-once.
+  const initialProfileUserIdRef = React.useRef(initialProfile?.id ?? null);
+
   const loadProfile = React.useCallback(
     async (userId: string) => {
       const { data } = await supabase
@@ -73,7 +78,19 @@ export function AuthProvider({ children, initialUser, initialProfile }: AuthProv
         setProfile(null);
         return;
       }
-      if (event === 'INITIAL_SESSION') return;
+      // On the initial client session we normally trust the SSR-provided
+      // initialProfile and skip a redundant fetch. But if SSR couldn't resolve
+      // the session (server/client cookie skew — e.g. right after a local DB
+      // reset), initialProfile is null while the client DOES hold a session.
+      // Without this, profile stays null and profile-gated UI (the Admin link,
+      // rewards badge, etc.) silently stays hidden until some later auth event
+      // fires. Fetch when SSR gave us no profile, or one for a different user.
+      if (event === 'INITIAL_SESSION') {
+        if (initialProfileUserIdRef.current !== session.user.id) {
+          void loadProfile(session.user.id);
+        }
+        return;
+      }
       void loadProfile(session.user.id);
     });
     return () => subscription.subscription.unsubscribe();

--- a/frontend/src/providers/__tests__/AuthProvider.test.tsx
+++ b/frontend/src/providers/__tests__/AuthProvider.test.tsx
@@ -119,6 +119,76 @@ describe('AuthProvider', () => {
     });
   });
 
+  it('loads the profile on INITIAL_SESSION when SSR provided none', async () => {
+    // SSR couldn't resolve the session (initialProfile null) but the client
+    // restores it via INITIAL_SESSION. The profile must still be fetched so
+    // profile-gated UI (e.g. the Admin link) doesn't stay hidden.
+    fromMock.mockImplementation(() => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: {
+              id: 'u3',
+              username: 'carol',
+              display_name: null,
+              avatar_url: null,
+              is_admin: true,
+              is_super_admin: true,
+            },
+          }),
+        }),
+      }),
+    }));
+
+    render(
+      withProviders(
+        <AuthProvider initialUser={null} initialProfile={null}>
+          <Consumer />
+        </AuthProvider>
+      )
+    );
+
+    await act(async () => {
+      authCallback?.('INITIAL_SESSION', { user: { id: 'u3' } as User });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user').textContent).toBe('u3');
+      expect(screen.getByTestId('username').textContent).toBe('carol');
+    });
+  });
+
+  it('does NOT refetch on INITIAL_SESSION when SSR already provided the profile', async () => {
+    fromMock.mockImplementation(() => {
+      throw new Error('loadProfile should not be called when SSR provided the profile');
+    });
+
+    render(
+      withProviders(
+        <AuthProvider
+          initialUser={{ id: 'u1' } as User}
+          initialProfile={{
+            id: 'u1',
+            username: 'alice',
+            displayName: null,
+            avatarUrl: null,
+            isAdmin: false,
+            isSuperAdmin: false,
+          }}
+        >
+          <Consumer />
+        </AuthProvider>
+      )
+    );
+
+    await act(async () => {
+      authCallback?.('INITIAL_SESSION', { user: { id: 'u1' } as User });
+    });
+
+    expect(fromMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('username').textContent).toBe('alice');
+  });
+
   it('clears the React Query cache when SIGNED_OUT fires', async () => {
     // Seed cache with stale data that would belong to the previous user.
     queryClient.setQueryData(['predictions'], { stale: true });


### PR DESCRIPTION
## Problem
The super-admin's **Admin link disappeared** (intermittently) even though the account had `is_admin`/`is_super_admin = true` in the DB. Investigation ruled out the entire backend — the DB row, RLS, column grants, the `is_admin()` function, and the exact client REST query all return `is_admin: true`. The fault was purely client-side state.

## Root cause
`profile` is seeded from SSR (`layout.tsx` → `initialProfile`). The auth listener in `AuthProvider` did:

```ts
if (event === 'INITIAL_SESSION') return;   // ← skipped loadProfile
void loadProfile(session.user.id);
```

On a page load the listener fires `INITIAL_SESSION` and trusts the SSR profile. But when the **server couldn't resolve the session** at render time (server/client cookie skew — which is exactly what a local `supabase db reset` + re-login leaves behind), `initialProfile` is `null` while the client still holds a session. The listener set `user` (so the account menu appeared — "logged in") but returned before `loadProfile`, leaving `profile` null indefinitely. So every profile-gated piece of UI (Admin link, rewards badge, etc.) stayed hidden until some later auth event (token refresh, re-login, a hard reload) happened to fire `loadProfile`. That intermittency was the giveaway.

## Fix
On `INITIAL_SESSION`, fetch the profile when SSR provided none (or one for a different user). A ref tracks the SSR-resolved profile owner so:
- the listener effect still mounts once (no dependency churn), and
- the common path (SSR resolved the profile) skips the redundant refetch.

## Tests
- New: loads the profile on `INITIAL_SESSION` when `initialProfile` is null.
- New: does **not** refetch on `INITIAL_SESSION` when SSR already provided the profile.
- `npm test` 429 pass, `npm run typecheck` clean, `npm run lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)