### PR TITLE
fix(payments): emphasize registered email required in Interac message

### DIFF
--- a/frontend/src/components/predictions/UnpaidPaymentNotice.tsx
+++ b/frontend/src/components/predictions/UnpaidPaymentNotice.tsx
@@ -58,10 +58,14 @@ export function UnpaidPaymentNotice({
               ${totalDue} {PRICING.currency}
             </span>
             ). Send an <span className="font-semibold">Interac e-transfer</span> to{' '}
-            <span className="font-semibold break-all">{PAYMENTS_EMAIL}</span> and{' '}
-            <span className="font-semibold">include your registered email</span> (
-            <span className="font-medium break-all">{emailLabel}</span>) in the
-            transfer message so we can match it to your account.
+            <span className="font-semibold break-all">{PAYMENTS_EMAIL}</span>. You{' '}
+            <span className="font-semibold uppercase">must</span> put your registered
+            email{' '}
+            <span className="inline-flex items-center rounded bg-red-600 px-1.5 py-0.5 font-mono text-xs font-semibold break-all text-white dark:bg-red-500">
+              {emailLabel}
+            </span>{' '}
+            in the Interac message so we can match the payment to your account —
+            without it your entries can&apos;t be credited.
           </p>
           <p className="text-sm">
             <span className="font-semibold">How to pay:</span> log in to your online

--- a/frontend/src/components/predictions/__tests__/UnpaidPaymentNotice.test.tsx
+++ b/frontend/src/components/predictions/__tests__/UnpaidPaymentNotice.test.tsx
@@ -23,6 +23,16 @@ describe('UnpaidPaymentNotice', () => {
     ).toBeInTheDocument();
   });
 
+  it('emphasizes that the registered email MUST be in the Interac message', () => {
+    render(<UnpaidPaymentNotice unpaidCount={1} email="player@example.com" />);
+
+    expect(screen.getByText(/must/i)).toBeInTheDocument();
+    // The email renders as its own (chip) element, not just inline prose.
+    const chip = screen.getByText('player@example.com');
+    expect(chip.tagName).toBe('SPAN');
+    expect(chip.className).toMatch(/bg-red-600/);
+  });
+
   it('uses singular copy for a single unpaid prediction', () => {
     render(<UnpaidPaymentNotice unpaidCount={1} email="player@example.com" />);
     expect(screen.getByText(/1 unpaid prediction(?!s)/i)).toBeInTheDocument();


### PR DESCRIPTION
## Problem

In the unpaid-prediction notice, the **registered email** the user must put in the Interac e-transfer message was plain inline text — easy to miss. If it's omitted, payments can't be matched to an account.

## Fix

- Render the registered email as a high-contrast **red chip** (monospace) so it stands out.
- Strengthen the copy: "You **MUST** put your registered email … in the Interac message … without it your entries can't be credited."

Shared module → both `/predictions` and `/leaderboard` update.

## Verification
- `npm run typecheck` ✅ · `npm run lint` ✅ (pre-existing warnings only) · `UnpaidPaymentNotice` tests ✅ 6/6 (new test asserts the MUST copy + chip element).