### PR TITLE
feat(email): No-prediction and Unpaid broadcast segments (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the function's secrets (`supabase secrets set ...`); the Worker now needs `BROADCAST_SHARED_SECRET`,
   and the function must be deployed (`supabase functions deploy send-broadcast`). (#221)
 
+## [1.3.0] - 2026-06-10
+
+### Added
+
+- Admin broadcast email: two more recipient segments alongside **All users** and **Paid** —
+  **No prediction** (users with no prediction in the active tournament) and **Prediction, unpaid**
+  (users with a prediction but no payment). The four segments partition the user base, so admins can
+  target non-participants and unpaid participants directly. Migration `0064` adds an
+  `admin_list_recipient_emails(p_segment text)` overload (`all|paid|unpaid|no_prediction`); the
+  recipients/send API and the Messages UI switch from a boolean `paidOnly` to the `segment` selector.
+  (#222)
+
 ## [1.2.0] - 2026-06-10
 
 ### Changed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/admin/messages/AdminMessages.tsx
+++ b/frontend/src/app/admin/messages/AdminMessages.tsx
@@ -22,11 +22,17 @@ import {
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
-type Scope = 'all' | 'paid';
+const SEGMENTS = [
+  { key: 'all', label: 'All users' },
+  { key: 'no_prediction', label: 'No prediction' },
+  { key: 'unpaid', label: 'Prediction, unpaid' },
+  { key: 'paid', label: 'Paid' },
+] as const;
+type Segment = (typeof SEGMENTS)[number]['key'];
 
 interface RecipientsResponse {
   count: number;
-  paidOnly: boolean;
+  segment: Segment;
 }
 
 interface SendResponse {
@@ -44,16 +50,16 @@ async function readError(res: Response): Promise<string> {
 export function AdminMessages() {
   const [subject, setSubject] = React.useState('');
   const [html, setHtml] = React.useState('');
-  const [scope, setScope] = React.useState<Scope>('all');
+  const [segment, setSegment] = React.useState<Segment>('all');
   const [confirmOpen, setConfirmOpen] = React.useState(false);
   const [sending, setSending] = React.useState(false);
 
-  const paidOnly = scope === 'paid';
+  const segmentLabel = SEGMENTS.find((s) => s.key === segment)?.label ?? 'All users';
 
   const recipients = useQuery<RecipientsResponse>({
-    queryKey: ['admin-message-recipients', paidOnly],
+    queryKey: ['admin-message-recipients', segment],
     queryFn: async () => {
-      const res = await fetch(`/api/admin/messages/recipients?paidOnly=${paidOnly}`);
+      const res = await fetch(`/api/admin/messages/recipients?segment=${segment}`);
       if (!res.ok) throw new Error(await readError(res));
       return res.json();
     },
@@ -68,7 +74,7 @@ export function AdminMessages() {
       const res = await fetch('/api/admin/messages/send', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ subject, html, paidOnly, test }),
+        body: JSON.stringify({ subject, html, segment, test }),
       });
       if (!res.ok) throw new Error(await readError(res));
       const data = (await res.json()) as SendResponse;
@@ -129,23 +135,18 @@ export function AdminMessages() {
 
             <div className="space-y-1.5">
               <Label>Recipients</Label>
-              <div className="flex gap-2">
-                <Button
-                  type="button"
-                  variant={scope === 'all' ? 'default' : 'outline'}
-                  size="sm"
-                  onClick={() => setScope('all')}
-                >
-                  All users
-                </Button>
-                <Button
-                  type="button"
-                  variant={scope === 'paid' ? 'default' : 'outline'}
-                  size="sm"
-                  onClick={() => setScope('paid')}
-                >
-                  Paid users only
-                </Button>
+              <div className="flex flex-wrap gap-2">
+                {SEGMENTS.map((s) => (
+                  <Button
+                    key={s.key}
+                    type="button"
+                    variant={segment === s.key ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setSegment(s.key)}
+                  >
+                    {s.label}
+                  </Button>
+                ))}
               </div>
               <p className="text-muted-foreground text-xs">
                 {recipients.isLoading
@@ -204,8 +205,8 @@ export function AdminMessages() {
           <DialogHeader>
             <DialogTitle>Send broadcast?</DialogTitle>
             <DialogDescription>
-              This will email &quot;{subject}&quot; to {recipientCount}{' '}
-              {scope === 'paid' ? 'paid ' : ''}recipient{recipientCount === 1 ? '' : 's'}. This
+              This will email &quot;{subject}&quot; to {recipientCount} recipient
+              {recipientCount === 1 ? '' : 's'} in the <strong>{segmentLabel}</strong> group. This
               cannot be undone.
             </DialogDescription>
           </DialogHeader>

--- a/frontend/src/app/admin/messages/__tests__/AdminMessages.test.tsx
+++ b/frontend/src/app/admin/messages/__tests__/AdminMessages.test.tsx
@@ -19,7 +19,7 @@ jest.mock('sonner', () => ({
 import { AdminMessages } from '../AdminMessages';
 
 function mockRecipients(count: number) {
-  mockUseQuery.mockReturnValue({ data: { count, paidOnly: false }, isLoading: false, isError: false });
+  mockUseQuery.mockReturnValue({ data: { count, segment: 'all' }, isLoading: false, isError: false });
 }
 
 const fetchMock = jest.fn();
@@ -46,12 +46,12 @@ describe('AdminMessages', () => {
     expect(iframe.getAttribute('sandbox')).toBe('');
   });
 
-  it('refetches the count with paidOnly=true when switching scope', async () => {
+  it('refetches the count with the chosen segment when switching recipients', async () => {
     mockRecipients(5);
     render(<AdminMessages />);
-    await userEvent.click(screen.getByRole('button', { name: /paid users only/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Prediction, unpaid' }));
     const lastCall = mockUseQuery.mock.calls.at(-1)?.[0] as { queryKey: unknown[] };
-    expect(lastCall.queryKey).toEqual(['admin-message-recipients', true]);
+    expect(lastCall.queryKey).toEqual(['admin-message-recipients', 'unpaid']);
   });
 
   it('shows a confirm dialog before a real broadcast, then sends with test:false', async () => {

--- a/frontend/src/app/api/admin/messages/recipients/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/messages/recipients/__tests__/route.test.ts
@@ -46,31 +46,37 @@ describe('GET /api/admin/messages/recipients', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns the recipient count for all users', async () => {
+  it('defaults to the "all" segment and returns the count', async () => {
     supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
     mockAdminProfile(true);
     supabaseMock.rpc.mockResolvedValue({
       data: [{ email: 'a@x.com' }, { email: 'b@x.com' }],
       error: null,
     });
-    const res = await GET(req('?paidOnly=false'));
+    const res = await GET(req());
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ count: 2, paidOnly: false });
-    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_list_recipient_emails', {
-      p_paid_only: false,
-    });
+    expect(body).toEqual({ count: 2, segment: 'all' });
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_list_recipient_emails', { p_segment: 'all' });
   });
 
-  it('passes paidOnly=true through to the RPC', async () => {
+  it.each(['paid', 'unpaid', 'no_prediction'])('passes the %s segment to the RPC', async (segment) => {
     supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
     mockAdminProfile(true);
     supabaseMock.rpc.mockResolvedValue({ data: [{ email: 'a@x.com' }], error: null });
-    const res = await GET(req('?paidOnly=true'));
+    const res = await GET(req(`?segment=${segment}`));
     const body = await res.json();
-    expect(body).toEqual({ count: 1, paidOnly: true });
-    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_list_recipient_emails', {
-      p_paid_only: true,
-    });
+    expect(body).toEqual({ count: 1, segment });
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_list_recipient_emails', { p_segment: segment });
+  });
+
+  it('falls back to "all" for an unknown segment', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: [], error: null });
+    const res = await GET(req('?segment=bogus'));
+    const body = await res.json();
+    expect(body.segment).toBe('all');
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_list_recipient_emails', { p_segment: 'all' });
   });
 });

--- a/frontend/src/app/api/admin/messages/recipients/route.ts
+++ b/frontend/src/app/api/admin/messages/recipients/route.ts
@@ -2,17 +2,24 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
 import { safeMessage } from '@/lib/api/errors';
 
+export const RECIPIENT_SEGMENTS = ['all', 'paid', 'unpaid', 'no_prediction'] as const;
+export type RecipientSegment = (typeof RECIPIENT_SEGMENTS)[number];
+
+export function normalizeSegment(value: string | null | undefined): RecipientSegment {
+  return RECIPIENT_SEGMENTS.includes(value as RecipientSegment) ? (value as RecipientSegment) : 'all';
+}
+
 // Returns the recipient count for the admin broadcast confirm dialog.
-// ?paidOnly=true restricts to users with a paid entry in the active tournament.
+// ?segment=all|paid|unpaid|no_prediction (scoped to the active tournament).
 export async function GET(request: NextRequest) {
   const ctx = await requireAdmin();
   if (isAdminGateError(ctx)) return ctx.response;
 
   const { searchParams } = new URL(request.url);
-  const paidOnly = searchParams.get('paidOnly') === 'true';
+  const segment = normalizeSegment(searchParams.get('segment'));
 
   const { data, error } = await ctx.supabase.rpc('admin_list_recipient_emails', {
-    p_paid_only: paidOnly,
+    p_segment: segment,
   });
 
   if (error) {
@@ -20,5 +27,5 @@ export async function GET(request: NextRequest) {
   }
 
   const rows = (data ?? []) as Array<{ email: string }>;
-  return NextResponse.json({ count: rows.length, paidOnly });
+  return NextResponse.json({ count: rows.length, segment });
 }

--- a/frontend/src/app/api/admin/messages/send/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/messages/send/__tests__/route.test.ts
@@ -96,12 +96,12 @@ describe('POST /api/admin/messages/send', () => {
       error: null,
     });
     sendBulkEmailMock.mockResolvedValue({ sent: 2, failed: 0, skipped: 0, errors: [] });
-    const res = await POST(postReq({ subject: 'Hi', html: '<p>x</p>', paidOnly: true }));
+    const res = await POST(postReq({ subject: 'Hi', html: '<p>x</p>', segment: 'unpaid' }));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toMatchObject({ sent: 2, test: false });
     expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_list_recipient_emails', {
-      p_paid_only: true,
+      p_segment: 'unpaid',
     });
     expect(sendBulkEmailMock).toHaveBeenCalledWith(
       expect.objectContaining({ recipients: ['a@x.com', 'b@x.com'] })

--- a/frontend/src/app/api/admin/messages/send/route.ts
+++ b/frontend/src/app/api/admin/messages/send/route.ts
@@ -2,12 +2,13 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
 import { safeMessage } from '@/lib/api/errors';
 import { sendBulkEmail } from '@/lib/email/sendBulk';
+import { normalizeSegment } from '../recipients/route';
 
 const MAX_SUBJECT_LENGTH = 200;
 const MAX_HTML_LENGTH = 200_000;
 
 // Sends a broadcast email. test:true delivers only to the calling admin;
-// test:false fetches recipients (all users, or paid-only) and sends to each.
+// test:false fetches recipients for the chosen segment and sends to each.
 export async function POST(request: NextRequest) {
   const ctx = await requireAdmin();
   if (isAdminGateError(ctx)) return ctx.response;
@@ -15,13 +16,13 @@ export async function POST(request: NextRequest) {
   const body = (await request.json().catch(() => ({}))) as {
     subject?: string;
     html?: string;
-    paidOnly?: boolean;
+    segment?: string;
     test?: boolean;
   };
 
   const subject = typeof body.subject === 'string' ? body.subject.trim() : '';
   const html = typeof body.html === 'string' ? body.html : '';
-  const paidOnly = body.paidOnly === true;
+  const segment = normalizeSegment(body.segment);
   const test = body.test === true;
 
   if (!subject || subject.length > MAX_SUBJECT_LENGTH) {
@@ -46,7 +47,7 @@ export async function POST(request: NextRequest) {
     recipients = [ctx.user.email];
   } else {
     const { data, error } = await ctx.supabase.rpc('admin_list_recipient_emails', {
-      p_paid_only: paidOnly,
+      p_segment: segment,
     });
     if (error) {
       return NextResponse.json({ error: safeMessage(error) }, { status: 500 });

--- a/supabase/migrations/0064_recipient_segments.sql
+++ b/supabase/migrations/0064_recipient_segments.sql
@@ -1,0 +1,68 @@
+-- Migration 0064: recipient segments for the admin broadcast-email tool
+--
+-- Extends 0063 (which only had all / paid-only) with two more mailing segments
+-- so admins can nudge non-participants and unpaid participants:
+--   'all'            — every registered user with an email
+--   'paid'           — >=1 prediction with a payment in the active tournament
+--   'unpaid'         — >=1 prediction in the active tournament, but none paid
+--   'no_prediction'  — no predictions in the active tournament
+-- Together these partition the user base (no_prediction + unpaid + paid = all).
+--
+-- Added as a NEW overload `(p_segment text)` rather than replacing the existing
+-- `(p_paid_only boolean)` so the deployed Worker keeps working until the new
+-- code ships (zero-downtime). The boolean overload is now superseded and can be
+-- dropped in a later cleanup migration.
+
+create or replace function public.admin_list_recipient_emails(p_segment text)
+returns table (email text)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid;
+    v_segment text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    v_segment := lower(coalesce(nullif(trim(p_segment), ''), 'all'));
+
+    select t.id into v_tournament_id from public.tournaments t where t.is_active limit 1;
+
+    return query
+    select distinct u.email::text as email
+    from public.profiles p
+    join auth.users u on u.id = p.id
+    where u.email is not null
+      and btrim(u.email::text) <> ''
+      and (
+        case v_segment
+          when 'paid' then exists (
+            select 1
+            from public.predictions pr
+            join public.tournament_payments tp on tp.prediction_id = pr.id
+            where pr.user_id = p.id and pr.tournament_id = v_tournament_id
+          )
+          when 'unpaid' then exists (
+            select 1 from public.predictions pr
+            where pr.user_id = p.id and pr.tournament_id = v_tournament_id
+          ) and not exists (
+            select 1
+            from public.predictions pr
+            join public.tournament_payments tp on tp.prediction_id = pr.id
+            where pr.user_id = p.id and pr.tournament_id = v_tournament_id
+          )
+          when 'no_prediction' then not exists (
+            select 1 from public.predictions pr
+            where pr.user_id = p.id and pr.tournament_id = v_tournament_id
+          )
+          else true -- 'all'
+        end
+      )
+    order by email;
+end;
+$$;
+
+grant execute on function public.admin_list_recipient_emails(text) to authenticated;


### PR DESCRIPTION
## What

Adds two recipient segments to the admin broadcast tool, alongside **All users** and **Paid**:
- **No prediction** — users with no prediction in the active tournament
- **Prediction, unpaid** — users with a prediction but no payment

The four segments **partition** the user base (`no_prediction + unpaid + paid = all`), so admins can target non-participants and unpaid participants directly.

## How

- Migration `0064` adds an `admin_list_recipient_emails(p_segment text)` overload (`all|paid|unpaid|no_prediction`), scoped to the active tournament. **Additive** — the old boolean overload is kept so the deployed v1.2.0 Worker keeps working (zero-downtime).
- The recipients + send API move from a boolean `paidOnly` to a validated `segment` param; the Messages UI replaces the 2-button toggle with a 4-segment selector and reflects the segment in the confirm dialog.

## Verification

- Segment logic checked against local data: all=11, paid=1, unpaid=7, no_prediction=3 (partitions cleanly).
- Full suite (507), typecheck, lint green.

## Deploy note

Apply migration `0064` to prod (`supabase db push`) — ideally before/around merge. It's additive, so applying it early won't break the running v1.2.0 Worker.

MINOR release **v1.3.0** (`### Added`).