### PR TITLE
release: v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2026-06-02
+
+### Fixed
+
+- Unpaid-prediction notice (`/predictions` + `/leaderboard`): removed the "Email payment
+  to …" button and the `mailto:` links on the payments address — an Interac e-transfer is
+  sent through the user's bank, not by email, so the button was misleading. The address is
+  now plain selectable text, with a short "How to pay" instruction (online banking →
+  Interac e-Transfer → send to the address). (#197)
+
 ## [1.0.6] - 2026-06-02
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v1.0.7 (hotfix)

Patch release for the unpaid-prediction notice fix.

### Included
- **#197** — Removed the misleading "Email payment to …" button / `mailto:` links from the shared unpaid-prediction notice (`/predictions` + `/leaderboard`); Interac e-transfers go through the user's bank, not email. Address is now plain text with a "How to pay" instruction.

### Release mechanics
- `CHANGELOG.md`: new `## [1.0.7]` section.
- `frontend/package.json`: `1.0.6` → `1.0.7`.

The #197 change already landed on `main`; this branch carries the changelog + version bump.