### PR TITLE
feat(admin): broadcast email tool for all/paid users

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0",
+      "version": "1.0.13",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
@@ -26,12 +26,14 @@
         "lucide-react": "^0.562.0",
         "next": "16.1.4",
         "next-themes": "^0.4.6",
+        "nodemailer": "^8.0.10",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.4.0",
+        "worker-mailer": "^1.2.1",
         "zustand": "^5.0.10"
       },
       "devDependencies": {
@@ -43,6 +45,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^20",
+        "@types/nodemailer": "^8.0.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -7173,6 +7176,16 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
@@ -13838,6 +13851,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -16734,6 +16756,12 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/worker-mailer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/worker-mailer/-/worker-mailer-1.2.1.tgz",
+      "integrity": "sha512-gS2ei/mrpRqNs+AHmqxhT6vFPwCLw2qnz5ShmyGD0ULaU0Q9hxnFAcx9jhAip/MnD6+MjgnQu6hQQgA8mlOkVA==",
       "license": "MIT"
     },
     "node_modules/workerd": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,12 +36,14 @@
     "lucide-react": "^0.562.0",
     "next": "16.1.4",
     "next-themes": "^0.4.6",
+    "nodemailer": "^8.0.10",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.4.0",
+    "worker-mailer": "^1.2.1",
     "zustand": "^5.0.10"
   },
   "devDependencies": {
@@ -53,6 +55,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
+    "@types/nodemailer": "^8.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/frontend/src/app/admin/messages/AdminMessages.tsx
+++ b/frontend/src/app/admin/messages/AdminMessages.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Loader2, Mail, Send } from 'lucide-react';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { AdminNav } from '@/components/admin/AdminNav';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+type Scope = 'all' | 'paid';
+
+interface RecipientsResponse {
+  count: number;
+  paidOnly: boolean;
+}
+
+interface SendResponse {
+  sent: number;
+  failed: number;
+  skipped: number;
+  test: boolean;
+}
+
+async function readError(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return body.error ?? 'Failed';
+}
+
+export function AdminMessages() {
+  const [subject, setSubject] = React.useState('');
+  const [html, setHtml] = React.useState('');
+  const [scope, setScope] = React.useState<Scope>('all');
+  const [confirmOpen, setConfirmOpen] = React.useState(false);
+  const [sending, setSending] = React.useState(false);
+
+  const paidOnly = scope === 'paid';
+
+  const recipients = useQuery<RecipientsResponse>({
+    queryKey: ['admin-message-recipients', paidOnly],
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/messages/recipients?paidOnly=${paidOnly}`);
+      if (!res.ok) throw new Error(await readError(res));
+      return res.json();
+    },
+  });
+
+  const recipientCount = recipients.data?.count ?? 0;
+  const canCompose = subject.trim().length > 0 && html.trim().length > 0;
+
+  const send = async (test: boolean) => {
+    setSending(true);
+    try {
+      const res = await fetch('/api/admin/messages/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subject, html, paidOnly, test }),
+      });
+      if (!res.ok) throw new Error(await readError(res));
+      const data = (await res.json()) as SendResponse;
+      const summary = [
+        `${data.sent} sent`,
+        data.failed > 0 ? `${data.failed} failed` : null,
+        data.skipped > 0 ? `${data.skipped} skipped (daily cap)` : null,
+      ]
+        .filter(Boolean)
+        .join(', ');
+      toast.success(test ? `Test email sent to you (${summary})` : `Broadcast complete: ${summary}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to send');
+    } finally {
+      setSending(false);
+      setConfirmOpen(false);
+    }
+  };
+
+  return (
+    <PageLayout>
+      <h1 className="mb-2 text-3xl font-bold">Admin</h1>
+      <AdminNav />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Compose */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Mail className="h-5 w-5" /> Compose broadcast
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="subject">Subject</Label>
+              <Input
+                id="subject"
+                value={subject}
+                maxLength={200}
+                onChange={(e) => setSubject(e.target.value)}
+                placeholder="Subject line"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="body">Message body (HTML)</Label>
+              <Textarea
+                id="body"
+                value={html}
+                onChange={(e) => setHtml(e.target.value)}
+                placeholder="<h1>Hello!</h1><p>Your World Cup update…</p>"
+                className="min-h-64 font-mono text-xs"
+              />
+              <p className="text-muted-foreground text-xs">
+                Raw HTML is sent as-is. The preview on the right renders it in a sandbox.
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Recipients</Label>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant={scope === 'all' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setScope('all')}
+                >
+                  All users
+                </Button>
+                <Button
+                  type="button"
+                  variant={scope === 'paid' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setScope('paid')}
+                >
+                  Paid users only
+                </Button>
+              </div>
+              <p className="text-muted-foreground text-xs">
+                {recipients.isLoading
+                  ? 'Counting recipients…'
+                  : recipients.isError
+                    ? 'Could not load recipient count.'
+                    : `${recipientCount} recipient${recipientCount === 1 ? '' : 's'}.`}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-2 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={!canCompose || sending}
+                onClick={() => send(true)}
+              >
+                {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                Send test to me
+              </Button>
+              <Button
+                type="button"
+                disabled={!canCompose || sending || recipientCount === 0}
+                onClick={() => setConfirmOpen(true)}
+              >
+                <Send className="h-4 w-4" />
+                Send to {recipientCount} recipient{recipientCount === 1 ? '' : 's'}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Preview */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Preview</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="bg-background rounded-md border">
+              <div className="text-muted-foreground border-b px-3 py-2 text-sm">
+                <span className="font-medium">Subject:</span> {subject || '(none)'}
+              </div>
+              <iframe
+                title="Email preview"
+                sandbox=""
+                srcDoc={html}
+                className={cn('h-96 w-full rounded-b-md bg-white')}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Dialog open={confirmOpen} onOpenChange={(open) => !sending && setConfirmOpen(open)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Send broadcast?</DialogTitle>
+            <DialogDescription>
+              This will email &quot;{subject}&quot; to {recipientCount}{' '}
+              {scope === 'paid' ? 'paid ' : ''}recipient{recipientCount === 1 ? '' : 's'}. This
+              cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" disabled={sending} onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button disabled={sending} onClick={() => send(false)}>
+              {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              Send now
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageLayout>
+  );
+}

--- a/frontend/src/app/admin/messages/__tests__/AdminMessages.test.tsx
+++ b/frontend/src/app/admin/messages/__tests__/AdminMessages.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockUseQuery = jest.fn();
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (opts: unknown) => mockUseQuery(opts),
+}));
+jest.mock('@/components/layout/PageLayout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+jest.mock('@/components/admin/AdminNav', () => ({ AdminNav: () => <nav /> }));
+
+const toastSuccess = jest.fn();
+const toastError = jest.fn();
+jest.mock('sonner', () => ({
+  toast: { success: (...a: unknown[]) => toastSuccess(...a), error: (...a: unknown[]) => toastError(...a) },
+}));
+
+import { AdminMessages } from '../AdminMessages';
+
+function mockRecipients(count: number) {
+  mockUseQuery.mockReturnValue({ data: { count, paidOnly: false }, isLoading: false, isError: false });
+}
+
+const fetchMock = jest.fn();
+
+beforeEach(() => {
+  mockUseQuery.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+  fetchMock.mockReset().mockResolvedValue({
+    ok: true,
+    json: async () => ({ sent: 2, failed: 0, skipped: 0, test: false }),
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+describe('AdminMessages', () => {
+  it('renders the typed HTML into the sandboxed preview iframe', async () => {
+    mockRecipients(5);
+    render(<AdminMessages />);
+    const body = screen.getByLabelText(/message body/i);
+    await userEvent.type(body, '<h1>Hello</h1>');
+    const iframe = screen.getByTitle('Email preview') as HTMLIFrameElement;
+    expect(iframe.getAttribute('srcDoc')).toContain('<h1>Hello</h1>');
+    expect(iframe.getAttribute('sandbox')).toBe('');
+  });
+
+  it('refetches the count with paidOnly=true when switching scope', async () => {
+    mockRecipients(5);
+    render(<AdminMessages />);
+    await userEvent.click(screen.getByRole('button', { name: /paid users only/i }));
+    const lastCall = mockUseQuery.mock.calls.at(-1)?.[0] as { queryKey: unknown[] };
+    expect(lastCall.queryKey).toEqual(['admin-message-recipients', true]);
+  });
+
+  it('shows a confirm dialog before a real broadcast, then sends with test:false', async () => {
+    mockRecipients(3);
+    render(<AdminMessages />);
+    await userEvent.type(screen.getByLabelText(/subject/i), 'Kickoff');
+    await userEvent.type(screen.getByLabelText(/message body/i), '<p>hi</p>');
+
+    await userEvent.click(screen.getByRole('button', { name: /send to 3 recipients/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/send broadcast\?/i)).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: /send now/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
+      subject: 'Kickoff',
+      test: false,
+    });
+  });
+
+  it('sends a test to the admin (test:true) without a confirm dialog', async () => {
+    mockRecipients(3);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ sent: 1, failed: 0, skipped: 0, test: true }),
+    });
+    render(<AdminMessages />);
+    await userEvent.type(screen.getByLabelText(/subject/i), 'Kickoff');
+    await userEvent.type(screen.getByLabelText(/message body/i), '<p>hi</p>');
+
+    await userEvent.click(screen.getByRole('button', { name: /send test to me/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({ test: true });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/admin/messages/page.tsx
+++ b/frontend/src/app/admin/messages/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { AdminMessages } from './AdminMessages';
+
+export const metadata: Metadata = {
+  title: 'Messages | Admin',
+};
+
+export default function AdminMessagesPage() {
+  return <AdminMessages />;
+}

--- a/frontend/src/app/api/admin/messages/recipients/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/messages/recipients/__tests__/route.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route');
+
+function req(qs = '') {
+  return new NextRequest(`http://localhost:3000/api/admin/messages/recipients${qs}`);
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }) }),
+  }));
+}
+
+describe('GET /api/admin/messages/recipients', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await GET(req());
+    expect(res.status).toBe(403);
+  });
+
+  it('returns the recipient count for all users', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: [{ email: 'a@x.com' }, { email: 'b@x.com' }],
+      error: null,
+    });
+    const res = await GET(req('?paidOnly=false'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ count: 2, paidOnly: false });
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_list_recipient_emails', {
+      p_paid_only: false,
+    });
+  });
+
+  it('passes paidOnly=true through to the RPC', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: [{ email: 'a@x.com' }], error: null });
+    const res = await GET(req('?paidOnly=true'));
+    const body = await res.json();
+    expect(body).toEqual({ count: 1, paidOnly: true });
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_list_recipient_emails', {
+      p_paid_only: true,
+    });
+  });
+});

