### PR TITLE
fix(predictions): don't show Save progress before a champion is picked

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -1274,14 +1274,26 @@ export function PredictionsPageContent({
   const showReviewSubmit = isLastStep && !lockedReadOnly;
   const showContinue =
     !isLastStep && (lockedReadOnly || !isPhase1LastStep || isSuperAdmin);
+  // A Phase 1 server save needs champion_team_id (the RPC requires it on any
+  // Phase 1 write), but the champion is the *last* Phase 1 step — so on the
+  // earlier steps (Group Stage, Best 3rds) there's nothing we can persist to
+  // the server yet. canAutosave() already skips the save in that window; this
+  // mirrors it for the explicit button. Without this, Save progress would call
+  // persist(), hit its champion guard, and bounce the user to the Champion
+  // Pick step — skipping Best 3rds. Their picks are still safe in the
+  // localStorage draft; "Save Phase 1 Picks" on the champion step is the real
+  // server commit.
+  const championRequiredButMissing =
+    (usesAdminRoute || phase === 'phase1') && !championTeamId;
   // Save progress: an explicit "persist now, don't advance" action so a user
   // can checkpoint the current round (Phase 1 or Phase 2) in place. Auto-save
   // still fires on Continue / Back / sub-tab; this covers staying put. Hidden
   // where a dedicated commit button already owns the footer (Phase 1 last
-  // step → Save Phase 1 Picks; final/tiebreaker → Submit Prediction) and in a
-  // locked read-only view. Reuses persist()'s name + champion validation.
+  // step → Save Phase 1 Picks; final/tiebreaker → Submit Prediction), in a
+  // locked read-only view, and where no server save is yet possible (Phase 1
+  // before the champion is picked). Reuses persist()'s name + champion validation.
   const showSaveProgressInline =
-    !showSavePhase1 && !showReviewSubmit && !lockedReadOnly;
+    !showSavePhase1 && !showReviewSubmit && !lockedReadOnly && !championRequiredButMissing;
   // Phase 2 only: let the user pull up the FULL prediction (both phases,
   // read-only) at any point in the knockout flow. Needs a persisted prediction
   // to fetch, so it's edit-mode + an existing id.

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -1258,13 +1258,56 @@ describe('PredictionsPageContent — autosave', () => {
     );
   });
 
-  it('renders Save progress on a Phase 1 round step', async () => {
+  it('hides Save progress in the Phase 1 create flow until a champion is picked (no skip to champion)', async () => {
+    // Repro for the reported bug: on the Group Stage step of a NEW Phase 1
+    // prediction the champion isn't picked yet (it's the last Phase 1 step).
+    // The create RPC requires a champion, so there's nothing to server-save —
+    // yet the old UI showed a "Save progress" button that, when clicked, hit
+    // persist()'s champion guard and bounced the user straight to the Gut
+    // Feeling Champion step, SKIPPING Best 3rds. The button is now hidden
+    // until a champion exists (the draft still checkpoints picks locally), so
+    // the only forward path is Continue → Best 3rds.
     configureQueries(); // phase 1 default
+    const user = userEvent.setup();
     render(<PredictionsPageContent mode="create" />);
 
-    // Group Stage is a "round" — the user can checkpoint here without
-    // advancing to Best 3rds.
     await screen.findByTestId('fill-all-groups');
+    await user.click(screen.getByTestId('fill-all-groups'));
+
+    // Still on Group Stage, no champion → no Save progress button to mis-fire.
+    expect(screen.getByTestId('group-stage-form')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Save progress/i })).toBeNull();
+    // Forward path advances to Best 3rds, not champion.
+    expect(
+      screen.getByRole('button', { name: /Continue to Best 3rds/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders Save progress on a Phase 1 round once a champion is set (edit mode)', async () => {
+    // With a champion already chosen (e.g. editing an existing Phase 1
+    // prediction) a Phase 1 server save IS possible, so Save progress returns
+    // on the Group Stage round for in-place checkpointing.
+    configureQueries(); // phase 1 default
+    render(
+      <PredictionsPageContent
+        mode="edit"
+        predictionId="pred-1"
+        initial={{
+          id: 'pred-1',
+          name: 'Main',
+          totalGoals: null,
+          championTeamId: 'arg',
+          submittedAt: null,
+          isPaid: false,
+          paidAt: null,
+          groups: [],
+          knockout: [],
+          advancers: [],
+        }}
+      />
+    );
+
+    await screen.findByTestId('group-stage-form');
     expect(screen.getByRole('button', { name: /Save progress/i })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## The bug

Users reported: in a new prediction, after entering a name + group-stage teams and clicking **Save progress**, the wizard skips the **Best 3rds** step and jumps straight to **Gut Feeling Champion**.

## Root cause

`submit_predictions` requires `champion_team_id` for any Phase 1 write, and the champion is the **last** Phase 1 step (after Best 3rds). `canAutosave()` already accounts for this — it returns `false` in Phase 1 until a champion is set, so **Continue/Back** correctly defer the server save (the draft holds picks meanwhile).

But `handleSaveProgress` calls `persist()` **directly**, bypassing that guard. On the Group Stage step (no champion yet) it hit `persist()`'s own champion guard:

```js
if (willSendPhase1 && !championTeamId) {
  toast.error('Pick a champion before saving');
  goToStep('champion_pick');   // ← jumps to champion, skipping Best 3rds
  return false;
}
```

So **Save progress** was offered on steps where it could never succeed, and clicking it hijacked navigation to the champion step — skipping Best 3rds. (An existing test even encoded this assumption, asserting the button renders there.)

## The fix

Hide **Save progress** when a server save is impossible because the champion is required-but-missing — the same `willSendPhase1 && !championTeamId` condition `canAutosave()` uses:

```js
const championRequiredButMissing = (usesAdminRoute || phase === 'phase1') && !championTeamId;
```

- **Phase 1 create flow, pre-champion** → hidden. Forward path is `Continue → Best 3rds`; the localStorage draft keeps checkpointing picks; `Save Phase 1 Picks` on the champion step is the real commit.
- **Edit mode (champion set)** and **Phase 2 (champion not required)** → unchanged, button still shown and functional.

## Tests
- Replaced the test that encoded the buggy assumption with a regression test (Group Stage, no champion → no Save progress button, `Continue to Best 3rds` present).
- Added an edit-mode positive case (champion set → Save progress returns on the Group Stage round).
- `npm test` (484 passed), `npm run typecheck`, `npm run lint` (pre-existing warnings only) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)