### PR TITLE
feat(predictions): rename "Randomize" button to "Randomize Picks"

### DIFF
--- a/frontend/src/components/predictions/AdvancersForm.tsx
+++ b/frontend/src/components/predictions/AdvancersForm.tsx
@@ -135,7 +135,7 @@ export function AdvancersForm({
                 size="lg"
                 onClick={onRandomize}
               >
-                Randomize
+                Randomize Picks
               </Button>
             )}
           </div>

--- a/frontend/src/components/predictions/GroupStageForm.tsx
+++ b/frontend/src/components/predictions/GroupStageForm.tsx
@@ -270,7 +270,7 @@ export function GroupStageForm({
                 size="lg"
                 onClick={onRandomize}
               >
-                Randomize
+                Randomize Picks
               </Button>
             )}
           </div>


### PR DESCRIPTION
## Summary

Renames the **"Randomize"** button label to **"Randomize Picks"** in both the **Group Stage** and **Best 3rd-place picks** wizard steps.

## Changes

- `GroupStageForm.tsx` — button label `Randomize` → `Randomize Picks`.
- `AdvancersForm.tsx` — button label `Randomize` → `Randomize Picks`.

Label-only change; the `onRandomize` handlers and behavior are unchanged.

## Verification

- `npm run typecheck` — clean.
- `npm run lint` — only pre-existing warnings.
- `npm test` — 437/437 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)