### PR TITLE
feat(email): radio recipient selector + Specific user option (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the function's secrets (`supabase secrets set ...`); the Worker now needs `BROADCAST_SHARED_SECRET`,
   and the function must be deployed (`supabase functions deploy send-broadcast`). (#221)
 
+## [1.4.0] - 2026-06-10
+
+### Added
+
+- Admin broadcast email: a **"Specific user"** recipient option to address a single user. Selecting
+  it reveals a searchable user picker (search by name/email, debounced, backed by `/api/admin/users`);
+  the chosen user's email is the sole recipient. The send route validates the address (admin-gated).
+
+### Changed
+
+- Admin broadcast recipient selection is now a **radio group** (one option per line) instead of a row
+  of toggle buttons, and includes the new "Specific user" choice. Adds `@radix-ui/react-radio-group`
+  and a shadcn `RadioGroup` component. (#223)
+
 ## [1.3.0] - 2026-06-10
 
 ### Added

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "frontend",
-  "version": "1.1.4",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.1.4",
+      "version": "1.3.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-navigation-menu": "^1.2.14",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-radio-group": "^1.4.0",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -5192,6 +5193,328 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.0.tgz",
+      "integrity": "sha512-eHdV5bLx9sH+tBnbDjkIBdvQEH/c6MEtQYhTbxkaDK9qsIFFLtmJYEQFVdwhnruWotLfQmIuWEL/J+L3utE8rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.9.tgz",
+      "integrity": "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.12.tgz",
+      "integrity": "sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+      "integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -22,6 +22,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-radio-group": "^1.4.0",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/frontend/src/app/admin/messages/AdminMessages.tsx
+++ b/frontend/src/app/admin/messages/AdminMessages.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { Loader2, Mail, Send } from 'lucide-react';
+import { Loader2, Mail, Send, X } from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { AdminNav } from '@/components/admin/AdminNav';
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import {
   Dialog,
   DialogContent,
@@ -22,11 +23,14 @@ import {
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
+// 'user' is a UI-only option (a single hand-picked recipient); the other four
+// map to the admin_list_recipient_emails segments.
 const SEGMENTS = [
   { key: 'all', label: 'All users' },
   { key: 'no_prediction', label: 'No prediction' },
   { key: 'unpaid', label: 'Prediction, unpaid' },
   { key: 'paid', label: 'Paid' },
+  { key: 'user', label: 'Specific user' },
 ] as const;
 type Segment = (typeof SEGMENTS)[number]['key'];
 
@@ -42,6 +46,12 @@ interface SendResponse {
   test: boolean;
 }
 
+interface PickUser {
+  id: string;
+  username: string;
+  email: string;
+}
+
 async function readError(res: Response): Promise<string> {
   const body = (await res.json().catch(() => ({}))) as { error?: string };
   return body.error ?? 'Failed';
@@ -54,10 +64,22 @@ export function AdminMessages() {
   const [confirmOpen, setConfirmOpen] = React.useState(false);
   const [sending, setSending] = React.useState(false);
 
+  // Single-user picker state.
+  const [userSearch, setUserSearch] = React.useState('');
+  const [debouncedUserSearch, setDebouncedUserSearch] = React.useState('');
+  const [selectedUser, setSelectedUser] = React.useState<PickUser | null>(null);
+
+  React.useEffect(() => {
+    const t = setTimeout(() => setDebouncedUserSearch(userSearch), 250);
+    return () => clearTimeout(t);
+  }, [userSearch]);
+
+  const isSingle = segment === 'user';
   const segmentLabel = SEGMENTS.find((s) => s.key === segment)?.label ?? 'All users';
 
   const recipients = useQuery<RecipientsResponse>({
     queryKey: ['admin-message-recipients', segment],
+    enabled: !isSingle,
     queryFn: async () => {
       const res = await fetch(`/api/admin/messages/recipients?segment=${segment}`);
       if (!res.ok) throw new Error(await readError(res));
@@ -65,7 +87,20 @@ export function AdminMessages() {
     },
   });
 
-  const recipientCount = recipients.data?.count ?? 0;
+  const usersQuery = useQuery<{ users: Array<{ id: string; username: string; email: string | null }> }>({
+    queryKey: ['admin-message-users', debouncedUserSearch],
+    enabled: isSingle && !selectedUser,
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/admin/users?search=${encodeURIComponent(debouncedUserSearch)}&page=1&pageSize=8`
+      );
+      if (!res.ok) throw new Error(await readError(res));
+      return res.json();
+    },
+  });
+  const userResults = (usersQuery.data?.users ?? []).filter((u): u is PickUser => Boolean(u.email));
+
+  const recipientCount = isSingle ? (selectedUser ? 1 : 0) : (recipients.data?.count ?? 0);
   const canCompose = subject.trim().length > 0 && html.trim().length > 0;
 
   const send = async (test: boolean) => {
@@ -74,7 +109,13 @@ export function AdminMessages() {
       const res = await fetch('/api/admin/messages/send', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ subject, html, segment, test }),
+        body: JSON.stringify({
+          subject,
+          html,
+          segment,
+          email: isSingle ? selectedUser?.email : undefined,
+          test,
+        }),
       });
       if (!res.ok) throw new Error(await readError(res));
       const data = (await res.json()) as SendResponse;
@@ -133,27 +174,82 @@ export function AdminMessages() {
               </p>
             </div>
 
-            <div className="space-y-1.5">
+            <div className="space-y-2">
               <Label>Recipients</Label>
-              <div className="flex flex-wrap gap-2">
+              <RadioGroup value={segment} onValueChange={(v) => setSegment(v as Segment)}>
                 {SEGMENTS.map((s) => (
-                  <Button
-                    key={s.key}
-                    type="button"
-                    variant={segment === s.key ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => setSegment(s.key)}
-                  >
-                    {s.label}
-                  </Button>
+                  <div key={s.key} className="flex items-center gap-2">
+                    <RadioGroupItem value={s.key} id={`seg-${s.key}`} />
+                    <Label htmlFor={`seg-${s.key}`} className="cursor-pointer font-normal">
+                      {s.label}
+                    </Label>
+                  </div>
                 ))}
-              </div>
+              </RadioGroup>
+
+              {/* Single-user picker */}
+              {isSingle && (
+                <div className="space-y-2 pt-1">
+                  {selectedUser ? (
+                    <div className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+                      <span className="truncate">
+                        <span className="font-medium">{selectedUser.username}</span>
+                        <span className="text-muted-foreground"> · {selectedUser.email}</span>
+                      </span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setSelectedUser(null)}
+                      >
+                        <X className="h-4 w-4" /> Change
+                      </Button>
+                    </div>
+                  ) : (
+                    <>
+                      <Input
+                        aria-label="Search users"
+                        placeholder="Search users by name or email"
+                        value={userSearch}
+                        onChange={(e) => setUserSearch(e.target.value)}
+                      />
+                      <div className="max-h-48 overflow-auto rounded-md border">
+                        {usersQuery.isLoading ? (
+                          <p className="text-muted-foreground p-2 text-sm">Searching…</p>
+                        ) : userResults.length === 0 ? (
+                          <p className="text-muted-foreground p-2 text-sm">No users found.</p>
+                        ) : (
+                          userResults.map((u) => (
+                            <button
+                              key={u.id}
+                              type="button"
+                              onClick={() => {
+                                setSelectedUser(u);
+                                setUserSearch('');
+                              }}
+                              className="hover:bg-accent flex w-full flex-col items-start px-3 py-1.5 text-left text-sm"
+                            >
+                              <span className="font-medium">{u.username}</span>
+                              <span className="text-muted-foreground text-xs">{u.email}</span>
+                            </button>
+                          ))
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+
               <p className="text-muted-foreground text-xs">
-                {recipients.isLoading
-                  ? 'Counting recipients…'
-                  : recipients.isError
-                    ? 'Could not load recipient count.'
-                    : `${recipientCount} recipient${recipientCount === 1 ? '' : 's'}.`}
+                {isSingle
+                  ? selectedUser
+                    ? `1 recipient — ${selectedUser.email}`
+                    : 'Select a user above.'
+                  : recipients.isLoading
+                    ? 'Counting recipients…'
+                    : recipients.isError
+                      ? 'Could not load recipient count.'
+                      : `${recipientCount} recipient${recipientCount === 1 ? '' : 's'}.`}
               </p>
             </div>
 
@@ -205,9 +301,18 @@ export function AdminMessages() {
           <DialogHeader>
             <DialogTitle>Send broadcast?</DialogTitle>
             <DialogDescription>
-              This will email &quot;{subject}&quot; to {recipientCount} recipient
-              {recipientCount === 1 ? '' : 's'} in the <strong>{segmentLabel}</strong> group. This
-              cannot be undone.
+              {isSingle ? (
+                <>
+                  This will email &quot;{subject}&quot; to <strong>{selectedUser?.email}</strong>.
+                  This cannot be undone.
+                </>
+              ) : (
+                <>
+                  This will email &quot;{subject}&quot; to {recipientCount} recipient
+                  {recipientCount === 1 ? '' : 's'} in the <strong>{segmentLabel}</strong> group.
+                  This cannot be undone.
+                </>
+              )}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/frontend/src/app/admin/messages/__tests__/AdminMessages.test.tsx
+++ b/frontend/src/app/admin/messages/__tests__/AdminMessages.test.tsx
@@ -18,8 +18,24 @@ jest.mock('sonner', () => ({
 
 import { AdminMessages } from '../AdminMessages';
 
-function mockRecipients(count: number) {
-  mockUseQuery.mockReturnValue({ data: { count, segment: 'all' }, isLoading: false, isError: false });
+type QueryUser = { id: string; username: string; email: string };
+
+// The component runs two useQuery calls (recipient count + user search); return
+// the right shape per queryKey.
+function mockRecipients(count: number, users: QueryUser[] = []) {
+  mockUseQuery.mockImplementation((opts: { queryKey: unknown[] }) => {
+    if (opts.queryKey[0] === 'admin-message-users') {
+      return { data: { users }, isLoading: false, isError: false };
+    }
+    return { data: { count, segment: 'all' }, isLoading: false, isError: false };
+  });
+}
+
+function lastRecipientsQueryKey(): unknown[] {
+  const calls = mockUseQuery.mock.calls.filter(
+    (c) => (c[0] as { queryKey: unknown[] }).queryKey[0] === 'admin-message-recipients'
+  );
+  return (calls.at(-1)?.[0] as { queryKey: unknown[] }).queryKey;
 }
 
 const fetchMock = jest.fn();
@@ -46,12 +62,35 @@ describe('AdminMessages', () => {
     expect(iframe.getAttribute('sandbox')).toBe('');
   });
 
-  it('refetches the count with the chosen segment when switching recipients', async () => {
+  it('refetches the count with the chosen segment when switching the radio', async () => {
     mockRecipients(5);
     render(<AdminMessages />);
-    await userEvent.click(screen.getByRole('button', { name: 'Prediction, unpaid' }));
-    const lastCall = mockUseQuery.mock.calls.at(-1)?.[0] as { queryKey: unknown[] };
-    expect(lastCall.queryKey).toEqual(['admin-message-recipients', 'unpaid']);
+    await userEvent.click(screen.getByRole('radio', { name: 'Prediction, unpaid' }));
+    expect(lastRecipientsQueryKey()).toEqual(['admin-message-recipients', 'unpaid']);
+  });
+
+  it('picks a specific user and sends to just that email', async () => {
+    mockRecipients(0, [{ id: 'u9', username: 'charlie', email: 'charlie@x.com' }]);
+    render(<AdminMessages />);
+    await userEvent.type(screen.getByLabelText(/subject/i), 'Hi');
+    await userEvent.type(screen.getByLabelText(/message body/i), '<p>hi</p>');
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Specific user' }));
+    // pick the user from the results list
+    await userEvent.click(screen.getByRole('button', { name: /charlie/i }));
+
+    await userEvent.click(screen.getByRole('button', { name: /send to 1 recipient/i }));
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/charlie@x\.com/)).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole('button', { name: /send now/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const sendCall = fetchMock.mock.calls.find((c) => c[0] === '/api/admin/messages/send');
+    expect(JSON.parse((sendCall![1] as RequestInit).body as string)).toMatchObject({
+      segment: 'user',
+      email: 'charlie@x.com',
+      test: false,
+    });
   });
 
   it('shows a confirm dialog before a real broadcast, then sends with test:false', async () => {

--- a/frontend/src/app/api/admin/messages/send/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/messages/send/__tests__/route.test.ts
@@ -117,6 +117,28 @@ describe('POST /api/admin/messages/send', () => {
     expect(sendBulkEmailMock).not.toHaveBeenCalled();
   });
 
+  it('segment "user" sends to the provided email and skips the RPC', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
+    mockAdminProfile(true);
+    sendBulkEmailMock.mockResolvedValue({ sent: 1, failed: 0, skipped: 0, errors: [] });
+    const res = await POST(
+      postReq({ subject: 'Hi', html: '<p>x</p>', segment: 'user', email: 'pick@x.com' })
+    );
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+    expect(sendBulkEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ recipients: ['pick@x.com'] })
+    );
+  });
+
+  it('segment "user" returns 400 when the email is missing/invalid', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({ subject: 'Hi', html: '<p>x</p>', segment: 'user', email: 'nope' }));
+    expect(res.status).toBe(400);
+    expect(sendBulkEmailMock).not.toHaveBeenCalled();
+  });
+
   it('returns 500 when sendBulkEmail throws (e.g. SMTP not configured)', async () => {
     supabaseMock.auth.getUser.mockResolvedValue({ data: { user: adminUser } });
     mockAdminProfile(true);

--- a/frontend/src/app/api/admin/messages/send/route.ts
+++ b/frontend/src/app/api/admin/messages/send/route.ts
@@ -17,11 +17,15 @@ export async function POST(request: NextRequest) {
     subject?: string;
     html?: string;
     segment?: string;
+    email?: string;
     test?: boolean;
   };
 
   const subject = typeof body.subject === 'string' ? body.subject.trim() : '';
   const html = typeof body.html === 'string' ? body.html : '';
+  // 'user' = a single hand-picked recipient (email in the body); the rest map
+  // to a recipient segment resolved server-side.
+  const isSingleUser = body.segment === 'user';
   const segment = normalizeSegment(body.segment);
   const test = body.test === true;
 
@@ -45,6 +49,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'your account has no email address' }, { status: 400 });
     }
     recipients = [ctx.user.email];
+  } else if (isSingleUser) {
+    // Admin-picked single recipient. The caller is an authenticated admin (who
+    // can already see every user's email), so we trust the address and only
+    // validate its shape.
+    const email = typeof body.email === 'string' ? body.email.trim() : '';
+    if (!email || !email.includes('@') || email.length > 254) {
+      return NextResponse.json({ error: 'a valid recipient email is required' }, { status: 400 });
+    }
+    recipients = [email];
   } else {
     const { data, error } = await ctx.supabase.rpc('admin_list_recipient_emails', {
       p_segment: segment,

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import * as React from 'react';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { Circle } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Root className={cn('grid gap-2', className)} {...props} ref={ref} />
+));
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      'border-primary text-primary focus-visible:ring-ring aspect-square h-4 w-4 rounded-full border shadow focus:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <Circle className="h-3.5 w-3.5 fill-primary" />
+    </RadioGroupPrimitive.Indicator>
+  </RadioGroupPrimitive.Item>
+));
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };


### PR DESCRIPTION
## What

- Recipient selection is now a **radio group** (one option per line) instead of toggle buttons.
- New **"Specific user"** option: a searchable picker (by name/email, via `/api/admin/users`) to address a **single** user. The send route sends to just that validated email (admin-gated).

## Notes

- No DB change — the four segments already ship in `0064`; single-user needs no migration.
- Adds `@radix-ui/react-radio-group` + a shadcn `RadioGroup` component.

## Verification

Verified locally end-to-end on dev (radio switching updates counts; user search → pick → real send arrived in Mailpit). Typecheck, lint, full suite (510) green.

MINOR release **v1.4.0** (`### Added` + `### Changed`). Prod: Worker deploy only — no migration, no new secrets.