### PR TITLE
release/v1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.13] - 2026-06-09
+
+### Fixed
+
+- Predictions wizard: in a new (Phase 1) prediction, clicking **Save progress** on the Group Stage
+  step no longer skips Best 3rds and jumps to the Gut Feeling Champion step. The create flow requires
+  a champion (the last Phase 1 step) for any server save, so "Save progress" — which can't persist
+  yet — is now hidden until a champion is picked, instead of calling `persist()` and being bounced to
+  the champion step. Picks are still checkpointed locally via the draft; "Save Phase 1 Picks" on the
+  champion step remains the Phase 1 commit. The button is unchanged in edit mode (champion already
+  set) and Phase 2. (#213)
+
 ## [1.0.12] - 2026-06-09
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Release **v1.0.13** — version bump + changelog entry.

Patch release (fix-only, per strict semver):
- **#213** `fix(predictions)` — "Save progress" no longer skips Best 3rds and jumps to the Gut Feeling Champion step in the Phase 1 create flow (hidden until a champion is picked, since no server save is possible before then).

Code-only — **no DB migration** required. Only `package.json` (1.0.12 → 1.0.13) and `CHANGELOG.md` change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)