### PR TITLE
release: v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2026-06-02
+
+### Added
+
+- Admin: a new **Referrals** tab where an admin can search any member, view their full
+  referral state, and link/unlink referee accounts to credit referrals retroactively
+  (e.g. signups that arrived without a `?ref=` link). Rewards stay purely derived
+  (`floor(qualified/4) − redeemed`); `admin_add_referral` backfills `qualified_at` from
+  the referee's earliest non-free payment, and every add/remove is recorded in a
+  `referral_admin_audit` trail with actor, targets, and a required proof note. (#194)
+- Unpaid-prediction payment prompts on `/predictions` and `/leaderboard`: a shared,
+  persistent red notice tells the user how many entries are unpaid, the total CAD due,
+  and to send an Interac e-transfer to the payments email including their registered
+  account email. The predictions list tints unpaid rows red, and the leaderboard shows a
+  dedicated "not ranked yet" table of the user's unpaid entries above the ranking. The
+  nudge mirrors the leaderboard's own eligibility filter, so Phase 1 saved drafts
+  (`submitted_at` null but a complete pick set) are included. (#195)
+
 ## [1.0.5] - 2026-06-02
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/admin/referrals/AdminReferrals.tsx
+++ b/frontend/src/app/admin/referrals/AdminReferrals.tsx
@@ -1,0 +1,654 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Gift, Search, X } from 'lucide-react';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { AdminNav } from '@/components/admin/AdminNav';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import { FieldError } from '@/components/ui/field-error';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  useAdminReferralDetail,
+  adminReferralDetailKey,
+  type AdminReferee,
+} from '@/hooks/useAdminReferralDetail';
+
+interface AdminUser {
+  id: string;
+  username: string;
+  email: string | null;
+}
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return body.error ?? 'Failed';
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function AdminReferrals() {
+  const [selected, setSelected] = React.useState<AdminUser | null>(null);
+
+  return (
+    <PageLayout>
+      <h1 className="mb-2 text-3xl font-bold">Admin</h1>
+      <AdminNav />
+
+      <div className="space-y-6">
+        <MemberPicker selected={selected} onSelect={setSelected} />
+        {selected ? (
+          <MemberDetail member={selected} />
+        ) : (
+          <Card>
+            <CardContent className="text-muted-foreground flex flex-col items-center gap-2 py-12 text-center">
+              <Gift className="h-8 w-8" aria-hidden />
+              <p>Search a member above to view and manage their referrals.</p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </PageLayout>
+  );
+}
+
+function MemberPicker({
+  selected,
+  onSelect,
+}: {
+  selected: AdminUser | null;
+  onSelect: (u: AdminUser | null) => void;
+}) {
+  const [search, setSearch] = React.useState('');
+  const [debounced, setDebounced] = React.useState('');
+  const [open, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    const t = setTimeout(() => setDebounced(search.trim()), 250);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const query = useQuery<{ users: AdminUser[] }>({
+    queryKey: ['admin-users', 'referral-picker', debounced],
+    enabled: debounced.length >= 1,
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/admin/users?search=${encodeURIComponent(debounced)}&page=1&pageSize=10`
+      );
+      if (!res.ok) throw new Error('Failed to load users');
+      return res.json();
+    },
+  });
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-4">
+        <Label htmlFor="member-search">Member</Label>
+        {selected ? (
+          <div className="flex items-center justify-between gap-2 rounded-md border p-3">
+            <div className="text-sm">
+              <span className="font-medium">{selected.username}</span>
+              <span className="text-muted-foreground"> · {selected.email ?? 'no email'}</span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                onSelect(null);
+                setSearch('');
+                setDebounced('');
+              }}
+            >
+              <X className="mr-1 h-4 w-4" /> Change
+            </Button>
+          </div>
+        ) : (
+          <div className="relative">
+            <div className="relative">
+              <Search className="text-muted-foreground absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2" />
+              <Input
+                id="member-search"
+                placeholder="Search by username or email…"
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.target.value);
+                  setOpen(true);
+                }}
+                onFocus={() => setOpen(true)}
+                className="pl-8"
+                autoComplete="off"
+              />
+            </div>
+            {open && debounced.length >= 1 && (
+              <div className="bg-popover absolute z-10 mt-1 w-full overflow-hidden rounded-md border shadow-md">
+                {query.isLoading ? (
+                  <div className="p-3">
+                    <Skeleton className="h-6 w-full" />
+                  </div>
+                ) : (query.data?.users ?? []).length === 0 ? (
+                  <p className="text-muted-foreground p-3 text-sm">No members found</p>
+                ) : (
+                  <ul className="max-h-72 overflow-auto">
+                    {(query.data?.users ?? []).map((u) => (
+                      <li key={u.id}>
+                        <button
+                          type="button"
+                          className="hover:bg-accent w-full px-3 py-2 text-left text-sm"
+                          onClick={() => {
+                            onSelect(u);
+                            setOpen(false);
+                          }}
+                        >
+                          <span className="font-medium">{u.username}</span>
+                          <span className="text-muted-foreground"> · {u.email ?? 'no email'}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MemberDetail({ member }: { member: AdminUser }) {
+  const { data, isLoading } = useAdminReferralDetail(member.id);
+  const [applyOpen, setApplyOpen] = React.useState(false);
+  const [removeTarget, setRemoveTarget] = React.useState<AdminReferee | null>(null);
+
+  const overview = data?.overview;
+  const toNext = overview ? overview.qualifiedTotal % 4 : 0;
+
+  return (
+    <>
+      {/* Summary band */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <Gift className="h-5 w-5" />
+            {member.username}&apos;s referrals
+          </CardTitle>
+          <Button onClick={() => setApplyOpen(true)}>Apply a referral</Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isLoading || !overview ? (
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-20 w-full" />
+              ))}
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 gap-4 text-center sm:grid-cols-4">
+                <Stat label="Qualified referrals" value={overview.qualifiedTotal} />
+                <Stat label="Earned free picks" value={overview.earnedCredits} />
+                <Stat label="Redeemed" value={overview.redeemedTotal} />
+                <Stat
+                  label="Available now"
+                  value={overview.availableCredits}
+                  emphasis={overview.availableCredits > 0}
+                />
+              </div>
+              <div className="space-y-1">
+                <Progress value={(toNext / 4) * 100} />
+                <p className="text-muted-foreground text-sm">
+                  <strong>
+                    {toNext}/4
+                  </strong>{' '}
+                  toward next free pick · referral code{' '}
+                  <span className="font-mono">{overview.referralCode ?? '—'}</span>
+                </p>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Referees table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Referees ({data?.referees.length ?? 0})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Referee</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Linked on</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(data?.referees ?? []).map((r) => (
+                  <TableRow key={r.refereeId}>
+                    <TableCell className="font-medium">{r.refereeUsername}</TableCell>
+                    <TableCell className="text-sm">{r.refereeEmail ?? '—'}</TableCell>
+                    <TableCell className="text-sm">{formatDate(r.createdAt)}</TableCell>
+                    <TableCell>
+                      {r.source === 'admin' ? (
+                        <Badge variant="secondary">Admin-applied</Badge>
+                      ) : (
+                        <Badge variant="outline">Organic</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {r.qualifiedAt ? (
+                        <span className="text-green-600 dark:text-green-400">
+                          Qualified · {formatDate(r.qualifiedAt)}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">Pending payment</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setRemoveTarget(r)}
+                      >
+                        Remove
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {(data?.referees ?? []).length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-muted-foreground py-8 text-center">
+                      No referees yet
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Inbound strip */}
+      {data?.inbound && (
+        <Card>
+          <CardContent className="text-muted-foreground py-3 text-sm">
+            Referred by{' '}
+            <span className="text-foreground font-medium">
+              {data.inbound.referrerUsername}
+            </span>{' '}
+            on {formatDate(data.inbound.createdAt)}
+            {data.inbound.source === 'admin' && ' (admin-applied)'}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Audit history */}
+      <AuditHistory entries={data?.audit ?? []} loading={isLoading} />
+
+      <ApplyReferralDialog
+        open={applyOpen}
+        onOpenChange={setApplyOpen}
+        referrer={member}
+      />
+      <RemoveRefereeDialog
+        target={removeTarget}
+        referrerId={member.id}
+        onOpenChange={(open) => !open && setRemoveTarget(null)}
+      />
+    </>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string;
+  value: number;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="rounded-md border p-3">
+      <div
+        className={
+          emphasis
+            ? 'text-2xl font-bold text-green-600 dark:text-green-400'
+            : 'text-2xl font-bold'
+        }
+      >
+        {value}
+      </div>
+      <div className="text-muted-foreground text-xs">{label}</div>
+    </div>
+  );
+}
+
+function AuditHistory({
+  entries,
+  loading,
+}: {
+  entries: import('@/hooks/useAdminReferralDetail').AdminReferralAuditEntry[];
+  loading: boolean;
+}) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Card>
+      <CardHeader>
+        <button
+          type="button"
+          className="flex w-full items-center justify-between"
+          onClick={() => setOpen((o) => !o)}
+        >
+          <CardTitle className="text-base">Admin history ({entries.length})</CardTitle>
+          <span className="text-muted-foreground text-sm">{open ? 'Hide' : 'Show'}</span>
+        </button>
+      </CardHeader>
+      {open && (
+        <CardContent>
+          {loading ? (
+            <Skeleton className="h-10 w-full" />
+          ) : entries.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No admin actions recorded.</p>
+          ) : (
+            <ul className="space-y-3">
+              {entries.map((e) => (
+                <li key={e.id} className="border-b pb-3 text-sm last:border-0 last:pb-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant={e.action === 'add' ? 'default' : 'destructive'}>
+                      {e.action}
+                    </Badge>
+                    <span className="font-medium">
+                      {e.refereeUsername ?? e.refereeEmail ?? 'unknown'}
+                    </span>
+                    <span className="text-muted-foreground">
+                      by {e.actorUsername ?? 'unknown'} · {formatDate(e.createdAt)}
+                    </span>
+                  </div>
+                  <p className="text-muted-foreground mt-1">{e.note}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+interface ResolveResult {
+  found: boolean;
+  refereeId?: string;
+  username?: string;
+  hasPaid?: boolean;
+  currentReferrerId?: string | null;
+  currentReferrerUsername?: string | null;
+}
+
+function ApplyReferralDialog({
+  open,
+  onOpenChange,
+  referrer,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  referrer: AdminUser;
+}) {
+  const queryClient = useQueryClient();
+  const [email, setEmail] = React.useState('');
+  const [debounced, setDebounced] = React.useState('');
+  const [note, setNote] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [serverError, setServerError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      setEmail('');
+      setDebounced('');
+      setNote('');
+      setSubmitting(false);
+      setServerError(null);
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    const t = setTimeout(() => setDebounced(email.trim()), 350);
+    return () => clearTimeout(t);
+  }, [email]);
+
+  const resolve = useQuery<ResolveResult>({
+    queryKey: ['admin-resolve-referee', debounced],
+    enabled: open && debounced.includes('@'),
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/admin/referrals/resolve?email=${encodeURIComponent(debounced)}`
+      );
+      if (!res.ok) throw new Error('Failed to resolve');
+      return res.json();
+    },
+  });
+
+  const r = resolve.data;
+  const isSelf = r?.found && r.refereeId === referrer.id;
+  const alreadyReferred = r?.found && !!r.currentReferrerId;
+  const creditable = !!r?.found && !isSelf && !alreadyReferred;
+  const canSubmit = creditable && note.trim().length > 0 && !submitting;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setServerError(null);
+    const res = await fetch('/api/admin/referrals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        referrerId: referrer.id,
+        refereeEmail: debounced,
+        note: note.trim(),
+      }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      setServerError(await readError(res));
+      return;
+    }
+    const body = (await res.json()) as { qualified?: boolean };
+    toast.success(
+      body.qualified
+        ? `Linked ${r?.username} — qualified immediately`
+        : `Linked ${r?.username} — qualifies on first payment`
+    );
+    await queryClient.invalidateQueries({ queryKey: adminReferralDetailKey(referrer.id) });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Apply a referral</DialogTitle>
+          <DialogDescription>
+            Link a referee account to <span className="font-medium">{referrer.username}</span>. The
+            referee must already have an account.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="referee-email">Referee email</Label>
+            <Input
+              id="referee-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="off"
+              placeholder="friend@example.com"
+            />
+            <div className="min-h-5 text-sm" aria-live="polite">
+              {debounced.includes('@') && resolve.isLoading && (
+                <span className="text-muted-foreground">Looking up…</span>
+              )}
+              {debounced.includes('@') && !resolve.isLoading && r && (
+                <>
+                  {!r.found && <span className="text-destructive">No account found</span>}
+                  {isSelf && (
+                    <span className="text-destructive">That&apos;s this member</span>
+                  )}
+                  {alreadyReferred && (
+                    <span className="text-destructive">
+                      Already referred by {r.currentReferrerUsername}
+                    </span>
+                  )}
+                  {creditable && (
+                    <span className="text-green-600 dark:text-green-400">
+                      ✓ {r.username} ·{' '}
+                      {r.hasPaid
+                        ? 'already paid → qualifies immediately'
+                        : 'not yet paid → qualifies on first payment'}
+                    </span>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="referral-note">Proof / reason</Label>
+            <Input
+              id="referral-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="e.g. screenshot of email invite"
+            />
+          </div>
+          <FieldError id="apply-server-error" message={serverError} />
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              {submitting ? 'Applying…' : 'Apply referral'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RemoveRefereeDialog({
+  target,
+  referrerId,
+  onOpenChange,
+}: {
+  target: AdminReferee | null;
+  referrerId: string;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const open = target !== null;
+  const [note, setNote] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (target) {
+      setNote('');
+      setSubmitting(false);
+    }
+  }, [target]);
+
+  const handleConfirm = async () => {
+    if (!target || !note.trim()) return;
+    setSubmitting(true);
+    const res = await fetch('/api/admin/referrals', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refereeId: target.refereeId, note: note.trim() }),
+    });
+    setSubmitting(false);
+    if (!res.ok) {
+      toast.error(await readError(res));
+      return;
+    }
+    toast.success(`Removed ${target.refereeUsername}`);
+    await queryClient.invalidateQueries({ queryKey: adminReferralDetailKey(referrerId) });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Remove referral?</DialogTitle>
+          <DialogDescription>
+            {target
+              ? `Unlink ${target.refereeUsername} from this member. Any already-redeemed free pick stays valid.`
+              : ''}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1">
+          <Label htmlFor="remove-note">Proof / reason</Label>
+          <Input
+            id="remove-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="e.g. duplicate / disputed"
+            autoComplete="off"
+          />
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={!note.trim() || submitting}
+          >
+            {submitting ? 'Removing…' : 'Remove'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/admin/referrals/page.tsx
+++ b/frontend/src/app/admin/referrals/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { AdminReferrals } from './AdminReferrals';
+
+export const metadata: Metadata = {
+  title: 'Referrals | Admin',
+};
+
+export default function AdminReferralsPage() {
+  return <AdminReferrals />;
+}

--- a/frontend/src/app/api/admin/referrals/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/referrals/__tests__/route.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET, POST, DELETE } = require('../route');
+
+function mockAdmin(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+function getReq(qs = '') {
+  return new NextRequest(`http://localhost:3000/api/admin/referrals${qs}`);
+}
+
+function bodyReq(method: string, body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/referrals', {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  supabaseMock.auth.getUser.mockReset();
+  supabaseMock.from.mockReset();
+  supabaseMock.rpc.mockReset();
+});
+
+describe('GET /api/admin/referrals', () => {
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(getReq('?userId=u1'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(false);
+    const res = await GET(getReq('?userId=u1'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when userId missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    const res = await GET(getReq());
+    expect(res.status).toBe(400);
+  });
+
+  it('shapes overview, referees, inbound, and audit', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockImplementation((fn: string) => {
+      if (fn === 'admin_referral_overview') {
+        return Promise.resolve({
+          data: [
+            {
+              referral_code: 'ABCDEFGH',
+              qualified_total: 4,
+              earned_credits: 1,
+              redeemed_total: 0,
+              available_credits: 1,
+              referee_count: 5,
+            },
+          ],
+          error: null,
+        });
+      }
+      if (fn === 'admin_list_user_referrals') {
+        return Promise.resolve({
+          data: [
+            {
+              direction: 'outbound',
+              referee_id: 'r1',
+              referee_username: 'ref1',
+              referee_email: 'ref1@x.co',
+              referrer_id: 'a',
+              referrer_username: 'me',
+              referrer_email: 'me@x.co',
+              referrer_code_used: 'ADMIN',
+              source: 'admin',
+              has_paid: true,
+              created_at: '2026-05-01T00:00:00Z',
+              qualified_at: '2026-05-02T00:00:00Z',
+            },
+            {
+              direction: 'inbound',
+              referee_id: 'a',
+              referee_username: 'me',
+              referee_email: 'me@x.co',
+              referrer_id: 'b',
+              referrer_username: 'boss',
+              referrer_email: 'boss@x.co',
+              referrer_code_used: 'XYZ12345',
+              source: 'organic',
+              has_paid: true,
+              created_at: '2026-04-01T00:00:00Z',
+              qualified_at: null,
+            },
+          ],
+          error: null,
+        });
+      }
+      return Promise.resolve({
+        data: [
+          {
+            id: 'aud1',
+            actor_username: 'admin',
+            action: 'add',
+            referrer_username: 'me',
+            referee_username: 'ref1',
+            referee_email: 'ref1@x.co',
+            note: 'proof',
+            created_at: '2026-05-01T00:00:00Z',
+          },
+        ],
+        error: null,
+      });
+    });
+
+    const res = await GET(getReq('?userId=a'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overview).toMatchObject({ availableCredits: 1, refereeCount: 5 });
+    expect(body.referees).toHaveLength(1);
+    expect(body.referees[0]).toMatchObject({ refereeUsername: 'ref1', source: 'admin' });
+    expect(body.inbound).toMatchObject({ referrerUsername: 'boss' });
+    expect(body.audit).toHaveLength(1);
+    expect(body.audit[0]).toMatchObject({ action: 'add', note: 'proof' });
+  });
+});
+
+describe('POST /api/admin/referrals', () => {
+  it('returns 403 for non-admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(false);
+    const res = await POST(
+      bodyReq('POST', { referrerId: 'a', refereeEmail: 'x@y.co', note: 'n' })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when note missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    const res = await POST(bodyReq('POST', { referrerId: 'a', refereeEmail: 'x@y.co' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when referee account not found', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'referee account not found' },
+    });
+    const res = await POST(
+      bodyReq('POST', { referrerId: 'a', refereeEmail: 'x@y.co', note: 'n' })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when already referred', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'referee already referred' },
+    });
+    const res = await POST(
+      bodyReq('POST', { referrerId: 'a', refereeEmail: 'x@y.co', note: 'n' })
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 201 with qualified flag on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: [{ referee_id: 'r1', qualified: true }],
+      error: null,
+    });
+    const res = await POST(
+      bodyReq('POST', { referrerId: 'a', refereeEmail: 'x@y.co', note: 'proof' })
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual({ refereeId: 'r1', qualified: true });
+  });
+});
+
+describe('DELETE /api/admin/referrals', () => {
+  it('returns 400 when refereeId missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    const res = await DELETE(bodyReq('DELETE', { note: 'n' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when referral not found', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockResolvedValue({ error: { message: 'referral not found' } });
+    const res = await DELETE(bodyReq('DELETE', { refereeId: 'r1', note: 'n' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns ok on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockResolvedValue({ error: null });
+    const res = await DELETE(bodyReq('DELETE', { refereeId: 'r1', note: 'proof' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+  });
+});

--- a/frontend/src/app/api/admin/referrals/resolve/route.ts
+++ b/frontend/src/app/api/admin/referrals/resolve/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+/**
+ * Live email resolution for the "Apply a referral" dialog. Returns the
+ * matching account (if any), whether it has a non-free payment (so the UI can
+ * say "qualifies immediately"), and who — if anyone — already referred it.
+ */
+export async function GET(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const email = request.nextUrl.searchParams.get('email')?.trim();
+  if (!email) {
+    return NextResponse.json({ found: false });
+  }
+
+  const { data, error } = await ctx.supabase.rpc('admin_resolve_referee', {
+    p_email: email,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: safeMessage(error) }, { status: 400 });
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) {
+    return NextResponse.json({ found: false });
+  }
+
+  return NextResponse.json({
+    found: true,
+    refereeId: row.referee_id,
+    username: row.username,
+    hasPaid: row.has_paid,
+    currentReferrerId: row.current_referrer_id ?? null,
+    currentReferrerUsername: row.current_referrer_username ?? null,
+  });
+}

--- a/frontend/src/app/api/admin/referrals/route.ts
+++ b/frontend/src/app/api/admin/referrals/route.ts
@@ -1,0 +1,204 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+/** Map an RPC error message to an HTTP status. */
+function statusFor(message: string): number {
+  const m = message.toLowerCase();
+  if (m.includes('not authenticated')) return 401;
+  if (m.includes('forbidden')) return 403;
+  if (m.includes('referee account not found')) return 404;
+  if (m.includes('referrer not found')) return 404;
+  if (m.includes('referral not found')) return 404;
+  if (m.includes('referee already referred')) return 409;
+  if (m.includes('cannot refer self')) return 409;
+  return 400;
+}
+
+type ReferralRow = {
+  direction: 'inbound' | 'outbound';
+  referee_id: string;
+  referee_username: string;
+  referee_email: string | null;
+  referrer_id: string;
+  referrer_username: string;
+  referrer_email: string | null;
+  referrer_code_used: string;
+  source: 'admin' | 'organic';
+  has_paid: boolean;
+  created_at: string;
+  qualified_at: string | null;
+};
+
+/**
+ * Full referral state for one member: derived credit summary, the referees
+ * they brought in (outbound), who referred them (inbound), and the admin
+ * audit trail. Powers the /admin/referrals tool.
+ */
+export async function GET(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const userId = request.nextUrl.searchParams.get('userId')?.trim();
+  if (!userId) {
+    return NextResponse.json({ error: 'userId is required' }, { status: 400 });
+  }
+
+  const [overviewRes, listRes, auditRes] = await Promise.all([
+    ctx.supabase.rpc('admin_referral_overview', { p_user_id: userId }),
+    ctx.supabase.rpc('admin_list_user_referrals', { p_user_id: userId }),
+    ctx.supabase.rpc('admin_list_referral_audit', { p_user_id: userId }),
+  ]);
+
+  const firstError = overviewRes.error ?? listRes.error ?? auditRes.error;
+  if (firstError) {
+    return NextResponse.json(
+      { error: safeMessage(firstError) },
+      { status: statusFor(firstError.message ?? '') }
+    );
+  }
+
+  const o = (Array.isArray(overviewRes.data) ? overviewRes.data[0] : overviewRes.data) ?? null;
+  const rows = (listRes.data ?? []) as ReferralRow[];
+
+  const referees = rows
+    .filter((r) => r.direction === 'outbound')
+    .map((r) => ({
+      refereeId: r.referee_id,
+      refereeUsername: r.referee_username,
+      refereeEmail: r.referee_email,
+      source: r.source,
+      hasPaid: r.has_paid,
+      createdAt: r.created_at,
+      qualifiedAt: r.qualified_at,
+    }));
+
+  const inboundRow = rows.find((r) => r.direction === 'inbound');
+  const inbound = inboundRow
+    ? {
+        referrerId: inboundRow.referrer_id,
+        referrerUsername: inboundRow.referrer_username,
+        referrerCodeUsed: inboundRow.referrer_code_used,
+        source: inboundRow.source,
+        createdAt: inboundRow.created_at,
+        qualifiedAt: inboundRow.qualified_at,
+      }
+    : null;
+
+  const audit = (
+    auditRes.data as Array<{
+      id: string;
+      actor_username: string | null;
+      action: 'add' | 'remove';
+      referrer_username: string | null;
+      referee_username: string | null;
+      referee_email: string | null;
+      note: string;
+      created_at: string;
+    }> | null
+  )?.map((a) => ({
+    id: a.id,
+    actorUsername: a.actor_username,
+    action: a.action,
+    referrerUsername: a.referrer_username,
+    refereeUsername: a.referee_username,
+    refereeEmail: a.referee_email,
+    note: a.note,
+    createdAt: a.created_at,
+  })) ?? [];
+
+  return NextResponse.json({
+    overview: {
+      referralCode: o?.referral_code ?? null,
+      qualifiedTotal: o?.qualified_total ?? 0,
+      earnedCredits: o?.earned_credits ?? 0,
+      redeemedTotal: o?.redeemed_total ?? 0,
+      availableCredits: o?.available_credits ?? 0,
+      refereeCount: o?.referee_count ?? 0,
+    },
+    referees,
+    inbound,
+    audit,
+  });
+}
+
+/** Link a referee account (by email) to a referrer. */
+export async function POST(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  let body: { referrerId?: unknown; refereeEmail?: unknown; note?: unknown } = {};
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json body' }, { status: 400 });
+  }
+
+  const referrerId = typeof body.referrerId === 'string' ? body.referrerId.trim() : '';
+  const refereeEmail = typeof body.refereeEmail === 'string' ? body.refereeEmail.trim() : '';
+  const note = typeof body.note === 'string' ? body.note.trim() : '';
+  if (!referrerId) {
+    return NextResponse.json({ error: 'referrerId is required' }, { status: 400 });
+  }
+  if (!refereeEmail) {
+    return NextResponse.json({ error: 'refereeEmail is required' }, { status: 400 });
+  }
+  if (!note) {
+    return NextResponse.json({ error: 'note is required' }, { status: 400 });
+  }
+
+  const { data, error } = await ctx.supabase.rpc('admin_add_referral', {
+    p_referrer_id: referrerId,
+    p_referee_email: refereeEmail,
+    p_note: note,
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: safeMessage(error) },
+      { status: statusFor(error.message ?? '') }
+    );
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  return NextResponse.json(
+    { refereeId: row?.referee_id ?? null, qualified: row?.qualified ?? false },
+    { status: 201 }
+  );
+}
+
+/** Unlink a referee. */
+export async function DELETE(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  let body: { refereeId?: unknown; note?: unknown } = {};
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json body' }, { status: 400 });
+  }
+
+  const refereeId = typeof body.refereeId === 'string' ? body.refereeId.trim() : '';
+  const note = typeof body.note === 'string' ? body.note.trim() : '';
+  if (!refereeId) {
+    return NextResponse.json({ error: 'refereeId is required' }, { status: 400 });
+  }
+  if (!note) {
+    return NextResponse.json({ error: 'note is required' }, { status: 400 });
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_remove_referral', {
+    p_referee_id: refereeId,
+    p_note: note,
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: safeMessage(error) },
+      { status: statusFor(error.message ?? '') }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -10,6 +10,7 @@ import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
 import { UnpaidPredictionsTable } from '@/components/leaderboard/UnpaidPredictionsTable';
 import { UnpaidPaymentNotice } from '@/components/predictions/UnpaidPaymentNotice';
 import { Pagination, DEFAULT_ITEMS_PER_PAGE } from '@/components/shared/Pagination';
+import { needsPayment } from '@/lib/predictions/paymentStatus';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -53,6 +54,8 @@ interface PredictionsResponse {
     name: string;
     submittedAt: string | null;
     isPaid: boolean;
+    groups: Array<{ groupId: string }>;
+    advancers: Array<{ rank: number; teamId: string }>;
   }>;
 }
 
@@ -141,11 +144,10 @@ export function LeaderboardPageContent() {
     enabled: !!user,
   });
 
-  const unpaidSubmitted = React.useMemo(
-    () =>
-      (predictionsQuery.data?.predictions ?? []).filter(
-        (p) => !p.isPaid && p.submittedAt
-      ),
+  // Mirror the leaderboard's own eligibility filter (submitted OR Phase-1
+  // complete) so unpaid Phase 1 saved drafts surface here too.
+  const unpaidPredictions = React.useMemo(
+    () => (predictionsQuery.data?.predictions ?? []).filter(needsPayment),
     [predictionsQuery.data]
   );
 
@@ -263,10 +265,10 @@ export function LeaderboardPageContent() {
       {user && (
         <>
           <UnpaidPaymentNotice
-            unpaidCount={unpaidSubmitted.length}
+            unpaidCount={unpaidPredictions.length}
             email={user.email ?? null}
           />
-          <UnpaidPredictionsTable predictions={unpaidSubmitted} isLocked={isLocked} />
+          <UnpaidPredictionsTable predictions={unpaidPredictions} isLocked={isLocked} />
         </>
       )}
 

--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -7,6 +7,8 @@ import { ArrowRight, Lock, Search, Trophy, Users } from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
+import { UnpaidPredictionsTable } from '@/components/leaderboard/UnpaidPredictionsTable';
+import { UnpaidPaymentNotice } from '@/components/predictions/UnpaidPaymentNotice';
 import { Pagination, DEFAULT_ITEMS_PER_PAGE } from '@/components/shared/Pagination';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -42,6 +44,16 @@ interface LeaderboardResponse {
   total: number;
   page: number;
   pageSize: number;
+}
+
+interface PredictionsResponse {
+  tournament: { id: string; lockTime: string };
+  predictions: Array<{
+    id: string;
+    name: string;
+    submittedAt: string | null;
+    isPaid: boolean;
+  }>;
 }
 
 export function LeaderboardPageContent() {
@@ -115,6 +127,27 @@ export function LeaderboardPageContent() {
     if (!matches.length) return null;
     return matches.reduce((best, m) => (m.rank < best.rank ? m : best), matches[0]);
   }, [meQuery.data]);
+
+  // The public leaderboard only lists paid entries. Fetch the signed-in user's
+  // own predictions (shared cache key with /predictions) so we can surface any
+  // submitted-but-unpaid entries that are missing from the ranking below.
+  const predictionsQuery = useQuery<PredictionsResponse>({
+    queryKey: ['predictions'],
+    queryFn: async () => {
+      const res = await fetch('/api/predictions');
+      if (!res.ok) throw new Error('Failed to fetch predictions');
+      return res.json();
+    },
+    enabled: !!user,
+  });
+
+  const unpaidSubmitted = React.useMemo(
+    () =>
+      (predictionsQuery.data?.predictions ?? []).filter(
+        (p) => !p.isPaid && p.submittedAt
+      ),
+    [predictionsQuery.data]
+  );
 
   const handleFindMyRank = React.useCallback(() => {
     if (!bestMatch) return;
@@ -225,6 +258,16 @@ export function LeaderboardPageContent() {
             )}
           </p>
         </div>
+      )}
+
+      {user && (
+        <>
+          <UnpaidPaymentNotice
+            unpaidCount={unpaidSubmitted.length}
+            email={user.email ?? null}
+          />
+          <UnpaidPredictionsTable predictions={unpaidSubmitted} isLocked={isLocked} />
+        </>
       )}
 
       <Card className="mb-6">

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -31,8 +31,10 @@ import {
 } from '@/hooks/useRewardsStatus';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
 import { FreePickBanner } from '@/components/predictions/FreePickBanner';
+import { UnpaidPaymentNotice } from '@/components/predictions/UnpaidPaymentNotice';
 import { PRICING, ROUTES } from '@/lib/constants';
 import { fetchJSON } from '@/lib/api/fetchJSON';
+import { cn } from '@/lib/utils';
 
 interface ApiPrediction {
   id: string;
@@ -79,6 +81,10 @@ export function PredictionsListPage() {
     phase === 'phase2_locked' || (phase === 'phase1_locked' && advancersSet);
 
   const predictions = query.data?.predictions ?? [];
+  // Submitted entries that haven't been marked paid — drive the red payment
+  // notice + row tint. `isPaid` already covers free picks (isFreePaid rows are
+  // isPaid === true), so they're excluded.
+  const unpaidSubmitted = predictions.filter((p) => !p.isPaid && p.submittedAt);
   // New predictions are accepted only during phase 1 (super admins may also
   // create while a later phase is still open). Once the tournament is LOCKED,
   // no role — including super admin — can create a new entry.
@@ -200,6 +206,11 @@ export function PredictionsListPage() {
         </Card>
       )}
 
+      <UnpaidPaymentNotice
+        unpaidCount={unpaidSubmitted.length}
+        email={user?.email ?? null}
+      />
+
       <div className="mb-4">
         <FreePickBanner />
       </div>
@@ -227,8 +238,16 @@ export function PredictionsListPage() {
         </Card>
       ) : (
         <div className="space-y-3">
-          {predictions.map((p) => (
-            <Card key={p.id}>
+          {predictions.map((p) => {
+            const isUnpaidSubmitted = !p.isPaid && !!p.submittedAt;
+            return (
+            <Card
+              key={p.id}
+              className={cn(
+                isUnpaidSubmitted &&
+                  'border-red-500/40 bg-red-500/5 dark:bg-red-500/10'
+              )}
+            >
               <CardContent className="flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex-1">
                   <div className="flex flex-wrap items-center gap-2">
@@ -321,7 +340,8 @@ export function PredictionsListPage() {
                 </div>
               </CardContent>
             </Card>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -34,6 +34,7 @@ import { FreePickBanner } from '@/components/predictions/FreePickBanner';
 import { UnpaidPaymentNotice } from '@/components/predictions/UnpaidPaymentNotice';
 import { PRICING, ROUTES } from '@/lib/constants';
 import { fetchJSON } from '@/lib/api/fetchJSON';
+import { needsPayment } from '@/lib/predictions/paymentStatus';
 import { cn } from '@/lib/utils';
 
 interface ApiPrediction {
@@ -44,6 +45,10 @@ interface ApiPrediction {
   isPaid: boolean;
   paidAt: string | null;
   isFreePaid: boolean;
+  // Used to mirror the leaderboard's Phase-1-complete eligibility (12 group
+  // rows + 8 advancer rows) so unpaid Phase 1 saved drafts get the payment nudge.
+  groups: Array<{ groupId: string }>;
+  advancers: Array<{ rank: number; teamId: string }>;
 }
 
 interface ApiResponse {
@@ -81,10 +86,11 @@ export function PredictionsListPage() {
     phase === 'phase2_locked' || (phase === 'phase1_locked' && advancersSet);
 
   const predictions = query.data?.predictions ?? [];
-  // Submitted entries that haven't been marked paid — drive the red payment
-  // notice + row tint. `isPaid` already covers free picks (isFreePaid rows are
-  // isPaid === true), so they're excluded.
-  const unpaidSubmitted = predictions.filter((p) => !p.isPaid && p.submittedAt);
+  // Unpaid entries that would rank once paid — drive the red payment notice +
+  // row tint. Mirrors the leaderboard eligibility filter (submitted OR Phase-1
+  // complete), so Phase 1 saved drafts are included. `isPaid` already covers
+  // free picks (isFreePaid rows are isPaid === true), so they're excluded.
+  const unpaidPredictions = predictions.filter(needsPayment);
   // New predictions are accepted only during phase 1 (super admins may also
   // create while a later phase is still open). Once the tournament is LOCKED,
   // no role — including super admin — can create a new entry.
@@ -207,7 +213,7 @@ export function PredictionsListPage() {
       )}
 
       <UnpaidPaymentNotice
-        unpaidCount={unpaidSubmitted.length}
+        unpaidCount={unpaidPredictions.length}
         email={user?.email ?? null}
       />
 
@@ -239,13 +245,12 @@ export function PredictionsListPage() {
       ) : (
         <div className="space-y-3">
           {predictions.map((p) => {
-            const isUnpaidSubmitted = !p.isPaid && !!p.submittedAt;
+            const isUnpaid = needsPayment(p);
             return (
             <Card
               key={p.id}
               className={cn(
-                isUnpaidSubmitted &&
-                  'border-red-500/40 bg-red-500/5 dark:bg-red-500/10'
+                isUnpaid && 'border-red-500/40 bg-red-500/5 dark:bg-red-500/10'
               )}
             >
               <CardContent className="flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:justify-between">

--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -7,7 +7,7 @@ import { ScoringBreakdown } from '@/components/marketing/ScoringBreakdown';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { PRICING, ROUTES, SCORING } from '@/lib/constants';
+import { PAYMENTS_EMAIL, PRICING, ROUTES, SCORING } from '@/lib/constants';
 
 export const metadata: Metadata = {
   title: 'Rules | World Cup 2026',
@@ -134,8 +134,8 @@ export default function RulesPage() {
                   <span className="text-foreground font-semibold">Payment</span>
                   <br />
                   E-transfer:{' '}
-                  <a href="mailto:payments@soccer-pool.com" className="text-foreground font-medium">
-                    payments@soccer-pool.com
+                  <a href={`mailto:${PAYMENTS_EMAIL}`} className="text-foreground font-medium">
+                    {PAYMENTS_EMAIL}
                   </a>
                   <br />
                   PayPal also accepted &mdash; email for info

--- a/frontend/src/components/admin/AdminNav.tsx
+++ b/frontend/src/components/admin/AdminNav.tsx
@@ -8,6 +8,7 @@ const links = [
   { label: 'Dashboard', href: '/admin' },
   { label: 'Results', href: '/admin/results' },
   { label: 'Users', href: '/admin/users' },
+  { label: 'Referrals', href: '/admin/referrals' },
   { label: 'Tournament', href: '/admin/tournament' },
 ];
 

--- a/frontend/src/components/leaderboard/UnpaidPredictionsTable.tsx
+++ b/frontend/src/components/leaderboard/UnpaidPredictionsTable.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { ROUTES } from '@/lib/constants';
+
+export interface UnpaidPrediction {
+  id: string;
+  name: string;
+  submittedAt: string | null;
+}
+
+function formatTime(value: string | null) {
+  if (!value) return '—';
+  return new Date(value).toLocaleString();
+}
+
+/**
+ * Read-only table of the signed-in user's submitted-but-unpaid predictions,
+ * shown directly above the public leaderboard (which only lists paid entries).
+ * Purpose-built rather than reusing `LeaderboardTable` — these rows have no
+ * rank/points and exist to nudge payment. Every row is red-tinted to contrast
+ * with the normal ranked rows below.
+ */
+export function UnpaidPredictionsTable({
+  predictions,
+  isLocked,
+}: {
+  predictions: UnpaidPrediction[];
+  isLocked: boolean;
+}) {
+  if (predictions.length === 0) return null;
+
+  return (
+    <Card className="mb-6 border-red-500/40">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base text-red-900 dark:text-red-200">
+          Your unpaid predictions — not ranked yet
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Prediction</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Submitted</TableHead>
+              {!isLocked && <TableHead className="text-right">Action</TableHead>}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {predictions.map((p) => (
+              <TableRow
+                key={p.id}
+                className="bg-red-500/5 hover:bg-red-500/10 dark:bg-red-500/10 dark:hover:bg-red-500/15"
+              >
+                <TableCell className="font-medium">{p.name}</TableCell>
+                <TableCell>
+                  <Badge variant="destructive">Payment pending — not ranked</Badge>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {formatTime(p.submittedAt)}
+                </TableCell>
+                {!isLocked && (
+                  <TableCell className="text-right">
+                    <Button asChild variant="outline" size="sm">
+                      <Link href={`${ROUTES.predictions}/${encodeURIComponent(p.id)}`}>
+                        Edit
+                      </Link>
+                    </Button>
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/predictions/UnpaidPaymentNotice.tsx
+++ b/frontend/src/components/predictions/UnpaidPaymentNotice.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import * as React from 'react';
+import { AlertTriangle, Mail } from 'lucide-react';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { PAYMENTS_EMAIL, PRICING } from '@/lib/constants';
+
+/**
+ * Urgent, persistent red notice shown to a signed-in user who has submitted
+ * predictions that haven't been marked paid yet. Used identically on
+ * `/predictions` and `/leaderboard` so the payment call-to-action reads the
+ * same everywhere.
+ *
+ * Intentionally NOT dismissible: an unmet payment obligation shouldn't be
+ * silenceable. It returns `null` once `unpaidCount` hits 0, so it disappears on
+ * its own when an admin marks the entries paid.
+ *
+ * Presentational only — the caller computes the count of submitted-but-unpaid
+ * predictions and passes the registered account email.
+ */
+export function UnpaidPaymentNotice({
+  unpaidCount,
+  email,
+}: {
+  unpaidCount: number;
+  email: string | null;
+}) {
+  if (unpaidCount <= 0) return null;
+
+  const plural = unpaidCount === 1 ? 'prediction' : 'predictions';
+  const totalDue = unpaidCount * PRICING.entryFeeCAD;
+  const emailLabel = email ?? 'your registered email';
+
+  const mailtoSubject = encodeURIComponent(
+    `World Cup 2026 pool payment${email ? ` — ${email}` : ''}`
+  );
+  const mailtoBody = encodeURIComponent(
+    `Hi,\n\nI'm sending an Interac e-transfer for ${unpaidCount} ${plural} ($${totalDue} ${PRICING.currency} total).\n\nRegistered account email: ${email ?? '(add your account email)'}\n`
+  );
+
+  return (
+    <Card
+      role="alert"
+      className="mb-6 border-red-500/40 bg-red-500/10 text-red-900 dark:text-red-200"
+    >
+      <CardContent className="flex items-start gap-3 py-4">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-red-600 dark:text-red-400" aria-hidden />
+        <div className="flex-1 space-y-2">
+          <p className="font-semibold">
+            Action needed: you have {unpaidCount} unpaid {plural}
+          </p>
+          <p className="text-sm">
+            Each entry is{' '}
+            <span className="font-semibold">
+              ${PRICING.entryFeeCAD} {PRICING.currency}
+            </span>{' '}
+            and won&apos;t be ranked on the leaderboard until payment is recorded
+            (total due:{' '}
+            <span className="font-semibold">
+              ${totalDue} {PRICING.currency}
+            </span>
+            ). Send an <span className="font-semibold">Interac e-transfer</span> to{' '}
+            <a
+              href={`mailto:${PAYMENTS_EMAIL}?subject=${mailtoSubject}&body=${mailtoBody}`}
+              className="font-medium underline underline-offset-2"
+            >
+              {PAYMENTS_EMAIL}
+            </a>{' '}
+            and <span className="font-semibold">include your registered email</span> (
+            <span className="font-medium break-all">{emailLabel}</span>) in the
+            transfer message so we can match it to your account.
+          </p>
+          <a
+            href={`mailto:${PAYMENTS_EMAIL}?subject=${mailtoSubject}&body=${mailtoBody}`}
+            className="inline-flex items-center gap-1.5 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-900 transition hover:bg-red-500/20 dark:text-red-200"
+          >
+            <Mail className="h-4 w-4" aria-hidden />
+            Email payment to {PAYMENTS_EMAIL}
+          </a>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/predictions/__tests__/UnpaidPaymentNotice.test.tsx
+++ b/frontend/src/components/predictions/__tests__/UnpaidPaymentNotice.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+
+import { UnpaidPaymentNotice } from '../UnpaidPaymentNotice';
+import { PAYMENTS_EMAIL, PRICING } from '@/lib/constants';
+
+describe('UnpaidPaymentNotice', () => {
+  it('renders nothing when there are no unpaid predictions', () => {
+    const { container } = render(
+      <UnpaidPaymentNotice unpaidCount={0} email="player@example.com" />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the count, registered email, and total due', () => {
+    render(<UnpaidPaymentNotice unpaidCount={2} email="player@example.com" />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/2 unpaid predictions/i)).toBeInTheDocument();
+    expect(screen.getByText('player@example.com')).toBeInTheDocument();
+    // total due = count * entry fee
+    expect(
+      screen.getByText(`$${2 * PRICING.entryFeeCAD} ${PRICING.currency}`)
+    ).toBeInTheDocument();
+  });
+
+  it('uses singular copy for a single unpaid prediction', () => {
+    render(<UnpaidPaymentNotice unpaidCount={1} email="player@example.com" />);
+    expect(screen.getByText(/1 unpaid prediction(?!s)/i)).toBeInTheDocument();
+  });
+
+  it('links to the payments email and falls back when email is null', () => {
+    render(<UnpaidPaymentNotice unpaidCount={1} email={null} />);
+
+    const links = screen
+      .getAllByRole('link')
+      .filter((a) => a.getAttribute('href')?.startsWith(`mailto:${PAYMENTS_EMAIL}`));
+    expect(links.length).toBeGreaterThan(0);
+    // The (<email>) label falls back to this phrase when no email is supplied.
+    expect(screen.getAllByText(/your registered email/i).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/hooks/useAdminReferralDetail.ts
+++ b/frontend/src/hooks/useAdminReferralDetail.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+export interface AdminReferralOverview {
+  referralCode: string | null;
+  qualifiedTotal: number;
+  earnedCredits: number;
+  redeemedTotal: number;
+  availableCredits: number;
+  refereeCount: number;
+}
+
+export interface AdminReferee {
+  refereeId: string;
+  refereeUsername: string;
+  refereeEmail: string | null;
+  source: 'admin' | 'organic';
+  hasPaid: boolean;
+  createdAt: string;
+  qualifiedAt: string | null;
+}
+
+export interface AdminReferralInbound {
+  referrerId: string;
+  referrerUsername: string;
+  referrerCodeUsed: string;
+  source: 'admin' | 'organic';
+  createdAt: string;
+  qualifiedAt: string | null;
+}
+
+export interface AdminReferralAuditEntry {
+  id: string;
+  actorUsername: string | null;
+  action: 'add' | 'remove';
+  referrerUsername: string | null;
+  refereeUsername: string | null;
+  refereeEmail: string | null;
+  note: string;
+  createdAt: string;
+}
+
+export interface AdminReferralDetail {
+  overview: AdminReferralOverview;
+  referees: AdminReferee[];
+  inbound: AdminReferralInbound | null;
+  audit: AdminReferralAuditEntry[];
+}
+
+export const adminReferralDetailKey = (userId: string | null) =>
+  ['admin-referral-detail', userId] as const;
+
+/**
+ * Full referral state for one member, backed by `/api/admin/referrals`.
+ * Mutations (add/remove) should invalidate the matching detail key on success.
+ */
+export function useAdminReferralDetail(userId: string | null) {
+  return useQuery<AdminReferralDetail>({
+    queryKey: adminReferralDetailKey(userId),
+    enabled: !!userId,
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/referrals?userId=${encodeURIComponent(userId!)}`);
+      if (!res.ok) throw new Error('Failed to load referral detail');
+      return res.json();
+    },
+  });
+}

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -61,6 +61,13 @@ const KNOWN_ERROR_FRAGMENTS = [
   'tournament_id is required',
   // Reset tournament (migration 0046)
   'tournament not found',
+  // Referral admin tool (migration 0059)
+  'referee account not found',
+  'referee already referred',
+  'cannot refer self',
+  'referrer not found',
+  'note is required',
+  'referral not found',
 ] as const;
 
 export function safeMessage(

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -51,6 +51,13 @@ export const PRICING = {
 } as const;
 
 /**
+ * Address for out-of-band entry payments (Interac e-transfer / PayPal). Surfaced
+ * in the rules page and the unpaid-prediction payment notice. Single source so
+ * the email only ever lives in one place.
+ */
+export const PAYMENTS_EMAIL = 'payments@soccer-pool.com';
+
+/**
  * Operating-cost model for the /audit transparency page. Every value here is
  * meant to be edited directly when costs change.
  *

--- a/frontend/src/lib/predictions/__tests__/paymentStatus.test.ts
+++ b/frontend/src/lib/predictions/__tests__/paymentStatus.test.ts
@@ -1,0 +1,53 @@
+import { isPhase1Complete, needsPayment } from '../paymentStatus';
+import { ADVANCER_COUNT, TOURNAMENT_CONFIG } from '@/lib/constants';
+
+const fullGroups = Array.from({ length: TOURNAMENT_CONFIG.totalGroups }, (_, i) => ({
+  groupId: String(i),
+}));
+const fullAdvancers = Array.from({ length: ADVANCER_COUNT }, (_, i) => ({
+  rank: i + 1,
+  teamId: `t${i}`,
+}));
+
+describe('isPhase1Complete', () => {
+  it('is true with all 12 group rows + 8 advancer rows', () => {
+    expect(
+      isPhase1Complete({ isPaid: false, submittedAt: null, groups: fullGroups, advancers: fullAdvancers })
+    ).toBe(true);
+  });
+
+  it('is false when group or advancer rows are incomplete', () => {
+    expect(
+      isPhase1Complete({ isPaid: false, submittedAt: null, groups: fullGroups.slice(0, 5), advancers: fullAdvancers })
+    ).toBe(false);
+    expect(
+      isPhase1Complete({ isPaid: false, submittedAt: null, groups: fullGroups, advancers: [] })
+    ).toBe(false);
+  });
+});
+
+describe('needsPayment', () => {
+  it('flags a Phase 1 saved draft (submittedAt null but complete) that is unpaid', () => {
+    expect(
+      needsPayment({ isPaid: false, submittedAt: null, groups: fullGroups, advancers: fullAdvancers })
+    ).toBe(true);
+  });
+
+  it('flags an explicitly-submitted unpaid prediction', () => {
+    expect(
+      needsPayment({ isPaid: false, submittedAt: '2026-06-01T00:00:00Z', groups: [], advancers: [] })
+    ).toBe(true);
+  });
+
+  it('does not flag a paid prediction', () => {
+    expect(
+      needsPayment({ isPaid: true, submittedAt: null, groups: fullGroups, advancers: fullAdvancers })
+    ).toBe(false);
+  });
+
+  it('does not flag a genuinely-incomplete unsubmitted draft', () => {
+    expect(
+      needsPayment({ isPaid: false, submittedAt: null, groups: fullGroups.slice(0, 3), advancers: [] })
+    ).toBe(false);
+  });
+});

--- a/frontend/src/lib/predictions/paymentStatus.ts
+++ b/frontend/src/lib/predictions/paymentStatus.ts
@@ -1,0 +1,39 @@
+import { ADVANCER_COUNT, TOURNAMENT_CONFIG } from '@/lib/constants';
+
+/**
+ * Minimal shape needed to decide whether a prediction needs a payment nudge.
+ * Mirrors the relevant fields of the `/api/predictions` GET response.
+ */
+export interface PaymentStatusInput {
+  isPaid: boolean;
+  submittedAt: string | null;
+  groups?: ReadonlyArray<unknown>;
+  advancers?: ReadonlyArray<unknown>;
+}
+
+/**
+ * Mirrors the DB `prediction_phase1_complete`: a complete Phase 1 pick set is
+ * all 12 group rows + 8 advancer rows. During Phase 1 these "Save Phase 1
+ * Picks" rows have `submitted_at = null` (they read as "Draft" in the UI) but
+ * are already leaderboard-eligible once paid.
+ */
+export function isPhase1Complete(p: PaymentStatusInput): boolean {
+  return (
+    (p.groups?.length ?? 0) === TOURNAMENT_CONFIG.totalGroups &&
+    (p.advancers?.length ?? 0) === ADVANCER_COUNT
+  );
+}
+
+/**
+ * True when a prediction would appear on the leaderboard if it were paid —
+ * i.e. it is unpaid AND either explicitly submitted OR has a complete Phase 1
+ * pick set. This is the exact frontend mirror of the eligibility filter in
+ * `get_leaderboard` (`submitted_at is not null OR prediction_phase1_complete`),
+ * so the unpaid payment notice + row tint cover Phase 1 saved drafts too.
+ *
+ * Genuinely-incomplete drafts (still mid-creation) are excluded: even if paid
+ * they wouldn't rank, so there's nothing to nudge yet.
+ */
+export function needsPayment(p: PaymentStatusInput): boolean {
+  return !p.isPaid && (p.submittedAt != null || isPhase1Complete(p));
+}

--- a/supabase/migrations/0059_admin_referrals.sql
+++ b/supabase/migrations/0059_admin_referrals.sql
@@ -1,0 +1,397 @@
+-- WC2026 — Referral Admin tool
+--
+-- Lets admins retroactively credit referrers whose referees signed up via a
+-- bare URL (emailed contact lists) instead of a `?ref=<code>` link, so no
+-- `referrals` row was ever created. There is no admin write path into
+-- `referrals` today (admin-SELECT RLS only; all mutations go through
+-- SECURITY DEFINER triggers), so this migration adds the missing path.
+--
+-- Design (no new credit concept): admins only *link* / *unlink* referee
+-- accounts. The existing derived math takes over —
+--   qualified_total = count of referrals rows with qualified_at set
+--   earned          = floor(qualified_total / 4)
+--   available       = greatest(0, earned - redeemed)
+-- A referee becomes qualified on their first non-free payment.
+--
+-- Correctness subtlety: the tournament_payments_sync_referrals trigger only
+-- fires on payment writes, so it will NOT retroactively qualify a referee who
+-- already paid *before* being linked. admin_add_referral therefore backfills
+-- qualified_at itself when the referee already has a non-free payment (using
+-- that payment's paid_at). Not-yet-paid referees keep qualified_at NULL and
+-- the existing trigger qualifies them on their first payment.
+--
+-- Source marker: admin-applied rows store referrer_code_used = 'ADMIN' (a
+-- 5-char sentinel; organic codes are 8 chars, so no collision) so the tool
+-- can distinguish organic vs admin-applied links in the UI and audit math.
+--
+-- Audit: every add/remove records the actor, action, targets, a snapshot of
+-- the referee email, and a required free-text proof/reason note.
+
+
+-- ========== referral_admin_audit table ==========
+
+create table public.referral_admin_audit (
+    id            uuid primary key default gen_random_uuid(),
+    actor_id      uuid references public.profiles(id) on delete set null,
+    action        text not null check (action in ('add', 'remove')),
+    referrer_id   uuid references public.profiles(id) on delete set null,
+    referee_id    uuid references public.profiles(id) on delete set null,
+    referee_email text,
+    note          text not null,
+    created_at    timestamptz not null default now()
+);
+
+create index referral_admin_audit_referrer_idx
+    on public.referral_admin_audit (referrer_id, created_at desc);
+create index referral_admin_audit_referee_idx
+    on public.referral_admin_audit (referee_id, created_at desc);
+
+alter table public.referral_admin_audit enable row level security;
+
+-- Admin-only reads; no INSERT policy — writes go through the SECURITY DEFINER
+-- RPCs below only.
+create policy "referral_admin_audit_admin_select"
+    on public.referral_admin_audit for select
+    using (public.is_admin());
+
+grant select on public.referral_admin_audit to authenticated;
+
+
+-- ========== RPC: admin_resolve_referee ==========
+-- Powers the "Apply a referral" dialog's live email resolution. Returns the
+-- matching account (if any) plus whether it has a non-free payment and who,
+-- if anyone, already referred it — so the UI can preview the consequence
+-- before the admin commits. SECURITY DEFINER so it can read auth.users.
+
+create function public.admin_resolve_referee(p_email text)
+returns table (
+    referee_id                uuid,
+    username                  text,
+    has_paid                  boolean,
+    current_referrer_id       uuid,
+    current_referrer_username text
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+    v_email text := lower(nullif(trim(p_email), ''));
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if v_email is null then
+        return;
+    end if;
+
+    return query
+    select
+        p.id,
+        p.username::text,
+        exists (
+            select 1
+              from public.tournament_payments tp
+              join public.predictions pr on pr.id = tp.prediction_id
+             where pr.user_id = p.id and tp.is_free = false
+        ),
+        r.referrer_id,
+        rer.username::text
+      from auth.users u
+      join public.profiles p on p.id = u.id
+      left join public.referrals r on r.referee_id = p.id
+      left join public.profiles rer on rer.id = r.referrer_id
+     where lower(u.email) = v_email;
+end;
+$$;
+
+grant execute on function public.admin_resolve_referee(text) to authenticated;
+
+
+-- ========== RPC: admin_add_referral ==========
+-- Links an existing referee account to a referrer. Backfills qualified_at if
+-- the referee already paid (the trigger won't re-fire for past payments).
+
+create function public.admin_add_referral(
+    p_referrer_id uuid,
+    p_referee_email text,
+    p_note text
+)
+returns table (
+    referee_id uuid,
+    qualified  boolean
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_note     text := nullif(trim(p_note), '');
+    v_email    text := lower(nullif(trim(p_referee_email), ''));
+    v_referee  uuid;
+    v_paid_at  timestamptz;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if v_note is null then
+        raise exception 'note is required' using errcode = 'P0001';
+    end if;
+
+    if not exists (select 1 from public.profiles where id = p_referrer_id) then
+        raise exception 'referrer not found' using errcode = 'P0001';
+    end if;
+
+    select p.id into v_referee
+      from auth.users u
+      join public.profiles p on p.id = u.id
+     where lower(u.email) = v_email;
+
+    if v_referee is null then
+        raise exception 'referee account not found' using errcode = 'P0001';
+    end if;
+    if v_referee = p_referrer_id then
+        raise exception 'cannot refer self' using errcode = 'P0001';
+    end if;
+    if exists (select 1 from public.referrals where public.referrals.referee_id = v_referee) then
+        raise exception 'referee already referred' using errcode = 'P0001';
+    end if;
+
+    -- Backfill qualification from the earliest existing non-free payment.
+    select min(tp.paid_at) into v_paid_at
+      from public.tournament_payments tp
+      join public.predictions pr on pr.id = tp.prediction_id
+     where pr.user_id = v_referee and tp.is_free = false;
+
+    insert into public.referrals (referee_id, referrer_id, referrer_code_used, qualified_at)
+    values (v_referee, p_referrer_id, 'ADMIN', v_paid_at);
+
+    insert into public.referral_admin_audit
+        (actor_id, action, referrer_id, referee_id, referee_email, note)
+    values
+        (auth.uid(), 'add', p_referrer_id, v_referee, v_email, v_note);
+
+    referee_id := v_referee;
+    qualified  := v_paid_at is not null;
+    return next;
+end;
+$$;
+
+grant execute on function public.admin_add_referral(uuid, text, text) to authenticated;
+
+
+-- ========== RPC: admin_remove_referral ==========
+-- Unlinks a referee. Already-redeemed credits stay sticky: the greatest(0, …)
+-- clamp in get_referral_status absorbs the post-redeem clawback.
+
+create function public.admin_remove_referral(
+    p_referee_id uuid,
+    p_note text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_note     text := nullif(trim(p_note), '');
+    v_referrer uuid;
+    v_email    text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if v_note is null then
+        raise exception 'note is required' using errcode = 'P0001';
+    end if;
+
+    select r.referrer_id into v_referrer
+      from public.referrals r
+     where r.referee_id = p_referee_id;
+
+    if v_referrer is null then
+        raise exception 'referral not found' using errcode = 'P0001';
+    end if;
+
+    select lower(u.email) into v_email from auth.users u where u.id = p_referee_id;
+
+    delete from public.referrals where referee_id = p_referee_id;
+
+    insert into public.referral_admin_audit
+        (actor_id, action, referrer_id, referee_id, referee_email, note)
+    values
+        (auth.uid(), 'remove', v_referrer, p_referee_id, v_email, v_note);
+end;
+$$;
+
+grant execute on function public.admin_remove_referral(uuid, text) to authenticated;
+
+
+-- ========== RPC: admin_referral_overview ==========
+-- Admin-scoped twin of get_referral_status for an arbitrary user, plus a
+-- referee_count so the tool can render a summary band for any member.
+
+create function public.admin_referral_overview(p_user_id uuid)
+returns table (
+    referral_code     text,
+    qualified_total   int,
+    earned_credits    int,
+    redeemed_total    int,
+    available_credits int,
+    referee_count     int
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+    v_code      text;
+    v_qualified int;
+    v_redeemed  int;
+    v_earned    int;
+    v_count     int;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    select rc.code::text into v_code
+      from public.referral_codes rc
+     where rc.user_id = p_user_id;
+
+    select
+        coalesce(sum(case when r.qualified_at is not null then 1 else 0 end), 0)::int,
+        count(*)::int
+      into v_qualified, v_count
+      from public.referrals r
+     where r.referrer_id = p_user_id;
+
+    select count(*)::int into v_redeemed
+      from public.referral_redemptions rr
+     where rr.user_id = p_user_id;
+
+    v_earned := v_qualified / 4;
+
+    referral_code     := v_code;
+    qualified_total   := v_qualified;
+    earned_credits    := v_earned;
+    redeemed_total    := v_redeemed;
+    available_credits := greatest(0, v_earned - v_redeemed);
+    referee_count     := v_count;
+    return next;
+end;
+$$;
+
+grant execute on function public.admin_referral_overview(uuid) to authenticated;
+
+
+-- ========== RPC: admin_list_user_referrals (enriched) ==========
+-- Adds referee_email / referrer_email, a source marker (organic vs admin),
+-- and a has_paid flag for the referee. Return type changes, so drop first.
+
+drop function if exists public.admin_list_user_referrals(uuid);
+
+create function public.admin_list_user_referrals(p_user_id uuid)
+returns table (
+    direction          text,
+    referee_id         uuid,
+    referee_username   text,
+    referee_email      text,
+    referrer_id        uuid,
+    referrer_username  text,
+    referrer_email     text,
+    referrer_code_used text,
+    source             text,
+    has_paid           boolean,
+    created_at         timestamptz,
+    qualified_at       timestamptz
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    return query
+    select
+        case when r.referrer_id = p_user_id then 'outbound' else 'inbound' end::text,
+        r.referee_id,
+        ree.username::text,
+        ree_u.email::text,
+        r.referrer_id,
+        rer.username::text,
+        rer_u.email::text,
+        r.referrer_code_used,
+        case when r.referrer_code_used = 'ADMIN' then 'admin' else 'organic' end::text,
+        exists (
+            select 1
+              from public.tournament_payments tp
+              join public.predictions pr on pr.id = tp.prediction_id
+             where pr.user_id = r.referee_id and tp.is_free = false
+        ),
+        r.created_at,
+        r.qualified_at
+      from public.referrals r
+      join public.profiles ree on ree.id = r.referee_id
+      left join auth.users ree_u on ree_u.id = r.referee_id
+      join public.profiles rer on rer.id = r.referrer_id
+      left join auth.users rer_u on rer_u.id = r.referrer_id
+     where r.referrer_id = p_user_id or r.referee_id = p_user_id
+     order by r.created_at desc;
+end;
+$$;
+
+grant execute on function public.admin_list_user_referrals(uuid) to authenticated;
+
+
+-- ========== RPC: admin_list_referral_audit ==========
+
+create function public.admin_list_referral_audit(p_user_id uuid)
+returns table (
+    id                uuid,
+    actor_username    text,
+    action            text,
+    referrer_id       uuid,
+    referrer_username text,
+    referee_id        uuid,
+    referee_username  text,
+    referee_email     text,
+    note              text,
+    created_at        timestamptz
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    return query
+    select
+        a.id,
+        actor.username::text,
+        a.action,
+        a.referrer_id,
+        rer.username::text,
+        a.referee_id,
+        ree.username::text,
+        a.referee_email,
+        a.note,
+        a.created_at
+      from public.referral_admin_audit a
+      left join public.profiles actor on actor.id = a.actor_id
+      left join public.profiles rer on rer.id = a.referrer_id
+      left join public.profiles ree on ree.id = a.referee_id
+     where a.referrer_id = p_user_id or a.referee_id = p_user_id
+     order by a.created_at desc;
+end;
+$$;
+
+grant execute on function public.admin_list_referral_audit(uuid) to authenticated;


### PR DESCRIPTION
## Release v1.0.6

Bundles two feature PRs for release, with changelog + version bump.

### Included
- **#194** — Admin Referrals tab: retroactive referral crediting (link/unlink referees, derived rewards, audit trail, `0059_admin_referrals.sql`).
- **#195** — Unpaid-prediction payment prompts on `/predictions` + `/leaderboard` (shared red notice, tinted rows, leaderboard "not ranked yet" table; includes Phase 1 saved drafts).

### Release mechanics
- `CHANGELOG.md`: new `## [1.0.6]` section.
- `frontend/package.json`: `1.0.5` → `1.0.6`.

### Verification (on the merged release tree)
- `npm run typecheck` ✅ · `npm run lint` ✅ (pre-existing warnings only) · `npm test` ✅ **459/459**.

Merging this closes #194 and #195 (their commits land on `main` via this branch).