### PR TITLE
feat(predictions): hide FIFA autofill buttons behind feature flag

### DIFF
--- a/frontend/src/components/predictions/AdvancersForm.tsx
+++ b/frontend/src/components/predictions/AdvancersForm.tsx
@@ -14,7 +14,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { TeamFlag } from '@/components/shared/TeamFlag';
-import { ADVANCER_COUNT, ADVANCER_RANK_LABELS } from '@/lib/constants';
+import { ADVANCER_COUNT, ADVANCER_RANK_LABELS, FEATURES } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 import type { AdvancerPrediction, Team } from '@/types/tournament';
 
@@ -61,7 +61,8 @@ export function AdvancersForm({
   const isComplete = filledCount === ADVANCER_COUNT;
   const pickedTeamIds = new Set(value.filter((v) => v.teamId).map((v) => v.teamId));
   const poolIncomplete = candidatePool.length < ADVANCER_COUNT;
-  const showAutofill = variant === 'predict' && !!onAutofillByFifaRanking && !disabled;
+  const showAutofill =
+    FEATURES.fifaAutofill && variant === 'predict' && !!onAutofillByFifaRanking && !disabled;
   const showRandomize = variant === 'predict' && !!onRandomize && !disabled;
   const showReset = variant === 'predict' && !!onResetPicks && !disabled;
   const showActions = showAutofill || showRandomize || showReset;

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { TeamFlag } from '@/components/shared/TeamFlag';
+import { FEATURES } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 import type { Group, GroupPrediction, Team } from '@/types/tournament';
 
@@ -196,7 +197,7 @@ export function GroupStageForm({
   onResetGroups,
 }: GroupStageFormProps) {
   const isAdmin = variant === 'admin';
-  const showAutofill = !isAdmin && !!onAutofillByFifaRanking && !disabled;
+  const showAutofill = FEATURES.fifaAutofill && !isAdmin && !!onAutofillByFifaRanking && !disabled;
   const showRandomize = !isAdmin && !!onRandomize && !disabled;
   const showReset = !isAdmin && !!onResetGroups && !disabled;
   const showActions = showAutofill || showRandomize || showReset;

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -9,6 +9,16 @@ export const TOURNAMENT_CONFIG = {
   totalMatches: 104,
 } as const;
 
+/**
+ * UI feature flags. `fifaAutofill` hides the "Auto-fill by FIFA ranking" buttons
+ * in the Group Stage and Best 3rds wizard steps. Disabled to encourage prediction
+ * variety; the autofill logic in lib/fifaRankings.ts is preserved — flip to `true`
+ * to bring the buttons back.
+ */
+export const FEATURES = {
+  fifaAutofill: false,
+} as const;
+
 // Scoring v4 (migration 0051) + third-place restored (0053) + group rebalance (0054):
 // Group stage: 11 standard groups × 10 (exact-order top-2) + Group I "Group of Death" exact-order 15
 //   = 110 + 15 = 125. Reversed = 7, single correct in slot = 5, single in wrong slot = 2.


### PR DESCRIPTION
## Summary

Hides the **"Auto-fill by FIFA ranking"** button from both the **Group Stage** and **Best 3rd-place picks (Top 8 advancers)** wizard steps. The team decided this autofill was reducing prediction variety (everyone ended up with near-identical FIFA-ordered brackets).

The underlying logic is **preserved** so the feature can be brought back with a one-line change.

## Changes

- **`src/lib/constants.ts`** — new `FEATURES = { fifaAutofill: false }` flag.
- **`GroupStageForm.tsx`** / **`AdvancersForm.tsx`** — AND `FEATURES.fifaAutofill` into the existing `showAutofill` conditions and import the flag.

## What stays untouched

- `lib/fifaRankings.ts` (`FIFA_RANKINGS`, `autofillGroupPredictionsByFifaRanking`, `autofillAdvancersByFifaRanking`).
- The handlers (`handleAutofillGroupsByFifaRanking`, `handleAutofillAdvancersByFifaRanking`) and prop wiring in `PredictionsPageContent.tsx`.

Re-enabling = flip `FEATURES.fifaAutofill` to `true`.

## Verification

- `npm test` — 437/437 pass (incl. unchanged `fifaRankings.test.ts`).
- `npm run typecheck` — clean.
- `npm run lint` — only pre-existing warnings, no new issues.
- The Randomize / Reset buttons still render in both steps; only Auto-fill is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)