### PR TITLE
feat(admin): read-only predictions list

### DIFF
--- a/frontend/src/app/admin/predictions/AdminPredictionsList.tsx
+++ b/frontend/src/app/admin/predictions/AdminPredictionsList.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { AdminNav } from '@/components/admin/AdminNav';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface AdminPrediction {
+  id: string;
+  userId: string;
+  username: string;
+  email: string | null;
+  predictionName: string | null;
+  submittedAt: string | null;
+  updatedAt: string;
+}
+
+interface PredictionsResponse {
+  predictions: AdminPrediction[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+const PAGE_SIZE = 25;
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString();
+}
+
+export function AdminPredictionsList() {
+  const [search, setSearch] = React.useState('');
+  const [debounced, setDebounced] = React.useState('');
+  const [page, setPage] = React.useState(1);
+
+  React.useEffect(() => {
+    const t = setTimeout(() => setDebounced(search), 250);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const query = useQuery<PredictionsResponse>({
+    queryKey: ['admin-predictions', debounced, page],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/admin/predictions?search=${encodeURIComponent(debounced)}&page=${page}&pageSize=${PAGE_SIZE}`
+      );
+      if (!res.ok) throw new Error('Failed to load predictions');
+      return res.json();
+    },
+  });
+
+  const totalPages = Math.max(1, Math.ceil((query.data?.total ?? 0) / PAGE_SIZE));
+
+  return (
+    <PageLayout>
+      <h1 className="mb-2 text-3xl font-bold">Admin</h1>
+      <AdminNav />
+
+      <Card>
+        <CardContent className="space-y-4 p-4">
+          <Input
+            placeholder="Search email, username, or prediction name…"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
+            className="max-w-sm"
+          />
+
+          {query.isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead>Prediction</TableHead>
+                  <TableHead>Saved</TableHead>
+                  <TableHead>Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(query.data?.predictions ?? []).map((p) => (
+                  <TableRow key={p.id}>
+                    <TableCell>
+                      <div className="text-sm font-medium">{p.email ?? '—'}</div>
+                      <div className="text-muted-foreground text-xs">{p.username}</div>
+                    </TableCell>
+                    <TableCell className="text-sm">{p.predictionName ?? '—'}</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatDateTime(p.submittedAt)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatDateTime(p.updatedAt)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {(query.data?.predictions ?? []).length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-muted-foreground py-8 text-center">
+                      No predictions found
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between pt-2">
+              <p className="text-muted-foreground text-sm">
+                Page {page} of {totalPages} · {query.data?.total ?? 0} predictions
+              </p>
+              <div className="space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/admin/predictions/page.tsx
+++ b/frontend/src/app/admin/predictions/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { AdminPredictionsList } from './AdminPredictionsList';
+
+export const metadata: Metadata = {
+  title: 'Predictions | Admin',
+};
+
+export default function AdminPredictionsPage() {
+  return <AdminPredictionsList />;
+}

--- a/frontend/src/app/api/admin/predictions/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/predictions/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route');
+
+function req(qs = '') {
+  return new NextRequest(`http://localhost:3000/api/admin/predictions${qs}`);
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('GET /api/admin/predictions', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await GET(req());
+    expect(res.status).toBe(403);
+  });
+
+  it('shapes admin_list_predictions into paginated response', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: [
+        {
+          id: 'p1',
+          user_id: 'a',
+          username: 'alice',
+          email: 'alice@example.com',
+          prediction_name: 'My Bracket',
+          submitted_at: '2026-06-05T10:00:00Z',
+          updated_at: '2026-06-06T12:00:00Z',
+          total_count: 2,
+        },
+        {
+          id: 'p2',
+          user_id: 'b',
+          username: 'bob',
+          email: null,
+          prediction_name: null,
+          submitted_at: null,
+          updated_at: '2026-06-04T09:00:00Z',
+          total_count: 2,
+        },
+      ],
+      error: null,
+    });
+    const res = await GET(req('?page=1&pageSize=25'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(2);
+    expect(body.page).toBe(1);
+    expect(body.pageSize).toBe(25);
+    expect(body.predictions).toHaveLength(2);
+    expect(body.predictions[0]).toMatchObject({
+      id: 'p1',
+      userId: 'a',
+      username: 'alice',
+      email: 'alice@example.com',
+      predictionName: 'My Bracket',
+      submittedAt: '2026-06-05T10:00:00Z',
+      updatedAt: '2026-06-06T12:00:00Z',
+    });
+    expect(body.predictions[1]).toMatchObject({
+      userId: 'b',
+      email: null,
+      predictionName: null,
+      submittedAt: null,
+    });
+  });
+});

--- a/frontend/src/app/api/admin/predictions/route.ts
+++ b/frontend/src/app/api/admin/predictions/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+export async function GET(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const { searchParams } = new URL(request.url);
+  const search = searchParams.get('search') ?? '';
+  const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get('pageSize') ?? '25', 10)));
+
+  const { data, error } = await ctx.supabase.rpc('admin_list_predictions', {
+    p_search: search,
+    p_page: page,
+    p_page_size: pageSize,
+  });
+  if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 500 });
+
+  const rows = (data ?? []) as Array<{
+    id: string;
+    user_id: string;
+    username: string;
+    email: string | null;
+    prediction_name: string | null;
+    submitted_at: string | null;
+    updated_at: string;
+    total_count: number;
+  }>;
+
+  return NextResponse.json({
+    predictions: rows.map((r) => ({
+      id: r.id,
+      userId: r.user_id,
+      username: r.username,
+      email: r.email ?? null,
+      predictionName: r.prediction_name,
+      submittedAt: r.submitted_at,
+      updatedAt: r.updated_at,
+    })),
+    total: Number(rows[0]?.total_count ?? 0),
+    page,
+    pageSize,
+  });
+}

