### PR TITLE
docs: adopt strict semver + backfill 1.0.12 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Admin predictions list (`/admin/predictions`): a new read-only, tournament-wide table of every
+  prediction (drafts + submitted) for the active tournament, ordered by most recently updated, with
+  columns for user (email + username), prediction name, saved/submitted, and updated. Includes
+  debounced search across email / username / prediction name and pagination, mirroring `/admin/users`.
+  Backed by the `admin_list_predictions` RPC (migration `0062`; SECURITY DEFINER + `is_admin()` gate)
+  and `GET /api/admin/predictions`. (`099a7b9`)
 - Admin user search (`/admin/users`): the search box now also matches **prediction name**, scoped to
   the active tournament, so payments referenced by a prediction name (rather than username/email) can
   be linked to the owning account. Migration `0061` adds an `EXISTS` branch to `admin_list_users`;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
-> **Version:** 3.7.1
-> **Last Updated:** 2026-05-30
+> **Version:** 3.8.0
+> **Last Updated:** 2026-06-09
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -209,6 +209,23 @@ All by client IP. The first three protect against email enumeration / mailbox fl
 - Do not include "Co-Authored-By" lines in commit messages.
 - **Never push directly to `main`.** All changes — including small follow-up fixes — must land on a feature branch and go through a pull request. Even one-line fixes during a session: branch, commit, push, open PR.
 
+
+## Versioning & Releases
+
+This project follows [Semantic Versioning](https://semver.org/) **strictly** — the CHANGELOG header is not aspirational. The version in `frontend/package.json` must match the git tag and GitHub release, and the bump is derived mechanically from the CHANGELOG sections in that release:
+
+- **MAJOR** (`2.0.0`) — any breaking change.
+- **MINOR** (`1.1.0`, resets PATCH to `0`) — any non-breaking `### Added` or `### Changed`.
+- **PATCH** (`1.0.13`) — the release contains **only** `### Fixed` (and/or internal/doc-only changes).
+
+A release that bundles features and fixes takes the **highest** applicable bump — features ⇒ MINOR even if fixes ride along. **Never patch-bump a release that ships a feature** (this is the rule the `1.0.x` line violated through 1.0.12; correct it going forward, but don't renumber already-published tags).
+
+### Release flow
+
+1. Branch `release/vX.Y.Z` off `main`.
+2. Bump `frontend/package.json` to `X.Y.Z` and prepend a `## [X.Y.Z] - YYYY-MM-DD` CHANGELOG section covering **every** PR merged since the last release, grouped into `### Added` / `### Changed` / `### Fixed`, each line referencing its `#PR`. Pick `X.Y.Z` by applying the bump rules above to those grouped sections. Commit: `chore(release): vX.Y.Z — changelog entry and version bump`.
+3. PR → merge to `main`.
+4. Annotated tag `vX.Y.Z` on the merge commit, push it, then publish the GitHub release from the CHANGELOG body: `gh release create vX.Y.Z --latest --notes-file <body>`.
 
 ## SQL Statements
 


### PR DESCRIPTION
Two doc-only changes:

### 1. Adopt strict Semantic Versioning (`CLAUDE.md`)
The CHANGELOG header already claims semver adherence but practice didn't follow it (every release `1.0.0`–`1.0.12` was a patch bump, including ones that shipped features). New **"Versioning & Releases"** section codifies:
- Mechanical bump rule keyed to CHANGELOG sections: `### Added`/`### Changed` ⇒ **MINOR**, `### Fixed`-only ⇒ **PATCH**, breaking ⇒ **MAJOR**; mixed release takes the highest applicable bump.
- "Never patch-bump a feature release," with a note to correct going forward and **not** renumber published tags.
- The release flow (release branch → version bump + changelog → PR → annotated tag → `gh release`), previously undocumented.
- Doc frontmatter `3.7.1 → 3.8.0` (new section is additive ⇒ minor — eating our own dog food).

### 2. Backfill missing 1.0.12 changelog entry (`CHANGELOG.md`)
The admin read-only predictions list (`099a7b9`, migration `0062`) shipped in v1.0.12 but was omitted from the `[1.0.12]` notes. Adds the missing `### Added` line. The published GitHub release notes for v1.0.12 have also been updated to match.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)