### PR TITLE
feat(predictions): auto-fill Best 3rds by FIFA ranking

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -43,7 +43,10 @@ import type {
   TournamentInfo,
 } from '@/types/tournament';
 import { ADVANCER_COUNT } from '@/lib/constants';
-import { autofillGroupPredictionsByFifaRanking } from '@/lib/fifaRankings';
+import {
+  autofillAdvancersByFifaRanking,
+  autofillGroupPredictionsByFifaRanking,
+} from '@/lib/fifaRankings';
 import { applyGroupPositionChange } from '@/lib/groupSwap';
 import { cascadeKnockoutPick } from '@/lib/knockoutCascade';
 import { AdvancersForm } from '@/components/predictions/AdvancersForm';
@@ -810,6 +813,17 @@ export function PredictionsPageContent({
     persistDraft({ championTeamId: value });
   };
 
+  const handleAutofillAdvancersByFifaRanking = () => {
+    const next = autofillAdvancersByFifaRanking(advancerCandidatePool);
+    setAdvancerPredictions(next);
+    persistDraft({ advancerPredictions: next });
+  };
+
+  const handleResetAdvancers = () => {
+    setAdvancerPredictions([]);
+    persistDraft({ advancerPredictions: [] });
+  };
+
   const handleAdvancerRankChange = (rank: number, teamId: string | null) => {
     setAdvancerPredictions((prev) => {
       const others = prev.filter((a) => a.rank !== rank);
@@ -1388,6 +1402,8 @@ export function PredictionsPageContent({
               candidatePool={advancerCandidatePool}
               value={advancerPredictions}
               onRankChange={handleAdvancerRankChange}
+              onAutofillByFifaRanking={handleAutofillAdvancersByFifaRanking}
+              onResetPicks={handleResetAdvancers}
               disabled={!phase1Editable}
             />
           )}

--- a/frontend/src/components/predictions/AdvancersForm.tsx
+++ b/frontend/src/components/predictions/AdvancersForm.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { CheckCircle2, Circle } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Select,
@@ -31,6 +32,10 @@ export interface AdvancersFormProps {
   value: AdvancerPrediction[];
   /** Called when a rank's team changes (null to clear). */
   onRankChange: (rank: number, teamId: string | null) => void;
+  /** Predict variant only: seed ranks 1–8 from the candidate pool by FIFA ranking. */
+  onAutofillByFifaRanking?: () => void;
+  /** Predict variant only: clear all ranked picks. */
+  onResetPicks?: () => void;
   disabled?: boolean;
 }
 
@@ -45,12 +50,17 @@ export function AdvancersForm({
   candidatePool,
   value,
   onRankChange,
+  onAutofillByFifaRanking,
+  onResetPicks,
   disabled = false,
 }: AdvancersFormProps) {
   const filledCount = value.filter((v) => !!v.teamId).length;
   const isComplete = filledCount === ADVANCER_COUNT;
   const pickedTeamIds = new Set(value.filter((v) => v.teamId).map((v) => v.teamId));
   const poolIncomplete = candidatePool.length < ADVANCER_COUNT;
+  const showAutofill = variant === 'predict' && !!onAutofillByFifaRanking && !disabled;
+  const showReset = variant === 'predict' && !!onResetPicks && !disabled;
+  const showActions = showAutofill || showReset;
 
   return (
     <div className="space-y-6">
@@ -97,6 +107,33 @@ export function AdvancersForm({
         <div className="rounded-md border border-amber-500/50 bg-amber-500/10 px-4 py-3 text-sm">
           <strong>Heads up:</strong> only {candidatePool.length} of 12 group 3rd-place picks
           are filled in. Finish the group stage first so all 12 candidates are available here.
+        </div>
+      )}
+
+      {showActions && (
+        <div className="flex items-center justify-between gap-2">
+          {showAutofill ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={onAutofillByFifaRanking}
+            >
+              Auto-fill by FIFA ranking
+            </Button>
+          ) : (
+            <span />
+          )}
+          {showReset && (
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={onResetPicks}
+            >
+              Reset
+            </Button>
+          )}
         </div>
       )}
 

--- a/frontend/src/lib/__tests__/fifaRankings.test.ts
+++ b/frontend/src/lib/__tests__/fifaRankings.test.ts
@@ -1,12 +1,18 @@
-import type { Group } from '@/types/tournament';
+import type { Group, Team } from '@/types/tournament';
 
-import { FIFA_RANKINGS, autofillGroupPredictionsByFifaRanking } from '../fifaRankings';
+import {
+  FIFA_RANKINGS,
+  autofillAdvancersByFifaRanking,
+  autofillGroupPredictionsByFifaRanking,
+} from '../fifaRankings';
 
 const makeGroup = (id: string, teams: Array<{ id: string; code: string }>): Group => ({
   id,
   name: `Group ${id}`,
   teams: teams.map((t) => ({ id: t.id, name: t.id, code: t.code, group: id })),
 });
+
+const makeTeam = (id: string, code: string): Team => ({ id, name: id, code, group: 'X' });
 
 describe('autofillGroupPredictionsByFifaRanking', () => {
   it('orders top-3 by rank ascending, with leftover team in 4th', () => {
@@ -78,5 +84,61 @@ describe('autofillGroupPredictionsByFifaRanking', () => {
     expect(pred.positions.first).toBe('esp');
     expect(pred.positions.second).toBe('uru');
     expect(FIFA_RANKINGS.ESP).toBeLessThan(FIFA_RANKINGS.URU);
+  });
+});
+
+describe('autofillAdvancersByFifaRanking', () => {
+  it('orders the pool by rank ascending and assigns ranks 1..8', () => {
+    const rankings = { AAA: 1, BBB: 2, CCC: 3 };
+    const pool = [makeTeam('c', 'CCC'), makeTeam('a', 'AAA'), makeTeam('b', 'BBB')];
+
+    const result = autofillAdvancersByFifaRanking(pool, rankings);
+
+    expect(result).toEqual([
+      { rank: 1, teamId: 'a' },
+      { rank: 2, teamId: 'b' },
+      { rank: 3, teamId: 'c' },
+    ]);
+  });
+
+  it('caps the result at the 8 best-ranked teams', () => {
+    const rankings = Object.fromEntries(
+      Array.from({ length: 12 }, (_, i) => [`T${i}`, i + 1]),
+    );
+    const pool = Array.from({ length: 12 }, (_, i) => makeTeam(`t${i}`, `T${i}`));
+
+    // Shuffle-ish: reverse so input order does not match rank order.
+    const result = autofillAdvancersByFifaRanking([...pool].reverse(), rankings);
+
+    expect(result).toHaveLength(8);
+    expect(result.map((p) => p.rank)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(result.map((p) => p.teamId)).toEqual([
+      't0', 't1', 't2', 't3', 't4', 't5', 't6', 't7',
+    ]);
+  });
+
+  it('sorts teams missing from the rankings to the bottom', () => {
+    const rankings = { AAA: 5, BBB: 10 };
+    const pool = [
+      makeTeam('unknown1', 'XXX'),
+      makeTeam('a', 'AAA'),
+      makeTeam('b', 'BBB'),
+    ];
+
+    const result = autofillAdvancersByFifaRanking(pool, rankings);
+
+    expect(result.map((p) => p.teamId)).toEqual(['a', 'b', 'unknown1']);
+  });
+
+  it('fills only what is available when the pool has fewer than 8 teams', () => {
+    const rankings = { AAA: 1, BBB: 2 };
+    const pool = [makeTeam('a', 'AAA'), makeTeam('b', 'BBB')];
+
+    const result = autofillAdvancersByFifaRanking(pool, rankings);
+
+    expect(result).toEqual([
+      { rank: 1, teamId: 'a' },
+      { rank: 2, teamId: 'b' },
+    ]);
   });
 });

--- a/frontend/src/lib/fifaRankings.ts
+++ b/frontend/src/lib/fifaRankings.ts
@@ -2,7 +2,8 @@
 // Hand-maintained; refresh after each official FIFA ranking publication.
 // Last updated: 2026-05.
 
-import type { Group, GroupPrediction } from '@/types/tournament';
+import { ADVANCER_COUNT } from '@/lib/constants';
+import type { AdvancerPrediction, Group, GroupPrediction, Team } from '@/types/tournament';
 
 export const FIFA_RANKINGS: Record<string, number> = {
   ESP: 1,
@@ -73,4 +74,16 @@ export function autofillGroupPredictionsByFifaRanking(
       },
     };
   });
+}
+
+export function autofillAdvancersByFifaRanking(
+  candidatePool: Team[],
+  rankings: Record<string, number> = FIFA_RANKINGS,
+): AdvancerPrediction[] {
+  const sorted = [...candidatePool].sort(
+    (a, b) => (rankings[a.code] ?? Infinity) - (rankings[b.code] ?? Infinity),
+  );
+  return sorted
+    .slice(0, ADVANCER_COUNT)
+    .map((team, i) => ({ rank: i + 1, teamId: team.id }));
 }


### PR DESCRIPTION
## Summary

Adds a one-click **"Auto-fill by FIFA ranking"** button (paired with **"Reset"**) to the **Best 3rds** wizard step, mirroring the existing Group Stage step. Auto-fill orders the user's candidate group 3rd-placers by the hand-maintained `FIFA_RANKINGS` map and seeds ranks 1–8.

## Changes

- **`lib/fifaRankings.ts`** — new `autofillAdvancersByFifaRanking(candidatePool)`: sorts the pool by FIFA rank (unranked → bottom, same `Infinity` fallback as the group helper) and returns the top 8 as ranks 1–8.
- **`app/predictions/PredictionsPageContent.tsx`** — `handleAutofillAdvancersByFifaRanking` (driven by the existing `advancerCandidatePool` memo) + `handleResetAdvancers`, wired into `<AdvancersForm>`.
- **`components/predictions/AdvancersForm.tsx`** — new `onAutofillByFifaRanking` / `onResetPicks` props and the two-button action row, guarded to `variant === 'predict'` so the admin editor and locked steps never show them.
- **`lib/__tests__/fifaRankings.test.ts`** — 4 new tests: rank order, cap-at-8, unranked-to-bottom, partial pool.

## Behavior notes

- Auto-fill picks the 8 highest-FIFA-ranked of your 12 group 3rd-place picks, so it's most useful once the Group Stage is complete. The existing "Heads up: only N of 12…" warning still flags a partial pool; auto-fill fills only what's available.
- Hidden in the admin Best-3rds editor (records actual finishers, not predictions) and when the step is locked (`!phase1Editable`).

## Verification

- `npm test` — 56 suites / 433 tests pass
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)