### PR TITLE
fix(theme): shim global __name to stop next-themes ReferenceError (v1.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-06-09
+
+### Fixed
+
+- `Uncaught ReferenceError: __name is not defined` on every page load. The OpenNext/esbuild worker
+  build instruments functions with an esbuild `__name` keep-names helper; next-themes serializes its
+  anti-flash theme function via `Function.prototype.toString()` and injects it as an inline `<script>`,
+  which then referenced `__name` in the browser global scope where it doesn't exist. Added a no-op
+  `window.__name` shim as the first child of `<body>` (running before next-themes' injected script).
+  Pre-existing issue (unrelated to the broadcast email work); non-fatal but noisy in the console. (#219)
+
 ## [1.1.2] - 2026-06-09
 
 ### Fixed

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -48,3 +48,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Cloudflare local dev secrets
+.dev.vars
+.dev.vars.*

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "postinstall": "patch-package",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -58,6 +58,20 @@ export default async function RootLayout({
   return (
     <html lang="en" className="dark" style={{ colorScheme: 'dark' }} suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
+        {/*
+          Turbopack instruments functions with an esbuild-style `__name` keep-names helper that
+          only exists inside its module runtime. next-themes serializes its anti-flash theme
+          function via `Function.prototype.toString()` and injects it as an inline <script>, which
+          then references `__name` in the browser global scope where it is undefined — throwing
+          "ReferenceError: __name is not defined" on every page load. This no-op shim defines it
+          globally and runs before the next-themes script (injected right after, as the next child
+          of <body>).
+        */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: 'window.__name||(window.__name=function(t){return t})',
+          }}
+        />
         <ThemeProvider>
           <QueryProvider>
             <AuthProvider initialUser={user} initialProfile={profile}>


### PR DESCRIPTION
## Problem

Every page load logged `Uncaught ReferenceError: __name is not defined` (confirmed on the public homepage and admin pages). The broken inline script is **next-themes'** anti-flash theme script:

```html
<script>((a,b,...) => { __name(k,"k"); ... })("class","theme","dark",...)</script>
```

The OpenNext/esbuild worker build instruments functions with esbuild's `__name` keep-names helper (the built worker has 966 `__name(` calls). next-themes serializes its theme function via `Function.prototype.toString()` and injects it as an inline `<script>`, which then references `__name` in the browser global scope where it doesn't exist.

Pre-existing issue, unrelated to the broadcast email work; non-fatal (only the anti-flash script fails) but noisy in the console on every page.

## Fix

A no-op `window.__name` shim rendered as the **first child of `<body>`**, so it defines `__name` globally before next-themes injects its script (which appears immediately after).

## Verification

- `next start` (Node SSR) confirms the shim renders as the first `<body>` script, immediately before the next-themes script.
- OpenNext build succeeds; built worker reproduces the `__name` instrumentation.
- **Note:** workerd can't run on the dev machine's macOS (12.6 < 13.5), so a local *runtime* preview wasn't possible — final confirmation is a prod reload after deploy. Ordering is React-deterministic (identical to the verified `next start` output).

Also: gitignore `.dev.vars`. Lint + typecheck clean. PATCH release **v1.1.3**.