--- a/frontend/src/app/api/admin/messages/recipients/route.ts
+++ b/frontend/src/app/api/admin/messages/recipients/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+// Returns the recipient count for the admin broadcast confirm dialog.
+// ?paidOnly=true restricts to users with a paid entry in the active tournament.
+export async function GET(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const { searchParams } = new URL(request.url);
+  const paidOnly = searchParams.get('paidOnly') === 'true';
+
+  const { data, error } = await ctx.supabase.rpc('admin_list_recipient_emails', {
+    p_paid_only: paidOnly,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: safeMessage(error) }, { status: 500 });
+  }
+
+  const rows = (data ?? []) as Array<{ email: string }>;
+  return NextResponse.json({ count: rows.length, paidOnly });
+}

--- a/frontend/src/app/api/admin/messages/send/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/messages/send/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+const sendBulkEmailMock = jest.fn();
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+jest.mock('@/lib/email/sendBulk', () => ({
+  sendBulkEmail: (...args: unknown[]) => sendBulkEmailMock(...args),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function postReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/messages/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }) }),
+  }));
+}
+
+const adminUser = { id: 'u1', email: 'admin@x.com' };
+
+beforeEach(() => {
+  supabaseMock.auth.getUser.mockReset();
+  supabaseMock.from.mockReset();
+  supabaseMock.rpc.mockReset();
+  sendBulkEmailMock.mockReset().mockResolvedValue({ sent: 1, failed: 0, skipped: 0, errors: [] });
+});
+
+describe('POST /api/admin/messages/send', () => {
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(postReq({ subject: 'Hi', html: '<p>x</p>' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
+    mockAdminProfile(false);
+    const res = await POST(postReq({ subject: 'Hi', html: '<p>x</p>' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when subject is empty', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({ subject: '   ', html: '<p>x</p>' }));
+    expect(res.status).toBe(400);
+    expect(sendBulkEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when body is empty', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({ subject: 'Hi', html: '   ' }));
+    expect(res.status).toBe(400);
+    expect(sendBulkEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('test mode sends only to the calling admin and skips the RPC', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({ subject: 'Hi', html: '<p>x</p>', test: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ sent: 1, test: true });
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+    expect(sendBulkEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ recipients: ['admin@x.com'], subject: 'Hi' })
+    );
+  });
+
+  it('broadcast mode fetches recipients via RPC and sends to them', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: [{ email: 'a@x.com' }, { email: 'b@x.com' }],
+      error: null,
+    });
+    sendBulkEmailMock.mockResolvedValue({ sent: 2, failed: 0, skipped: 0, errors: [] });
+    const res = await POST(postReq({ subject: 'Hi', html: '<p>x</p>', paidOnly: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ sent: 2, test: false });
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_list_recipient_emails', {
+      p_paid_only: true,
+    });
+    expect(sendBulkEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ recipients: ['a@x.com', 'b@x.com'] })
+    );
+  });
+
+  it('returns 400 when no recipients match', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: [], error: null });
+    const res = await POST(postReq({ subject: 'Hi', html: '<p>x</p>' }));
+    expect(res.status).toBe(400);
+    expect(sendBulkEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when sendBulkEmail throws (e.g. SMTP not configured)', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
+    mockAdminProfile(true);
+    sendBulkEmailMock.mockRejectedValue(new Error('SMTP is not configured: set SMTP_HOST'));
+    const res = await POST(postReq({ subject: 'Hi', html: '<p>x</p>', test: true }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/SMTP is not configured/);
+  });
+});

