### PR TITLE
fix(email): worker-mailer ESM build so cloudflare:sockets resolves at runtime (v1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-06-09
+
+### Fixed
+
+- Admin broadcast email send threw a 500 in production (`Dynamic require of "cloudflare:sockets" is
+  not supported`). Next/Turbopack was compiling `worker-mailer` and rewriting its
+  `import { connect } from "cloudflare:sockets"` into a CJS `require`, which the workerd runtime
+  rejects. `worker-mailer` is now declared in `serverExternalPackages` so Next leaves it untouched,
+  and `sendBulk` imports the package's ESM build (`worker-mailer/dist/index.mjs`) so the static
+  `import` survives to the OpenNext bundle (paired with the existing `cloudflare:sockets` esbuild
+  external from 1.1.1). Verified the built worker now emits an ESM `import … from "cloudflare:sockets"`
+  with zero `require(...)`. (#218)
+
 ## [1.1.1] - 2026-06-09
 
 ### Fixed

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -46,6 +46,13 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  // Don't let Next/Turbopack compile worker-mailer: it would rewrite the
+  // package's `import { connect } from "cloudflare:sockets"` into a CJS
+  // `require("cloudflare:sockets")`, which throws "Dynamic require ... not
+  // supported" on the workerd runtime. Left external, its ESM import survives
+  // to the OpenNext esbuild step (where cloudflare:sockets is marked external),
+  // so the final worker keeps a static ESM import that workerd resolves.
+  serverExternalPackages: ['worker-mailer'],
   async headers() {
     return [
       {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "postinstall": "patch-package",

--- a/frontend/src/lib/email/__tests__/sendBulk.test.ts
+++ b/frontend/src/lib/email/__tests__/sendBulk.test.ts
@@ -6,9 +6,9 @@
 const wmSendMock = jest.fn();
 const wmCloseMock = jest.fn().mockResolvedValue(undefined);
 const wmConnectMock = jest.fn();
-jest.mock('worker-mailer', () => ({
+jest.mock('worker-mailer/dist/index.mjs', () => ({
   WorkerMailer: { connect: (...args: unknown[]) => wmConnectMock(...args) },
-}));
+}), { virtual: true });
 
 // --- nodemailer mock (Node / `next dev` path) ---
 const nmSendMailMock = jest.fn();

--- a/frontend/src/lib/email/sendBulk.ts
+++ b/frontend/src/lib/email/sendBulk.ts
@@ -141,9 +141,13 @@ export async function sendBulkEmail({
   if (toSend.length === 0) return { sent: 0, failed: 0, skipped, errors: [] };
 
   if (isWorkersRuntime()) {
-    // Imported lazily: worker-mailer pulls in `cloudflare:sockets`, which only
-    // exists in the Workers runtime — keep it out of the Node build's graph.
-    const { WorkerMailer } = await import('worker-mailer');
+    // Import the ESM build explicitly. worker-mailer's `main` (CJS) does
+    // `require("cloudflare:sockets")`, which esbuild emits as a CJS require that
+    // throws "Dynamic require of cloudflare:sockets is not supported" at runtime
+    // on workerd. The `.mjs` build uses a static `import` that workerd resolves
+    // natively (paired with the cloudflare:sockets esbuild external, see
+    // patches/@opennextjs+cloudflare). Lazy so it stays out of the Node build.
+    const { WorkerMailer } = await import('worker-mailer/dist/index.mjs');
     const mailer = await WorkerMailer.connect({
       host: config.host,
       port: config.port,


### PR DESCRIPTION
## Problem

After v1.1.1 fixed the *build*, the broadcast send still 500'd in **production** (confirmed via `wrangler tail`):

```
[messages/send] sendBulkEmail failed:
Error: Failed to load external module cloudflare:sockets:
       Dynamic require of "cloudflare:sockets" is not supported
```

Root cause: Next/Turbopack was compiling `worker-mailer` and rewriting its ESM `import { connect } from "cloudflare:sockets"` into a CJS `require("cloudflare:sockets")`. The workerd runtime can't `require()` a `cloudflare:` built-in — only a static ESM `import` resolves.

## Fix

- **`serverExternalPackages: ['worker-mailer']`** in `next.config.ts` so Next leaves the package uncompiled (its ESM import survives to the OpenNext bundle).
- **Import the ESM build** (`worker-mailer/dist/index.mjs`) in `sendBulk` so esbuild keeps a static `import` (paired with the `cloudflare:sockets` esbuild external from 1.1.1).

## Verification

Ran `npx opennextjs-cloudflare build` and inspected the output bundle:
- `require("cloudflare:sockets")`: **0**
- `import {connect} from "cloudflare:sockets"`: **1** ✅

Lint + typecheck clean; messaging tests pass. PATCH release **v1.1.2**.