### PR TITLE
chore(release): v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-06-01
+
+### Added
+
+- Predictions wizard: the Group Stage and Best 3rds steps now have a "Randomize" button
+  (alongside "Auto-fill by FIFA ranking" and "Reset") that fills the picks with a random
+  arrangement — shuffling each group into positions 1–4 and seeding 8 random advancers
+  ranked 1–8. A "feeling lucky" alternative to the ranking-based auto-fill.
+
 ## [1.0.3] - 2026-06-01
 
 ### Added
@@ -99,6 +108,7 @@ admin-submitted real-world results.
 - Dark-mode default, container-query-driven priority+ navigation, and SEO no-index
   ahead of launch.
 
+[1.0.4]: https://github.com/leedium/wc-2026-fantasy/releases/tag/v1.0.4
 [1.0.3]: https://github.com/leedium/wc-2026-fantasy/releases/tag/v1.0.3
 [1.0.2]: https://github.com/leedium/wc-2026-fantasy/releases/tag/v1.0.2
 [1.0.1]: https://github.com/leedium/wc-2026-fantasy/releases/tag/v1.0.1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -47,6 +47,7 @@ import {
   autofillAdvancersByFifaRanking,
   autofillGroupPredictionsByFifaRanking,
 } from '@/lib/fifaRankings';
+import { randomizeAdvancers, randomizeGroupPredictions } from '@/lib/randomPredictions';
 import { applyGroupPositionChange } from '@/lib/groupSwap';
 import { cascadeKnockoutPick } from '@/lib/knockoutCascade';
 import { AdvancersForm } from '@/components/predictions/AdvancersForm';
