### PR TITLE
Release v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-06-02
+
+### Added
+
+- Rules page: a new "How the two phases work" card after the hero summarizes what each
+  phase covers and the points it's worth — Phase 1 (group standings, Best 3rds advancers,
+  Gut Feeling Champion) up to 150, Phase 2 (knockout bracket + Champion's Total Playoff
+  Goals tiebreaker) up to 263, for a 413 maximum. Totals derive from the scoring
+  constants. (#192)
+
+### Changed
+
+- Rules page: replaced the "up to five named predictions" copy — accounts can now create
+  unlimited named predictions per tournament, so the rule reads "Multiple named
+  predictions." (#191)
+- Predictions wizard: the "Randomize" button is now labelled "Randomize Picks" in both the
+  Group Stage and Best 3rds steps. (#190)
+
+### Removed
+
+- Predictions wizard: the "Auto-fill by FIFA ranking" buttons are hidden from the Group
+  Stage and Best 3rds steps to encourage prediction variety. The autofill logic is
+  preserved behind a `FEATURES.fifaAutofill` flag (default off) and can be re-enabled with
+  a one-line change. (#189)
+
 ## [1.0.4] - 2026-06-01
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -44,9 +44,9 @@ export default function RulesPage() {
                 </li>
                 <li>
                   <span className="text-foreground font-semibold">
-                    Up to five named predictions.
+                    Multiple named predictions.
                   </span>{' '}
-                  Each account can save as many as five separate predictions per tournament.
+                  Each account can save as many separate predictions per tournament as you like.
                   Each has its own name, picks, and tiebreaker.
                 </li>
                 <li>

--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -7,7 +7,7 @@ import { ScoringBreakdown } from '@/components/marketing/ScoringBreakdown';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { PRICING, ROUTES } from '@/lib/constants';
+import { PRICING, ROUTES, SCORING } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Rules | World Cup 2026',
@@ -27,6 +27,49 @@ export default function RulesPage() {
           Everything you need to know to play — what you predict, when it locks, and exactly
           how points are awarded.
         </p>
+      </section>
+
+      <section className="py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>How the two phases work</CardTitle>
+            <CardDescription>
+              Predictions are made and scored across two separately-locked phases.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4 text-sm">
+              <p className="text-muted-foreground">
+                <span className="text-foreground font-semibold">Phase 1 — Before kickoff.</span>{' '}
+                Predict group standings (1st–4th in all 12 groups), rank your 8 best third-place
+                advancers, and pick your Gut Feeling Champion. Locks at the opening match.{' '}
+                <span className="text-foreground font-medium">
+                  Up to{' '}
+                  {SCORING.maxGroupPoints +
+                    SCORING.maxAdvancerPoints +
+                    SCORING.championPickBonus}{' '}
+                  points.
+                </span>
+              </p>
+              <p className="text-muted-foreground">
+                <span className="text-foreground font-semibold">Phase 2 — The knockouts.</span>{' '}
+                Once the group results are in and the bracket is set, predict every match winner
+                from the Round of 32 through the Final, plus the third-place match, and set your
+                Champion&apos;s Total Playoff Goals tiebreaker. Locks before the Round of 32.{' '}
+                <span className="text-foreground font-medium">
+                  Up to {SCORING.maxKnockoutPoints} points.
+                </span>
+              </p>
+              <p className="text-muted-foreground">
+                Together they total a maximum of{' '}
+                <span className="text-foreground font-semibold">
+                  {SCORING.maxTotalPoints} points
+                </span>
+                .
+              </p>
+            </div>
+          </CardContent>
+        </Card>
       </section>
 
       <section className="py-8">


### PR DESCRIPTION
Bundles the unreleased changes since v1.0.4 and tags **v1.0.5**.

## Included

- **#192** — Rules page: new "How the two phases work" overview card after the hero.
- **#191** — Rules page: removed the "up to five named predictions" limit copy (now "Multiple named predictions").
- **#190** — Predictions wizard: "Randomize" → "Randomize Picks" label.
- **#189** — Predictions wizard: "Auto-fill by FIFA ranking" buttons hidden behind `FEATURES.fifaAutofill` (logic preserved).

(#189 and #190 already landed on `main` after v1.0.4; #191 and #192 are merged into this release branch.)

## Release chores

- `CHANGELOG.md` — `[1.0.5] - 2026-06-02` entry.
- `frontend/package.json` — version `1.0.4` → `1.0.5`.

## Verification

- `npm run typecheck` — clean · `npm run lint` — only pre-existing warnings · `npm test` — 437/437 pass.

> **Merge with a merge commit (not squash)** so the pushed `v1.0.5` tag stays on `main`'s history, matching the v1.0.4 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)