--- a/frontend/src/components/admin/AdminNav.tsx
+++ b/frontend/src/components/admin/AdminNav.tsx
@@ -8,6 +8,7 @@ const links = [
   { label: 'Dashboard', href: '/admin' },
   { label: 'Results', href: '/admin/results' },
   { label: 'Users', href: '/admin/users' },
+  { label: 'Predictions', href: '/admin/predictions' },
   { label: 'Referrals', href: '/admin/referrals' },
   { label: 'Tournament', href: '/admin/tournament' },
 ];

--- a/supabase/migrations/0062_admin_list_predictions.sql
+++ b/supabase/migrations/0062_admin_list_predictions.sql
@@ -1,0 +1,69 @@
+-- Admin-facing, tournament-wide list of every prediction (drafts + submitted)
+-- for the active tournament, ordered by most recently updated. Read-only.
+-- Mirrors admin_list_users (0061): SECURITY DEFINER + is_admin() gate +
+-- paginated with an embedded total_count. saved_date is sourced from
+-- submitted_at (null for unsubmitted drafts).
+
+create or replace function public.admin_list_predictions(
+    p_search text,
+    p_page int,
+    p_page_size int
+)
+returns table (
+    id uuid,
+    user_id uuid,
+    username text,
+    email text,
+    prediction_name text,
+    submitted_at timestamptz,
+    updated_at timestamptz,
+    total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid;
+    v_offset int;
+    v_limit int;
+    v_search text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    v_limit := greatest(1, least(coalesce(p_page_size, 25), 100));
+    v_offset := greatest(0, (coalesce(p_page, 1) - 1) * v_limit);
+    v_search := nullif(trim(coalesce(p_search, '')), '');
+
+    select t.id into v_tournament_id from public.tournaments t where t.is_active limit 1;
+
+    return query
+    with filtered as (
+        select
+            pr.id,
+            pr.user_id,
+            p.username::text as username,
+            u.email::text as email,
+            pr.prediction_name::text as prediction_name,
+            pr.submitted_at,
+            pr.updated_at
+        from public.predictions pr
+        left join public.profiles p on p.id = pr.user_id
+        left join auth.users u on u.id = pr.user_id
+        where pr.tournament_id = v_tournament_id
+          and (v_search is null
+               or p.username::text ilike '%' || v_search || '%'
+               or u.email::text ilike '%' || v_search || '%'
+               or pr.prediction_name::text ilike '%' || v_search || '%')
+    ),
+    counted as (select count(*) as total from filtered)
+    select f.*, c.total
+    from filtered f cross join counted c
+    order by f.updated_at desc
+    limit v_limit offset v_offset;
+end;
+$$;
+
+grant execute on function public.admin_list_predictions(text, int, int) to authenticated;


### PR DESCRIPTION
## Summary

Adds a tournament-wide, **read-only** `/admin/predictions` page so admins can see all participants' predictions in one feed instead of drilling into each user. Ordered by most recently updated.

Columns: **User** (email + username) · **Prediction** name · **Saved** (`submitted_at`) · **Updated** (`updated_at`). Includes debounced search (email / username / prediction name) and pagination, mirroring `/admin/users`.

## Decisions
- `saved_date` → `predictions.submitted_at` (shows "—" for unsubmitted drafts). No `created_at` column exists on `predictions`, so no schema change to that table.
- Includes **all** predictions (drafts + submitted), scoped to the active tournament.

## Changes
- **`0062_admin_list_predictions.sql`** — new SECURITY DEFINER, `is_admin()`-gated RPC, paginated with embedded `total_count`, `order by updated_at desc`. Mirrors `admin_list_users` (0061).
- **`GET /api/admin/predictions`** — `requireAdmin()` gate, maps RPC rows to camelCase.
- **`/admin/predictions` page + `AdminPredictionsList`** — read-only table (no mutations/dialogs).
- **`AdminNav`** — new "Predictions" link.
- **Route test** — 401 / 403 / 200-shaping.

## Verification
- `npm test` (477 passed), `npm run typecheck` (clean), `npm run lint` (only pre-existing warnings).
- Migration applies locally via `supabase db reset` / `supabase migration up`. Not run against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)