### PR TITLE
chore(release): v1.0.3 — changelog entry and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-06-01
+
+### Added
+
+- Predictions wizard: the Best 3rds step now has an "Auto-fill by FIFA ranking" button
+  (paired with "Reset"), mirroring the Group Stage step. Auto-fill orders your candidate
+  group 3rd-place picks by FIFA ranking and seeds ranks 1–8; it fills only what's
+  available when the group stage isn't complete yet.
+
 ## [1.0.2] - 2026-05-31
 
 ### Added
@@ -90,6 +99,7 @@ admin-submitted real-world results.
 - Dark-mode default, container-query-driven priority+ navigation, and SEO no-index
   ahead of launch.
 
+[1.0.3]: https://github.com/leedium/wc-2026-fantasy/releases/tag/v1.0.3
 [1.0.2]: https://github.com/leedium/wc-2026-fantasy/releases/tag/v1.0.2
 [1.0.1]: https://github.com/leedium/wc-2026-fantasy/releases/tag/v1.0.1
 [1.0.0]: https://github.com/leedium/wc-2026-fantasy/releases/tag/v1.0.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Release **v1.0.3**, covering the Best 3rds FIFA-ranking auto-fill feature (#185).

- `frontend/package.json` — version `1.0.2` → `1.0.3`
- `CHANGELOG.md` — new `[1.0.3] - 2026-06-01` entry + release-tag link

Follows the repo's pre-launch convention of patch bumps for additive changes (as with v1.0.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)