### PR TITLE
release: v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2026-06-02
+
+### Added
+
+- Unpaid-prediction notice (`/predictions` + `/leaderboard`): the official Interac logo now
+  appears inline next to the word "Interac" in the e-transfer instructions. (#201)
+
 ## [1.0.8] - 2026-06-02
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v1.0.9

### Included
- **#201** — Official Interac logo shown inline beside the word "Interac" in the unpaid-prediction notice (`/predictions` + `/leaderboard`).

### Release mechanics
- `CHANGELOG.md`: new `## [1.0.9]` section.
- `frontend/package.json`: `1.0.8` → `1.0.9`.

The #201 change already landed on `main`; this branch carries the changelog + version bump.