### PR TITLE
feat(admin): search user list by prediction name

### DIFF
--- a/frontend/src/app/admin/users/AdminUsersList.tsx
+++ b/frontend/src/app/admin/users/AdminUsersList.tsx
@@ -124,7 +124,7 @@ export function AdminUsersList() {
         <CardContent className="space-y-4 p-4">
           <div className="flex items-center justify-between gap-2">
             <Input
-              placeholder="Search username…"
+              placeholder="Search username, email, or prediction name…"
               value={search}
               onChange={(e) => {
                 setSearch(e.target.value);

--- a/supabase/migrations/0061_admin_list_users_prediction_name_search.sql
+++ b/supabase/migrations/0061_admin_list_users_prediction_name_search.sql
@@ -1,0 +1,122 @@
+-- Migration 0061: let admin_list_users match by prediction name
+--
+-- Payments sometimes arrive without an email/username identifier; in at least
+-- one case a customer used their prediction name as the reference instead.
+-- This extends the admin user search so typing a prediction name surfaces the
+-- owning user, exactly like a username/email hit. The admin then opens
+-- "Manage predictions" for that user and marks the right prediction paid.
+--
+-- Scope: prediction names are matched within the ACTIVE tournament only,
+-- consistent with how the per-user prediction counts here are already scoped.
+-- A user with multiple matching predictions still appears once (the EXISTS is
+-- boolean per user), so pagination/count semantics are unchanged.
+--
+-- Body is otherwise identical to 0040; only the filtered-CTE WHERE clause
+-- gains the prediction-name branch.
+
+create or replace function public.admin_list_users(
+    p_search text,
+    p_page int,
+    p_page_size int
+)
+returns table (
+    id uuid,
+    username text,
+    email text,
+    is_admin boolean,
+    is_super_admin boolean,
+    prediction_count int,
+    paid_prediction_count int,
+    total_rewards int,
+    total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid;
+    v_offset int;
+    v_limit int;
+    v_search text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    v_limit := greatest(1, least(coalesce(p_page_size, 25), 100));
+    v_offset := greatest(0, (coalesce(p_page, 1) - 1) * v_limit);
+    v_search := nullif(trim(coalesce(p_search, '')), '');
+
+    select t.id into v_tournament_id from public.tournaments t where t.is_active limit 1;
+
+    return query
+    with filtered as (
+        select
+            p.id,
+            p.username::text as username,
+            u.email::text as email,
+            p.is_admin,
+            p.is_super_admin,
+            coalesce(counts.prediction_count, 0)::int as prediction_count,
+            coalesce(counts.paid_prediction_count, 0)::int as paid_prediction_count,
+            (
+                coalesce(ref.qualified_count, 0) / 4
+                + coalesce(counts.cash_paid_count, 0) / 5
+            )::int as total_rewards
+        from public.profiles p
+        left join auth.users u on u.id = p.id
+        left join lateral (
+            select
+                count(*) as prediction_count,
+                count(*) filter (
+                    where exists (
+                        select 1 from public.tournament_payments tp
+                        where tp.prediction_id = pr.id
+                    )
+                ) as paid_prediction_count,
+                count(*) filter (
+                    where exists (
+                        select 1 from public.tournament_payments tp
+                        where tp.prediction_id = pr.id and tp.is_free = false
+                    )
+                ) as cash_paid_count
+            from public.predictions pr
+            where pr.user_id = p.id and pr.tournament_id = v_tournament_id
+        ) counts on true
+        left join lateral (
+            select count(*) as qualified_count
+            from public.referrals r
+            where r.referrer_id = p.id and r.qualified_at is not null
+        ) ref on true
+        where v_search is null
+           or p.username::text ilike '%' || v_search || '%'
+           or u.email::text ilike '%' || v_search || '%'
+           or exists (
+               select 1 from public.predictions pr
+               where pr.user_id = p.id
+                 and pr.tournament_id = v_tournament_id
+                 and pr.prediction_name::text ilike '%' || v_search || '%'
+           )
+    ),
+    counted as (
+        select count(*) as total from filtered
+    )
+    select
+        f.id,
+        f.username,
+        f.email,
+        f.is_admin,
+        f.is_super_admin,
+        f.prediction_count,
+        f.paid_prediction_count,
+        f.total_rewards,
+        c.total
+    from filtered f
+    cross join counted c
+    order by f.username asc
+    limit v_limit offset v_offset;
+end;
+$$;
+
+grant execute on function public.admin_list_users(text, int, int) to authenticated;


### PR DESCRIPTION
## Context

Some payments arrive without an email/username identifier in the message, making them hard to link to an account. In at least one case a customer used their **prediction name** as the reference. The admin user search (\`/admin/users\`) previously only matched username and email, so a prediction-name reference couldn't be looked up.

## Change

- **\`0061_admin_list_users_prediction_name_search.sql\`** — \`create or replace\` of \`admin_list_users\` adding a third \`or\` branch to the filtered-CTE \`WHERE\`: an \`EXISTS\` against \`predictions.prediction_name\` (ILIKE), scoped to the **active tournament**. Body is otherwise identical to \`0040\`. A user with multiple matching predictions still appears once, so pagination/count semantics are unchanged.
- **\`AdminUsersList.tsx\`** — search placeholder now reads "Search username, email, or prediction name…".

The API route already forwards \`search\` straight into \`p_search\` and the return shape is unchanged, so no route/type/test changes were needed.

## Behavior

Typing a prediction name surfaces the **owning user** in the list, exactly like a username/email hit. The admin then opens "Manage predictions" and marks the right prediction paid.

## Verification

- \`npm test\` → 472 passed, \`npm run typecheck\` clean, \`npm run lint\` (only pre-existing warnings, untouched files).
- Migration not yet applied to a live DB — apply via \`supabase db reset\`/\`migration up\` and confirm prediction-name search surfaces the owning user, while non-active-tournament names don't match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)