### PR TITLE
feat(leaderboard): gate leaderboard behind login

### DIFF
--- a/frontend/src/__tests__/middleware.test.ts
+++ b/frontend/src/__tests__/middleware.test.ts
@@ -41,8 +41,17 @@ describe('middleware', () => {
 
   it('passes through public routes even when signed out', async () => {
     getUserMock.mockResolvedValue({ data: { user: null } });
-    const res = await middleware(makeRequest('/leaderboard'));
+    const res = await middleware(makeRequest('/rules'));
     expect(res.status).toBe(200);
+  });
+
+  it('redirects unauthenticated users from /leaderboard to /login', async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+    const res = await middleware(makeRequest('/leaderboard'));
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location')!;
+    expect(location).toContain('/login');
+    expect(location).toContain('next=%2Fleaderboard');
   });
 
   it('redirects unauthenticated users from /admin to /login', async () => {

--- a/frontend/src/app/api/leaderboard/__tests__/route.test.ts
+++ b/frontend/src/app/api/leaderboard/__tests__/route.test.ts
@@ -41,8 +41,15 @@ describe('GET /api/leaderboard', () => {
     supabaseMock.from.mockReset();
     supabaseMock.rpc.mockReset();
     supabaseMock.auth.getUser.mockReset();
-    // Default: anonymous caller
+    // Default: authenticated non-admin caller (the leaderboard is login-gated).
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
     supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(req('?page=1&pageSize=25'));
+    expect(res.status).toBe(401);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
   });
 
   it('returns empty list when no active tournament', async () => {
@@ -54,8 +61,13 @@ describe('GET /api/leaderboard', () => {
     expect(await res.json()).toEqual({ entries: [], total: 0, page: 1, pageSize: 25 });
   });
 
-  it('shapes the RPC result into paginated entries (anon caller, no email)', async () => {
-    supabaseMock.from.mockImplementation(mockTournamentLookup);
+  it('shapes the RPC result into paginated entries (non-admin, no email)', async () => {
+    let callIdx = 0;
+    supabaseMock.from.mockImplementation(() => {
+      const handler = callIdx === 0 ? mockTournamentLookup() : mockProfileLookup(false);
+      callIdx += 1;
+      return handler;
+    });
     supabaseMock.rpc.mockResolvedValue({
       data: [
         {

--- a/frontend/src/app/api/leaderboard/route.ts
+++ b/frontend/src/app/api/leaderboard/route.ts
@@ -8,6 +8,13 @@ export async function GET(request: NextRequest) {
 
   const supabase = await getServerSupabase();
 
+  // The leaderboard is gated to signed-in users (middleware protects the page;
+  // this guards the API directly since the prefix check doesn't cover /api/*).
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
   const { data: tournament } = await supabase
     .from('tournaments')
     .select('id')
@@ -23,16 +30,12 @@ export async function GET(request: NextRequest) {
   // We check is_admin via profiles since the user's session is already
   // attached to the cookie client; admin_get_leaderboard double-checks
   // is_admin() at the DB level so the API can't be tricked.
-  const { data: authData } = await supabase.auth.getUser();
-  let isAdmin = false;
-  if (authData.user) {
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('is_admin')
-      .eq('id', authData.user.id)
-      .maybeSingle();
-    isAdmin = profile?.is_admin === true;
-  }
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .maybeSingle();
+  const isAdmin = profile?.is_admin === true;
 
   const rpcName = isAdmin ? 'admin_get_leaderboard' : 'get_leaderboard';
   const { data, error } = await supabase.rpc(rpcName, {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,6 +4,7 @@ import { env } from '@/config/env';
 
 const PROTECTED_PREFIXES = [
   '/predictions',
+  '/leaderboard',
   '/admin',
   '/account',
   '/referrals',


### PR DESCRIPTION
## Summary
Makes the leaderboard available only to registered, logged-in users (previously public). This matches how `/predictions`, `/results`, etc. are already protected.

## Changes
- **`src/middleware.ts`** — added `/leaderboard` to `PROTECTED_PREFIXES`; logged-out users hitting the page are redirected to `/login?next=%2Fleaderboard`.
- **`src/app/api/leaderboard/route.ts`** — returns `401 Unauthorized` when unauthenticated (defense-in-depth, since the middleware prefix check doesn't cover `/api/*`). Reuses the already-fetched `user` for the admin lookup, dropping a redundant second `getUser()` call.
- **Tests** — `middleware.test.ts`: repointed the public-route test to `/rules`, added a `/leaderboard` → 307 redirect test. `api/leaderboard/route.test.ts`: default caller is now an authenticated non-admin, plus an explicit anon → 401 test (asserts the RPC is never called).

## Notes
- Nav link stays visible to logged-out users (matches the existing `Predictions` link; clicking redirects to login).
- The page's logged-out fallback UI is now unreachable but left in place as harmless dead code.
- No DB / RLS / RPC changes.

## Verification
- `npm test` — 474 passing
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (only pre-existing warnings)