### PR TITLE
fix(rules): remove five-prediction limit copy

### DIFF
--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -44,9 +44,9 @@ export default function RulesPage() {
                 </li>
                 <li>
                   <span className="text-foreground font-semibold">
-                    Up to five named predictions.
+                    Multiple named predictions.
                   </span>{' '}
-                  Each account can save as many as five separate predictions per tournament.
+                  Each account can save as many separate predictions per tournament as you like.
                   Each has its own name, picks, and tiebreaker.
                 </li>
                 <li>


### PR DESCRIPTION
## Summary

The rules page stated **"Up to five named predictions"** and that each account "can save as many as five separate predictions per tournament." That limit has been removed — users may now create unlimited named predictions per tournament.

Reworded the list item to reflect no limit rather than deleting it, so the still-accurate "each has its own name, picks, and tiebreaker" detail is preserved.

## Changes

- `src/app/rules/page.tsx` — "Up to five named predictions" → "Multiple named predictions"; body now reads "as many separate predictions per tournament as you like."

This was the only reference to the five-prediction limit in the copy.

## Verification

- `npm run typecheck` — clean.
- `npm run lint` — only pre-existing warnings.
- `npm test` — 437/437 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)