### PR TITLE
release: v1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] - 2026-06-02
+
+### Fixed
+
+- Unpaid-prediction notice (`/predictions` + `/leaderboard`): the registered email the user
+  must include in the Interac e-transfer message now renders as a high-contrast red chip and
+  the copy is strengthened to "You MUST put your registered email … in the Interac message …
+  without it your entries can't be credited." Previously it was easy-to-miss inline text. (#199)
+
 ## [1.0.7] - 2026-06-02
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v1.0.8 (hotfix)

Patch release emphasizing the required registered email in the unpaid-prediction notice.

### Included
- **#199** — Registered email now renders as a high-contrast red chip with strengthened "MUST include" copy in the Interac e-transfer message (`/predictions` + `/leaderboard`).

### Release mechanics
- `CHANGELOG.md`: new `## [1.0.8]` section.
- `frontend/package.json`: `1.0.7` → `1.0.8`.

The #199 change already landed on `main`; this branch carries the changelog + version bump.