### PR TITLE
feat(rules): add two-phase overview card to rules page

### DIFF
--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -7,7 +7,7 @@ import { ScoringBreakdown } from '@/components/marketing/ScoringBreakdown';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { PRICING, ROUTES } from '@/lib/constants';
+import { PRICING, ROUTES, SCORING } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Rules | World Cup 2026',
@@ -27,6 +27,49 @@ export default function RulesPage() {
           Everything you need to know to play — what you predict, when it locks, and exactly
           how points are awarded.
         </p>
+      </section>
+
+      <section className="py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>How the two phases work</CardTitle>
+            <CardDescription>
+              Predictions are made and scored across two separately-locked phases.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4 text-sm">
+              <p className="text-muted-foreground">
+                <span className="text-foreground font-semibold">Phase 1 — Before kickoff.</span>{' '}
+                Predict group standings (1st–4th in all 12 groups), rank your 8 best third-place
+                advancers, and pick your Gut Feeling Champion. Locks at the opening match.{' '}
+                <span className="text-foreground font-medium">
+                  Up to{' '}
+                  {SCORING.maxGroupPoints +
+                    SCORING.maxAdvancerPoints +
+                    SCORING.championPickBonus}{' '}
+                  points.
+                </span>
+              </p>
+              <p className="text-muted-foreground">
+                <span className="text-foreground font-semibold">Phase 2 — The knockouts.</span>{' '}
+                Once the group results are in and the bracket is set, predict every match winner
+                from the Round of 32 through the Final, plus the third-place match, and set your
+                Champion&apos;s Total Playoff Goals tiebreaker. Locks before the Round of 32.{' '}
+                <span className="text-foreground font-medium">
+                  Up to {SCORING.maxKnockoutPoints} points.
+                </span>
+              </p>
+              <p className="text-muted-foreground">
+                Together they total a maximum of{' '}
+                <span className="text-foreground font-semibold">
+                  {SCORING.maxTotalPoints} points
+                </span>
+                .
+              </p>
+            </div>
+          </CardContent>
+        </Card>
       </section>
 
       <section className="py-8">


### PR DESCRIPTION
## Summary

The rules page explained the two phases only as *deadlines* (the "Lock times" card) — there was no upfront overview of what each phase covers or how points split between them. This adds a **"How the two phases work"** card right after the hero, so readers are oriented before hitting the detailed Scoring Breakdown.

Copy is Option B from our discussion; placement is immediately below the Game Rules hero (chosen over merging into "Lock times" so the overview and the deadline detail stay distinct).

## Content

- **Phase 1 — Before kickoff:** group standings (1st–4th ×12), 8 best-3rd advancers, Gut Feeling Champion. Locks at the opening match. Up to **150 points**.
- **Phase 2 — The knockouts:** R32→Final winners + third-place match + Champion's Total Playoff Goals tiebreaker. Locks before the Round of 32. Up to **263 points**.
- Combined max **413 points**.

Point totals derive from `SCORING` constants (`maxGroupPoints + maxAdvancerPoints + championPickBonus`, `maxKnockoutPoints`, `maxTotalPoints`) rather than hardcoded numbers, matching the rest of the page.

## Changes

- `src/app/rules/page.tsx` — new full-width card after the hero; import `SCORING`.

## Verification

- `npm run typecheck` — clean.
- `npm run lint` — only pre-existing warnings.
- `npm test` — 437/437 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)