### PR TITLE
fix(payments): drop misleading mailto button from unpaid notice

### DIFF
--- a/frontend/src/components/predictions/UnpaidPaymentNotice.tsx
+++ b/frontend/src/components/predictions/UnpaidPaymentNotice.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { AlertTriangle, Mail } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import { PAYMENTS_EMAIL, PRICING } from '@/lib/constants';
@@ -15,6 +15,10 @@ import { PAYMENTS_EMAIL, PRICING } from '@/lib/constants';
  * Intentionally NOT dismissible: an unmet payment obligation shouldn't be
  * silenceable. It returns `null` once `unpaidCount` hits 0, so it disappears on
  * its own when an admin marks the entries paid.
+ *
+ * Payment is an Interac e-transfer sent from the user's own bank — NOT an email
+ * — so the address is shown as plain text (no `mailto:`), with a short
+ * how-to-pay instruction instead of a misleading "email" button.
  *
  * Presentational only — the caller computes the count of submitted-but-unpaid
  * predictions and passes the registered account email.
@@ -31,13 +35,6 @@ export function UnpaidPaymentNotice({
   const plural = unpaidCount === 1 ? 'prediction' : 'predictions';
   const totalDue = unpaidCount * PRICING.entryFeeCAD;
   const emailLabel = email ?? 'your registered email';
-
-  const mailtoSubject = encodeURIComponent(
-    `World Cup 2026 pool payment${email ? ` — ${email}` : ''}`
-  );
-  const mailtoBody = encodeURIComponent(
-    `Hi,\n\nI'm sending an Interac e-transfer for ${unpaidCount} ${plural} ($${totalDue} ${PRICING.currency} total).\n\nRegistered account email: ${email ?? '(add your account email)'}\n`
-  );
 
   return (
     <Card
@@ -61,23 +58,18 @@ export function UnpaidPaymentNotice({
               ${totalDue} {PRICING.currency}
             </span>
             ). Send an <span className="font-semibold">Interac e-transfer</span> to{' '}
-            <a
-              href={`mailto:${PAYMENTS_EMAIL}?subject=${mailtoSubject}&body=${mailtoBody}`}
-              className="font-medium underline underline-offset-2"
-            >
-              {PAYMENTS_EMAIL}
-            </a>{' '}
-            and <span className="font-semibold">include your registered email</span> (
+            <span className="font-semibold break-all">{PAYMENTS_EMAIL}</span> and{' '}
+            <span className="font-semibold">include your registered email</span> (
             <span className="font-medium break-all">{emailLabel}</span>) in the
             transfer message so we can match it to your account.
           </p>
-          <a
-            href={`mailto:${PAYMENTS_EMAIL}?subject=${mailtoSubject}&body=${mailtoBody}`}
-            className="inline-flex items-center gap-1.5 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-900 transition hover:bg-red-500/20 dark:text-red-200"
-          >
-            <Mail className="h-4 w-4" aria-hidden />
-            Email payment to {PAYMENTS_EMAIL}
-          </a>
+          <p className="text-sm">
+            <span className="font-semibold">How to pay:</span> log in to your online
+            banking or banking app, choose <span className="font-medium">Interac
+            e-Transfer</span>, and send to{' '}
+            <span className="font-semibold break-all">{PAYMENTS_EMAIL}</span>. This
+            isn&apos;t an email — the transfer is sent through your bank.
+          </p>
         </div>
       </CardContent>
     </Card>

--- a/frontend/src/components/predictions/__tests__/UnpaidPaymentNotice.test.tsx
+++ b/frontend/src/components/predictions/__tests__/UnpaidPaymentNotice.test.tsx
@@ -28,14 +28,21 @@ describe('UnpaidPaymentNotice', () => {
     expect(screen.getByText(/1 unpaid prediction(?!s)/i)).toBeInTheDocument();
   });
 
-  it('links to the payments email and falls back when email is null', () => {
-    render(<UnpaidPaymentNotice unpaidCount={1} email={null} />);
+  it('shows the payments address as plain text with no mailto link', () => {
+    render(<UnpaidPaymentNotice unpaidCount={1} email="player@example.com" />);
 
-    const links = screen
-      .getAllByRole('link')
-      .filter((a) => a.getAttribute('href')?.startsWith(`mailto:${PAYMENTS_EMAIL}`));
-    expect(links.length).toBeGreaterThan(0);
-    // The (<email>) label falls back to this phrase when no email is supplied.
+    // Interac e-transfers go through the user's bank — there must be no
+    // mailto link / "email" button suggesting otherwise.
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByText(/email payment to/i)).not.toBeInTheDocument();
+    // The address is still shown (twice: body + how-to-pay instruction).
+    expect(screen.getAllByText(PAYMENTS_EMAIL).length).toBeGreaterThan(0);
+    expect(screen.getByText(/how to pay/i)).toBeInTheDocument();
+    expect(screen.getByText(/through your bank/i)).toBeInTheDocument();
+  });
+
+  it('falls back to a generic email label when none is supplied', () => {
+    render(<UnpaidPaymentNotice unpaidCount={1} email={null} />);
     expect(screen.getAllByText(/your registered email/i).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Problem

The shared `UnpaidPaymentNotice` (on `/predictions` and `/leaderboard`) had an "Email payment to payments@soccer-pool.com" button and a `mailto:` link on the address. An **Interac e-transfer goes through the user's bank**, not an email client, so this was misleading.

## Fix

- Remove the button and all `mailto:` links.
- Show the payments address as plain, selectable text.
- Add a short **"How to pay"** instruction: log in to online banking / banking app → choose Interac e-Transfer → send to the address; clarifies it isn't an email.

Shared module, so both pages update together.

## Verification
- `npm run typecheck` ✅ · `npm run lint` ✅ (pre-existing warnings only) · `UnpaidPaymentNotice` tests ✅ (5/5; updated to assert no `mailto`/link and presence of the how-to-pay instruction).