@@ -768,6 +769,13 @@ export function PredictionsPageContent({
     persistDraft({ groupPredictions: next });
   };
 
+  const handleRandomizeGroups = () => {
+    if (!groups) return;
+    const next = randomizeGroupPredictions(groups);
+    setGroupPredictions(next);
+    persistDraft({ groupPredictions: next });
+  };
+
   const handleResetGroups = () => {
     if (!groups) return;
     const next = buildEmptyGroups(groups);
@@ -815,6 +823,12 @@ export function PredictionsPageContent({
 
   const handleAutofillAdvancersByFifaRanking = () => {
     const next = autofillAdvancersByFifaRanking(advancerCandidatePool);
+    setAdvancerPredictions(next);
+    persistDraft({ advancerPredictions: next });
+  };
+
+  const handleRandomizeAdvancers = () => {
+    const next = randomizeAdvancers(advancerCandidatePool);
     setAdvancerPredictions(next);
     persistDraft({ advancerPredictions: next });
   };
@@ -1391,6 +1405,7 @@ export function PredictionsPageContent({
               predictions={groupPredictions}
               onPredictionChange={handleGroupPredictionChange}
               onAutofillByFifaRanking={handleAutofillGroupsByFifaRanking}
+              onRandomize={handleRandomizeGroups}
               onResetGroups={handleResetGroups}
               disabled={!phase1Editable}
             />
@@ -1403,6 +1418,7 @@ export function PredictionsPageContent({
               value={advancerPredictions}
               onRankChange={handleAdvancerRankChange}
               onAutofillByFifaRanking={handleAutofillAdvancersByFifaRanking}
+              onRandomize={handleRandomizeAdvancers}
               onResetPicks={handleResetAdvancers}
               disabled={!phase1Editable}
             />

--- a/frontend/src/components/predictions/AdvancersForm.tsx
+++ b/frontend/src/components/predictions/AdvancersForm.tsx
@@ -34,6 +34,8 @@ export interface AdvancersFormProps {
   onRankChange: (rank: number, teamId: string | null) => void;
   /** Predict variant only: seed ranks 1–8 from the candidate pool by FIFA ranking. */
   onAutofillByFifaRanking?: () => void;
+  /** Predict variant only: seed ranks 1–8 with a random selection from the pool. */
+  onRandomize?: () => void;
   /** Predict variant only: clear all ranked picks. */
   onResetPicks?: () => void;
   disabled?: boolean;
@@ -51,6 +53,7 @@ export function AdvancersForm({
   value,
   onRankChange,
   onAutofillByFifaRanking,
+  onRandomize,
   onResetPicks,
   disabled = false,
 }: AdvancersFormProps) {
@@ -59,8 +62,9 @@ export function AdvancersForm({
   const pickedTeamIds = new Set(value.filter((v) => v.teamId).map((v) => v.teamId));
   const poolIncomplete = candidatePool.length < ADVANCER_COUNT;
   const showAutofill = variant === 'predict' && !!onAutofillByFifaRanking && !disabled;
+  const showRandomize = variant === 'predict' && !!onRandomize && !disabled;
   const showReset = variant === 'predict' && !!onResetPicks && !disabled;
-  const showActions = showAutofill || showReset;
+  const showActions = showAutofill || showRandomize || showReset;
 
   return (
     <div className="space-y-6">
@@ -111,19 +115,29 @@ export function AdvancersForm({
       )}
 
       {showActions && (
-        <div className="flex items-center justify-between gap-2">
-          {showAutofill ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="lg"
-              onClick={onAutofillByFifaRanking}
-            >
-              Auto-fill by FIFA ranking
-            </Button>
-          ) : (
-            <span />
-          )}
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {showAutofill && (
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                onClick={onAutofillByFifaRanking}
+              >
+                Auto-fill by FIFA ranking
+              </Button>
+            )}
+            {showRandomize && (
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                onClick={onRandomize}
+              >
+                Randomize
+              </Button>
+            )}
+          </div>
           {showReset && (
             <Button
               type="button"

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -55,6 +55,11 @@ interface GroupStageFormProps {
    */
   onAutofillByFifaRanking?: () => void;
   /**
+   * Predict-variant only: when provided, renders a "Randomize" button that
+   * overwrites all 12 groups with a random ordering of each group's teams.
+   */
+  onRandomize?: () => void;
+  /**
    * Predict-variant only: when provided, renders a "Reset" button that clears
    * every position in every group back to the unselected state.
    */
@@ -187,12 +192,14 @@ export function GroupStageForm({
   variant = 'predict',
   extraPerCard,
   onAutofillByFifaRanking,
+  onRandomize,
   onResetGroups,
 }: GroupStageFormProps) {
   const isAdmin = variant === 'admin';
   const showAutofill = !isAdmin && !!onAutofillByFifaRanking && !disabled;
+  const showRandomize = !isAdmin && !!onRandomize && !disabled;
   const showReset = !isAdmin && !!onResetGroups && !disabled;
-  const showActions = showAutofill || showReset;
+  const showActions = showAutofill || showRandomize || showReset;
 
   // Calculate completion stats
   const completedGroups = predictions.filter((p) => {
@@ -243,19 +250,29 @@ export function GroupStageForm({
       )}
 
       {showActions && (
-        <div className="flex items-center justify-between gap-2">
-          {showAutofill ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="lg"
-              onClick={onAutofillByFifaRanking}
-            >
-              Auto-fill by FIFA ranking
-            </Button>
-          ) : (
-            <span />
-          )}
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {showAutofill && (
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                onClick={onAutofillByFifaRanking}
+              >
+                Auto-fill by FIFA ranking
+              </Button>
+            )}
+            {showRandomize && (
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                onClick={onRandomize}
+              >
+                Randomize
+              </Button>
+            )}
+          </div>
           {showReset && (
             <Button
               type="button"

--- a/frontend/src/lib/__tests__/randomPredictions.test.ts
+++ b/frontend/src/lib/__tests__/randomPredictions.test.ts
@@ -1,0 +1,72 @@
+import type { Group, Team } from '@/types/tournament';
+
+import { randomizeAdvancers, randomizeGroupPredictions } from '../randomPredictions';
+
+const makeGroup = (id: string, teamIds: string[]): Group => ({
+  id,
+  name: `Group ${id}`,
+  teams: teamIds.map((tid) => ({ id: tid, name: tid, code: tid.toUpperCase(), group: id })),
+});
+
+const makeTeam = (id: string): Team => ({ id, name: id, code: id.toUpperCase(), group: 'X' });
+
+// Deterministic rng: cycles through a fixed sequence of values in [0, 1).
+const seqRng = (values: number[]): (() => number) => {
+  let i = 0;
+  return () => values[i++ % values.length];
+};
+
+describe('randomizeGroupPredictions', () => {
+  it('fills all four positions with a permutation of the group teams', () => {
+    const groups = ['A', 'B', 'C'].map((g) =>
+      makeGroup(g, [`${g}1`, `${g}2`, `${g}3`, `${g}4`]),
+    );
+
+    const result = randomizeGroupPredictions(groups, seqRng([0.1, 0.9, 0.4, 0.7]));
+
+    expect(result).toHaveLength(3);
+    for (const pred of result) {
+      const group = groups.find((g) => g.id === pred.groupId)!;
+      const slots = Object.values(pred.positions);
+      expect(slots.every((v) => v !== null)).toBe(true);
+      expect(new Set(slots).size).toBe(4);
+      expect(new Set(slots)).toEqual(new Set(group.teams.map((t) => t.id)));
+    }
+  });
+
+  it('produces a deterministic ordering for a fixed rng', () => {
+    const group = makeGroup('A', ['a', 'b', 'c', 'd']);
+    const rngA = seqRng([0.0, 0.0, 0.0]);
+    const rngB = seqRng([0.0, 0.0, 0.0]);
+
+    const [first] = randomizeGroupPredictions([group], rngA);
+    const [second] = randomizeGroupPredictions([group], rngB);
+
+    expect(first.positions).toEqual(second.positions);
+  });
+});
+
+describe('randomizeAdvancers', () => {
+  it('returns 8 distinct picks ranked 1..8 drawn from the pool', () => {
+    const pool = Array.from({ length: 12 }, (_, i) => makeTeam(`t${i}`));
+
+    const result = randomizeAdvancers(pool, seqRng([0.3, 0.6, 0.1, 0.8, 0.5]));
+
+    expect(result).toHaveLength(8);
+    expect(result.map((p) => p.rank)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    const teamIds = result.map((p) => p.teamId);
+    expect(new Set(teamIds).size).toBe(8);
+    const poolIds = new Set(pool.map((t) => t.id));
+    expect(teamIds.every((id) => poolIds.has(id))).toBe(true);
+  });
+
+  it('fills only what is available when the pool has fewer than 8 teams', () => {
+    const pool = [makeTeam('a'), makeTeam('b'), makeTeam('c')];
+
+    const result = randomizeAdvancers(pool, seqRng([0.5, 0.2]));
+
+    expect(result).toHaveLength(3);
+    expect(result.map((p) => p.rank)).toEqual([1, 2, 3]);
+    expect(new Set(result.map((p) => p.teamId))).toEqual(new Set(['a', 'b', 'c']));
+  });
+});

--- a/frontend/src/lib/randomPredictions.ts
+++ b/frontend/src/lib/randomPredictions.ts
@@ -1,0 +1,43 @@
+// Random "feeling lucky" pick generators. These mirror the return shapes of the
+// FIFA-ranking auto-fill helpers in @/lib/fifaRankings, but shuffle instead of
+// sort. Kept in a separate module because randomization is not ranking-related.
+
+import { ADVANCER_COUNT } from '@/lib/constants';
+import type { AdvancerPrediction, Group, GroupPrediction, Team } from '@/types/tournament';
+
+// Fisher–Yates shuffle. `rng` is injectable so tests can be deterministic.
+function shuffle<T>(arr: T[], rng: () => number): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+export function randomizeGroupPredictions(
+  groups: Group[],
+  rng: () => number = Math.random,
+): GroupPrediction[] {
+  return groups.map((group) => {
+    const shuffled = shuffle(group.teams, rng);
+    return {
+      groupId: group.id,
+      positions: {
+        first: shuffled[0]?.id ?? null,
+        second: shuffled[1]?.id ?? null,
+        third: shuffled[2]?.id ?? null,
+        fourth: shuffled[3]?.id ?? null,
+      },
+    };
+  });
+}
+
+export function randomizeAdvancers(
+  candidatePool: Team[],
+  rng: () => number = Math.random,
+): AdvancerPrediction[] {
+  return shuffle(candidatePool, rng)
+    .slice(0, ADVANCER_COUNT)
+    .map((team, i) => ({ rank: i + 1, teamId: team.id }));
+}


### PR DESCRIPTION
## Release v1.0.4

Promotes the **Randomize** prediction feature (#187) to a tagged release.

### Added

- Predictions wizard: **Randomize** button on the Group Stage and Best 3rds steps (alongside Auto-fill by FIFA ranking and Reset) — shuffles each group into positions 1–4 and seeds 8 random advancers ranked 1–8. A "feeling lucky" alternative to ranking-based auto-fill.

### Release chores

- CHANGELOG.md entry for `[1.0.4]`
- `frontend/package.json` bump to `1.0.4`
- Tagged `v1.0.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)