### PR TITLE
release: v1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.10] - 2026-06-02
+
+### Changed
+
+- Unpaid-prediction notice: the inline Interac logo is reduced to 20px and marked decorative
+  (`alt=""` + `aria-hidden`) so screen readers don't announce "Interac" twice. (#203)
+
 ## [1.0.9] - 2026-06-02
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Release v1.0.10

### Included
- **#203** — Inline Interac logo reduced to 20px and marked decorative (`alt=""` + `aria-hidden`).

### Release mechanics
- `CHANGELOG.md`: new `## [1.0.10]` section.
- `frontend/package.json`: `1.0.9` → `1.0.10`.

The #203 change already landed on `main`; this branch carries the changelog + version bump.