--- a/frontend/src/app/api/admin/messages/send/route.ts
+++ b/frontend/src/app/api/admin/messages/send/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+import { sendBulkEmail } from '@/lib/email/sendBulk';
+
+const MAX_SUBJECT_LENGTH = 200;
+const MAX_HTML_LENGTH = 200_000;
+
+// Sends a broadcast email. test:true delivers only to the calling admin;
+// test:false fetches recipients (all users, or paid-only) and sends to each.
+export async function POST(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json().catch(() => ({}))) as {
+    subject?: string;
+    html?: string;
+    paidOnly?: boolean;
+    test?: boolean;
+  };
+
+  const subject = typeof body.subject === 'string' ? body.subject.trim() : '';
+  const html = typeof body.html === 'string' ? body.html : '';
+  const paidOnly = body.paidOnly === true;
+  const test = body.test === true;
+
+  if (!subject || subject.length > MAX_SUBJECT_LENGTH) {
+    return NextResponse.json(
+      { error: `subject is required (max ${MAX_SUBJECT_LENGTH} characters)` },
+      { status: 400 }
+    );
+  }
+  if (!html.trim() || html.length > MAX_HTML_LENGTH) {
+    return NextResponse.json(
+      { error: `message body is required (max ${MAX_HTML_LENGTH} characters)` },
+      { status: 400 }
+    );
+  }
+
+  // Resolve recipients.
+  let recipients: string[];
+  if (test) {
+    if (!ctx.user.email) {
+      return NextResponse.json({ error: 'your account has no email address' }, { status: 400 });
+    }
+    recipients = [ctx.user.email];
+  } else {
+    const { data, error } = await ctx.supabase.rpc('admin_list_recipient_emails', {
+      p_paid_only: paidOnly,
+    });
+    if (error) {
+      return NextResponse.json({ error: safeMessage(error) }, { status: 500 });
+    }
+    recipients = ((data ?? []) as Array<{ email: string }>).map((r) => r.email);
+    if (recipients.length === 0) {
+      return NextResponse.json({ error: 'no recipients match' }, { status: 400 });
+    }
+  }
+
+  try {
+    const result = await sendBulkEmail({ subject, html, recipients });
+    return NextResponse.json({
+      sent: result.sent,
+      failed: result.failed,
+      skipped: result.skipped,
+      test,
+    });
+  } catch (err) {
+    // Most likely missing SMTP config; surface a generic 500.
+    console.error('[messages/send] sendBulkEmail failed:', err);
+    const message =
+      err instanceof Error && err.message.startsWith('SMTP is not configured')
+        ? err.message
+        : 'failed to send email';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/frontend/src/components/admin/AdminNav.tsx
+++ b/frontend/src/components/admin/AdminNav.tsx
@@ -10,6 +10,7 @@ const links = [
   { label: 'Users', href: '/admin/users' },
   { label: 'Predictions', href: '/admin/predictions' },
   { label: 'Referrals', href: '/admin/referrals' },
+  { label: 'Messages', href: '/admin/messages' },
   { label: 'Tournament', href: '/admin/tournament' },
 ];
 

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-20 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-sm transition-colors focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/frontend/src/lib/email/__tests__/sendBulk.test.ts
+++ b/frontend/src/lib/email/__tests__/sendBulk.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @jest-environment node
+ */
+
+// --- worker-mailer mock (Workers runtime path) ---
+const wmSendMock = jest.fn();
+const wmCloseMock = jest.fn().mockResolvedValue(undefined);
+const wmConnectMock = jest.fn();
+jest.mock('worker-mailer', () => ({
+  WorkerMailer: { connect: (...args: unknown[]) => wmConnectMock(...args) },
+}));
+
+// --- nodemailer mock (Node / `next dev` path) ---
+const nmSendMailMock = jest.fn();
+const nmCloseMock = jest.fn();
+const nmCreateTransportMock = jest.fn((config?: unknown) => {
+  void config;
+  return { sendMail: (...a: unknown[]) => nmSendMailMock(...a), close: () => nmCloseMock() };
+});
+jest.mock('nodemailer', () => ({
+  __esModule: true,
+  default: { createTransport: (...a: unknown[]) => nmCreateTransportMock(...a) },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { sendBulkEmail, getSmtpConfig } = require('../sendBulk');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { MAX_RECIPIENTS_PER_SEND } = require('../sendBulk');
+
+const ENV = {
+  SMTP_HOST: 'smtpout.secureserver.net',
+  SMTP_PORT: '465',
+  SMTP_SECURE: 'true',
+  SMTP_USER: 'pool@example.com',
+  SMTP_PASS: 'secret',
+  SMTP_FROM: 'World Cup Pool <pool@example.com>',
+};
+
+function setEnv(overrides: Record<string, string | undefined> = {}) {
+  Object.assign(process.env, ENV, overrides);
+}
+function clearEnv() {
+  for (const k of Object.keys(ENV)) delete process.env[k];
+}
+
+function setRuntime(workers: boolean) {
+  // workerd identifies itself via navigator.userAgent.
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { userAgent: workers ? 'Cloudflare-Workers' : 'Node.js' },
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  wmSendMock.mockReset().mockResolvedValue(undefined);
+  wmCloseMock.mockClear();
+  wmConnectMock.mockReset().mockResolvedValue({ send: wmSendMock, close: wmCloseMock });
+  nmSendMailMock.mockReset().mockResolvedValue(undefined);
+  nmCloseMock.mockClear();
+  nmCreateTransportMock.mockClear();
+  clearEnv();
+  setRuntime(false);
+});
+
+describe('getSmtpConfig', () => {
+  it('throws when SMTP env vars are missing', () => {
+    expect(() => getSmtpConfig()).toThrow(/SMTP is not configured/);
+  });
+
+  it('uses implicit TLS on port 465 by default', () => {
+    setEnv({ SMTP_SECURE: undefined });
+    expect(getSmtpConfig()).toMatchObject({ port: 465, implicitTls: true, startTls: false });
+  });
+
+  it('uses STARTTLS (not implicit TLS) on 587 with SMTP_SECURE=true', () => {
+    setEnv({ SMTP_PORT: '587', SMTP_SECURE: 'true' });
+    expect(getSmtpConfig()).toMatchObject({ implicitTls: false, startTls: true });
+  });
+
+  it('uses no TLS at all when SMTP_SECURE=false (e.g. local Mailpit)', () => {
+    setEnv({ SMTP_PORT: '54325', SMTP_SECURE: 'false' });
+    expect(getSmtpConfig()).toMatchObject({ implicitTls: false, startTls: false });
+  });
+});
+
+describe('sendBulkEmail on the Workers runtime', () => {
+  beforeEach(() => setRuntime(true));
+
+  it('sends one message per recipient over one worker-mailer connection', async () => {
+    setEnv();
+    const result = await sendBulkEmail({
+      subject: 'Hi',
+      html: '<p>x</p>',
+      recipients: ['a@x.com', 'b@x.com'],
+      delayMs: 0,
+    });
+    expect(wmConnectMock).toHaveBeenCalledTimes(1);
+    expect(wmConnectMock).toHaveBeenCalledWith(
+      expect.objectContaining({ secure: true, startTls: false })
+    );
+    expect(wmSendMock).toHaveBeenCalledTimes(2);
+    expect(wmSendMock).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'a@x.com', subject: 'Hi', html: '<p>x</p>' })
+    );
+    expect(wmCloseMock).toHaveBeenCalledTimes(1);
+    expect(nmCreateTransportMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ sent: 2, failed: 0, skipped: 0 });
+  });
+
+  it('records per-recipient failures without aborting the batch', async () => {
+    setEnv();
+    wmSendMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('mailbox full'))
+      .mockResolvedValueOnce(undefined);
+    const result = await sendBulkEmail({
+      subject: 'Hi',
+      html: '<p>x</p>',
+      recipients: ['a@x.com', 'b@x.com', 'c@x.com'],
+      delayMs: 0,
+    });
+    expect(result).toMatchObject({ sent: 2, failed: 1 });
+    expect(result.errors[0]).toMatchObject({ email: 'b@x.com', error: 'mailbox full' });
+    expect(wmCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps at MAX_RECIPIENTS_PER_SEND and reports the surplus as skipped', async () => {
+    setEnv();
+    const recipients = Array.from(
+      { length: MAX_RECIPIENTS_PER_SEND + 5 },
+      (_, i) => `user${i}@x.com`
+    );
+    const result = await sendBulkEmail({ subject: 'Hi', html: '<p>x</p>', recipients, delayMs: 0 });
+    expect(result.sent).toBe(MAX_RECIPIENTS_PER_SEND);
+    expect(result.skipped).toBe(5);
+  });
+});
+
+describe('sendBulkEmail under Node (next dev)', () => {
+  beforeEach(() => setRuntime(false));
+
+  it('falls back to nodemailer with STARTTLS on 587', async () => {
+    setEnv({ SMTP_HOST: 'smtp.office365.com', SMTP_PORT: '587' });
+    const result = await sendBulkEmail({
+      subject: 'Hi',
+      html: '<p>x</p>',
+      recipients: ['A@x.com', 'a@x.com', 'b@x.com'],
+      delayMs: 0,
+    });
+    expect(nmCreateTransportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 587, secure: false, requireTLS: true })
+    );
+    // dedupes A@/a@ to one
+    expect(nmSendMailMock).toHaveBeenCalledTimes(2);
+    expect(wmConnectMock).not.toHaveBeenCalled();
+    expect(nmCloseMock).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ sent: 2, failed: 0 });
+  });
+
+  it('connects to plain SMTP (Mailpit) with no TLS when SMTP_SECURE=false', async () => {
+    setEnv({ SMTP_HOST: '127.0.0.1', SMTP_PORT: '54325', SMTP_SECURE: 'false' });
+    await sendBulkEmail({ subject: 'Hi', html: '<p>x</p>', recipients: ['a@x.com'], delayMs: 0 });
+    expect(nmCreateTransportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ host: '127.0.0.1', port: 54325, secure: false, requireTLS: false })
+    );
+  });
+});
+
+describe('sendBulkEmail config errors', () => {
+  it('throws (and never connects) when SMTP is not configured', async () => {
+    setRuntime(true);
+    await expect(
+      sendBulkEmail({ subject: 'Hi', html: '<p>x</p>', recipients: ['a@x.com'], delayMs: 0 })
+    ).rejects.toThrow(/SMTP is not configured/);
+    expect(wmConnectMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/email/sendBulk.ts
+++ b/frontend/src/lib/email/sendBulk.ts
@@ -1,0 +1,185 @@
+/**
+ * Server-only SMTP broadcast helper for the admin messaging tool.
+ * Never import this from a client component — it reads SMTP secrets and opens
+ * raw sockets (same convention as lib/supabase/admin.ts).
+ *
+ * Runtime-aware transport:
+ *  - On the Cloudflare Workers runtime (production, `npm run preview`) the Node
+ *    `net` module isn't available, so we use `worker-mailer`, which speaks SMTP
+ *    over the Workers `connect()` TCP socket API (ports 465/587 only; 25 blocked).
+ *  - Under plain Node (`next dev`) `cloudflare:sockets` doesn't exist, so we fall
+ *    back to `nodemailer`. Each is imported lazily so neither pollutes the other
+ *    runtime's bundle / module graph.
+ *
+ * TLS model (combining SMTP_SECURE + port):
+ *  - SMTP_SECURE=true (default) + port 465 ⇒ implicit TLS
+ *  - SMTP_SECURE=true (default) + other port (587) ⇒ STARTTLS upgrade
+ *  - SMTP_SECURE=false ⇒ plain, no TLS at all (e.g. local Mailpit)
+ * Deriving STARTTLS from the port is more reliable than trusting SMTP_SECURE
+ * for implicit TLS (e.g. Office 365 on 587 must STARTTLS even though "secure").
+ *
+ * Bulk sends are paced and hard-capped at MAX_RECIPIENTS_PER_SEND because the
+ * upstream SMTP relay (GoDaddy / O365) rate-limits daily volume; the surplus is
+ * reported as `skipped` rather than silently dropped. Each recipient gets an
+ * individually addressed message (no shared BCC) for privacy + deliverability.
+ */
+
+const MAX_RECIPIENTS_PER_SEND = 250;
+const DEFAULT_DELAY_MS = 250;
+
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  /** Connect over TLS from the start (port 465). */
+  implicitTls: boolean;
+  /** Upgrade a plain connection to TLS via STARTTLS (e.g. 587). */
+  startTls: boolean;
+  username: string;
+  password: string;
+  from: string;
+}
+
+/**
+ * Reads + validates the SMTP_* env vars. Throws a clear error if any required
+ * value is missing — mirrors the fail-fast pattern in lib/auth/reset-intent.ts.
+ * Secrets are read directly from process.env (never from config/env.ts, which
+ * is for public/validated config only).
+ */
+export function getSmtpConfig(): SmtpConfig {
+  const host = process.env.SMTP_HOST?.trim();
+  const portRaw = process.env.SMTP_PORT?.trim();
+  const username = process.env.SMTP_USER?.trim();
+  const password = process.env.SMTP_PASS;
+  const from = process.env.SMTP_FROM?.trim();
+
+  const port = portRaw ? Number.parseInt(portRaw, 10) : NaN;
+
+  if (!host || !username || !password || !from || !Number.isFinite(port)) {
+    throw new Error(
+      'SMTP is not configured: set SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM'
+    );
+  }
+
+  // secureFlag=false ⇒ plain (no TLS). Otherwise: implicit TLS on 465, STARTTLS
+  // elsewhere. SMTP_SECURE can never turn 587/25 into implicit TLS.
+  const secureFlag = (process.env.SMTP_SECURE?.trim().toLowerCase() ?? 'true') !== 'false';
+  const implicitTls = secureFlag && port === 465;
+  const startTls = secureFlag && port !== 465;
+
+  return { host, port, implicitTls, startTls, username, password, from };
+}
+
+export interface SendBulkParams {
+  subject: string;
+  html: string;
+  recipients: string[];
+  /** Delay between individual sends, in ms. Defaults to 250ms; pass 0 in tests. */
+  delayMs?: number;
+}
+
+export interface SendBulkResult {
+  /** Number of messages accepted by the SMTP server. */
+  sent: number;
+  /** Number of recipients the server rejected (bad address, transient error). */
+  failed: number;
+  /** Recipients beyond MAX_RECIPIENTS_PER_SEND that were not attempted. */
+  skipped: number;
+  errors: Array<{ email: string; error: string }>;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** workerd sets navigator.userAgent to this; Node does not. */
+function isWorkersRuntime(): boolean {
+  return (
+    typeof navigator !== 'undefined' && navigator.userAgent === 'Cloudflare-Workers'
+  );
+}
+
+/** Sends one message at a time over a callback, applying the cap/dedupe/pacing. */
+async function sendEach(
+  toSend: string[],
+  delayMs: number,
+  skipped: number,
+  sendOne: (email: string) => Promise<void>
+): Promise<SendBulkResult> {
+  const result: SendBulkResult = { sent: 0, failed: 0, skipped, errors: [] };
+  for (let i = 0; i < toSend.length; i++) {
+    const email = toSend[i];
+    try {
+      await sendOne(email);
+      result.sent++;
+    } catch (err) {
+      result.failed++;
+      result.errors.push({ email, error: err instanceof Error ? err.message : 'send failed' });
+    }
+    if (delayMs > 0 && i < toSend.length - 1) await sleep(delayMs);
+  }
+  return result;
+}
+
+/**
+ * Sends `html` (with `subject`) individually to each recipient over a single
+ * reused SMTP connection. Resilient: one bad recipient is recorded in `errors`
+ * and the batch continues. Always closes the connection before returning.
+ */
+export async function sendBulkEmail({
+  subject,
+  html,
+  recipients,
+  delayMs = DEFAULT_DELAY_MS,
+}: SendBulkParams): Promise<SendBulkResult> {
+  const config = getSmtpConfig();
+
+  // Dedupe + normalize, then split at the daily cap.
+  const unique = Array.from(
+    new Set(recipients.map((e) => e.trim().toLowerCase()).filter(Boolean))
+  );
+  const toSend = unique.slice(0, MAX_RECIPIENTS_PER_SEND);
+  const skipped = unique.length - toSend.length;
+
+  if (toSend.length === 0) return { sent: 0, failed: 0, skipped, errors: [] };
+
+  if (isWorkersRuntime()) {
+    // Imported lazily: worker-mailer pulls in `cloudflare:sockets`, which only
+    // exists in the Workers runtime — keep it out of the Node build's graph.
+    const { WorkerMailer } = await import('worker-mailer');
+    const mailer = await WorkerMailer.connect({
+      host: config.host,
+      port: config.port,
+      secure: config.implicitTls,
+      startTls: config.startTls,
+      credentials: { username: config.username, password: config.password },
+      authType: ['plain', 'login'],
+    });
+    try {
+      return await sendEach(toSend, delayMs, skipped, (email) =>
+        mailer.send({ from: config.from, to: email, subject, html })
+      );
+    } finally {
+      await mailer.close().catch(() => {});
+    }
+  }
+
+  // Node fallback (next dev). Variable specifier keeps nodemailer out of the
+  // worker bundle (the bundler can't statically follow it) and this branch never
+  // runs on workerd anyway.
+  const nodemailerSpecifier = 'nodemailer';
+  const nodemailer = (await import(nodemailerSpecifier)).default;
+  const transporter = nodemailer.createTransport({
+    host: config.host,
+    port: config.port,
+    secure: config.implicitTls,
+    requireTLS: config.startTls,
+    auth: { user: config.username, pass: config.password },
+  });
+  try {
+    return await sendEach(toSend, delayMs, skipped, async (email) => {
+      await transporter.sendMail({ from: config.from, to: email, subject, html });
+    });
+  } finally {
+    transporter.close();
+  }
+}
+
+export { MAX_RECIPIENTS_PER_SEND };

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -8,7 +8,7 @@ directory = ".open-next/assets"
 binding = "ASSETS"
 
 [secrets]
-required = ["SUPABASE_SERVICE_ROLE_KEY","RESET_INTENT_SECRET"]
+required = ["SUPABASE_SERVICE_ROLE_KEY","RESET_INTENT_SECRET", "SMTP_HOST","SMTP_PORT","SMTP_USER","SMTP_PASS","SMTP_FROM"]
 
 
 # Environment variables are set via the Cloudflare dashboard or `wrangler secret put`.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -54,6 +54,10 @@ content_path = "./supabase/templates/email_change.html"
 [inbucket]
 enabled = true
 port = 54324
+# Expose Mailpit's SMTP port to the host so local `next dev` can deliver the
+# admin broadcast tool's test emails here (viewable at http://127.0.0.1:54324).
+smtp_port = 54325
+pop3_port = 54326
 
 [analytics]
 enabled = false

--- a/supabase/migrations/0063_admin_recipient_emails.sql
+++ b/supabase/migrations/0063_admin_recipient_emails.sql
@@ -1,0 +1,50 @@
+-- Migration 0063: recipient enumeration for the admin broadcast-email tool
+--
+-- The admin "Messages" page composes a subject + HTML body and sends it to
+-- either every registered user or only users who have a paid entry in the
+-- active tournament. This RPC returns the de-duplicated recipient email list
+-- (or its count) for that send. SECURITY DEFINER so it can read auth.users,
+-- gated on is_admin() exactly like admin_list_users (0061).
+--
+-- "Paid" mirrors the dashboard's usersWithPaidPrediction definition: a user
+-- owning >=1 prediction with ANY tournament_payments row (cash or free) in the
+-- active tournament. Emails with a null/blank address (shouldn't happen for
+-- email-auth accounts, but auth.users.email is nullable) are excluded so the
+-- caller never tries to send to an empty address.
+
+create or replace function public.admin_list_recipient_emails(p_paid_only boolean)
+returns table (email text)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    select t.id into v_tournament_id from public.tournaments t where t.is_active limit 1;
+
+    return query
+    select distinct u.email::text as email
+    from public.profiles p
+    join auth.users u on u.id = p.id
+    where u.email is not null
+      and btrim(u.email::text) <> ''
+      and (
+        not coalesce(p_paid_only, false)
+        or exists (
+            select 1
+            from public.predictions pr
+            join public.tournament_payments tp on tp.prediction_id = pr.id
+            where pr.user_id = p.id
+              and pr.tournament_id = v_tournament_id
+        )
+      )
+    order by email;
+end;
+$$;
+
+grant execute on function public.admin_list_recipient_emails(boolean) to authenticated;


### PR DESCRIPTION
## What

Adds an admin **Messages** page (`/admin/messages`) to compose a subject + raw-HTML body and email it to **all registered users** or **only users with a paid entry** in the active tournament.

## How it works

- **Transport (runtime-aware)** — `src/lib/email/sendBulk.ts` uses `worker-mailer` on the Cloudflare Workers runtime (production / `npm run preview`) and falls back to `nodemailer` under plain Node (`next dev`), since `worker-mailer` needs `cloudflare:sockets`. Each is imported lazily so neither pollutes the other runtime's bundle.
- **Sending** — individually-addressed messages (no shared BCC), paced, hard-capped at 250/send (GoDaddy/O365 daily limits); surplus reported as `skipped`, per-recipient errors captured. TLS derived from `SMTP_SECURE` + port: 465 ⇒ implicit TLS, 587 ⇒ STARTTLS, `SMTP_SECURE=false` ⇒ plain (local Mailpit).
- **Recipients** — migration `0063` adds `admin_list_recipient_emails(p_paid_only)` (`SECURITY DEFINER`, `is_admin()`-gated), returning deduped emails. "Paid" = ≥1 `tournament_payments` row in the active tournament.
- **API** — `GET /api/admin/messages/recipients` (count) + `POST /api/admin/messages/send` (`test` ⇒ caller only; broadcast ⇒ RPC recipients), both behind `requireAdmin()`.
- **UI** — subject input, HTML textarea with a sandboxed `<iframe>` preview, all/paid scope toggle with live count, "Send test to me", and a confirm dialog showing the recipient count before a broadcast. New **Messages** nav tab + reusable `Textarea` component.

## Config / deploy

- `wrangler.toml` declares `SMTP_*` in `[secrets] required`; values are set as **Cloudflare Worker secrets** (not committed, not in GitHub).
- `supabase/config.toml` exposes local Mailpit SMTP (`54325`) so `next dev` test sends land at http://127.0.0.1:54324.

## Tests

New tests cover the helper (both transports + all TLS modes), both API routes (auth gate, validation, test vs broadcast), and the component (preview, scope refetch, confirm dialog).

## Notes

- DB migration `0063` must be applied to production before the feature works there.
- `SMTP_FROM` must be a real mailbox on the sending domain; O365 tenants often disable basic SMTP AUTH (infra config, not code).