### PR TITLE
fix(payments): Interac logo to 20px and decorative alt

### DIFF
--- a/frontend/src/components/predictions/UnpaidPaymentNotice.tsx
+++ b/frontend/src/components/predictions/UnpaidPaymentNotice.tsx
@@ -63,10 +63,11 @@ export function UnpaidPaymentNotice({
               Interac
               <Image
                 src="/interac-logo.png"
-                alt="Interac"
-                width={50}
-                height={50}
-                className="inline-block h-auto w-[50px] align-middle"
+                alt=""
+                aria-hidden
+                width={20}
+                height={20}
+                className="inline-block h-auto w-[20px] align-middle"
               />
             </span>{' '}
             e-transfer to{' '}

--- a/frontend/src/components/predictions/__tests__/UnpaidPaymentNotice.test.tsx
+++ b/frontend/src/components/predictions/__tests__/UnpaidPaymentNotice.test.tsx
@@ -33,11 +33,16 @@ describe('UnpaidPaymentNotice', () => {
     expect(chip.className).toMatch(/bg-red-600/);
   });
 
-  it('renders the Interac logo next to the word Interac', () => {
-    render(<UnpaidPaymentNotice unpaidCount={1} email="player@example.com" />);
-    const logo = screen.getByAltText('Interac');
+  it('renders the Interac logo as a decorative image', () => {
+    const { container } = render(
+      <UnpaidPaymentNotice unpaidCount={1} email="player@example.com" />
+    );
+    const logo = container.querySelector('img[src="/interac-logo.png"]');
     expect(logo).toBeInTheDocument();
-    expect(logo).toHaveAttribute('src', '/interac-logo.png');
+    // Decorative: empty alt + aria-hidden so the adjacent word "Interac" isn't
+    // announced twice by screen readers.
+    expect(logo).toHaveAttribute('alt', '');
+    expect(logo).toHaveAttribute('aria-hidden');
   });
 
   it('uses singular copy for a single unpaid prediction', () => {


### PR DESCRIPTION
## Change

Follow-up tweaks to the inline Interac logo in the unpaid-prediction notice:

- Size reduced from 50px → **20px** (better balance with the body text).
- Marked **decorative** (`alt=""` + `aria-hidden`) so screen readers don't announce "Interac" twice (the visible word sits right beside it).

## Verification
- `npm run typecheck` ✅ · `npm run lint` ✅ (pre-existing warnings only) · `UnpaidPaymentNotice` tests ✅ 7/7 (updated to assert the decorative image).