### PR TITLE
fix(email): worker-mailer root import + exports map (v1.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2026-06-09
+
+### Fixed
+
+- Admin broadcast email send still 500'd in production (`No such module
+  "worker-mailer-…/dist/index.mjs"`). With `worker-mailer` in `serverExternalPackages`, OpenNext
+  registers the package **entry** as a runtime module but not arbitrary subpaths, so the previous
+  `worker-mailer/dist/index.mjs` subpath import resolved to an unregistered module id. Now import the
+  package **root** (`worker-mailer`) and add a `patches/worker-mailer` `exports` map so the entry
+  resolves to the ESM `.mjs` build (whose static `import { connect } from "cloudflare:sockets"`
+  workerd resolves natively, vs the CJS build's `require`). (#220)
+
 ## [1.1.3] - 2026-06-09
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "scripts": {
     "postinstall": "patch-package",

--- a/frontend/patches/worker-mailer+1.2.1.patch
+++ b/frontend/patches/worker-mailer+1.2.1.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/worker-mailer/package.json b/node_modules/worker-mailer/package.json
+index e203744..1331642 100644
+--- a/node_modules/worker-mailer/package.json
++++ b/node_modules/worker-mailer/package.json
+@@ -4,6 +4,13 @@
+   "main": "./dist/index.js",
+   "module": "./dist/index.mjs",
+   "types": "./dist/index.d.ts",
++  "exports": {
++    ".": {
++      "types": "./dist/index.d.ts",
++      "import": "./dist/index.mjs",
++      "require": "./dist/index.js"
++    }
++  },
+   "keywords": [
+     "cloudflare",
+     "workers",

--- a/frontend/src/lib/email/__tests__/sendBulk.test.ts
+++ b/frontend/src/lib/email/__tests__/sendBulk.test.ts
@@ -6,9 +6,9 @@
 const wmSendMock = jest.fn();
 const wmCloseMock = jest.fn().mockResolvedValue(undefined);
 const wmConnectMock = jest.fn();
-jest.mock('worker-mailer/dist/index.mjs', () => ({
+jest.mock('worker-mailer', () => ({
   WorkerMailer: { connect: (...args: unknown[]) => wmConnectMock(...args) },
-}), { virtual: true });
+}));
 
 // --- nodemailer mock (Node / `next dev` path) ---
 const nmSendMailMock = jest.fn();

--- a/frontend/src/lib/email/sendBulk.ts
+++ b/frontend/src/lib/email/sendBulk.ts
@@ -141,13 +141,16 @@ export async function sendBulkEmail({
   if (toSend.length === 0) return { sent: 0, failed: 0, skipped, errors: [] };
 
   if (isWorkersRuntime()) {
-    // Import the ESM build explicitly. worker-mailer's `main` (CJS) does
-    // `require("cloudflare:sockets")`, which esbuild emits as a CJS require that
-    // throws "Dynamic require of cloudflare:sockets is not supported" at runtime
-    // on workerd. The `.mjs` build uses a static `import` that workerd resolves
-    // natively (paired with the cloudflare:sockets esbuild external, see
-    // patches/@opennextjs+cloudflare). Lazy so it stays out of the Node build.
-    const { WorkerMailer } = await import('worker-mailer/dist/index.mjs');
+    // Import the package root (not a subpath). worker-mailer is in
+    // `serverExternalPackages`, so OpenNext copies it out and registers it as a
+    // runtime module — but only the package entry, not arbitrary subpaths (a
+    // `/dist/index.mjs` subpath import resolves to an unregistered module id and
+    // throws "No such module" at runtime). A `patches/worker-mailer` patch adds an
+    // `exports` map so the entry resolves to the ESM `.mjs` build, whose static
+    // `import { connect } from "cloudflare:sockets"` workerd resolves natively
+    // (vs the CJS build's `require`, which throws). Lazy so it stays out of the
+    // Node build's module graph (Node uses the nodemailer branch below).
+    const { WorkerMailer } = await import('worker-mailer');
     const mailer = await WorkerMailer.connect({
       host: config.host,
       port: config.port,


### PR DESCRIPTION
## Problem (3rd send error in the chain)

```
[messages/send] sendBulkEmail failed:
Error: Failed to load external module worker-mailer-…/dist/index.mjs:
       No such module "worker-mailer-…/dist/index.mjs".
```

v1.1.2 put worker-mailer in `serverExternalPackages` and imported the `/dist/index.mjs` **subpath**. OpenNext registers the package **entry** as a runtime module but not arbitrary subpaths, so the hashed subpath id was never registered → 500 at runtime.

## Fix

- Import the package **root** (`worker-mailer`) — OpenNext's supported external case.
- Add `patches/worker-mailer` `exports` map so the entry resolves to the **ESM** `.mjs` build (static `import { connect } from "cloudflare:sockets"`, which workerd resolves; the CJS build's `require` is what threw earlier).

## Verification (and its limit)

- OpenNext build succeeds; the reference is now the **root** id `a.y("worker-mailer-…")` (no subpath), and the copied module is the ESM build with `import{connect}from"cloudflare:sockets"`.
- typecheck + email tests pass.
- ⚠️ **Runtime resolution can't be tested locally** — workerd requires macOS 13.5+ and this dev machine is 12.6. If this still 500s with "No such module", the durable fix is the Supabase Edge Function approach.

PATCH release **v1.1.4**.