### PR TITLE
feat(referrals): super-admin tool to set custom vanity referral codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-06-10
+
+### Added
+
+- Custom (vanity) referral codes: a super-admin can overwrite any user's auto-generated referral
+  code with a recognizable one — e.g. an influencer's handle. A super-admin-only **"Referral code"**
+  section in the **Edit user** dialog (admin users list) sets it via a new gated
+  `admin_set_referral_code` RPC (format-validated `^[A-Z0-9]{4,32}$`, case-insensitive uniqueness,
+  written to the referral admin audit trail). The signup referral validation (`REFERRAL_CODE_REGEX`)
+  was widened to 4–32 chars over `A–Z`/`0–9` so vanity deep-links (`/register?ref=…`) resolve
+  end-to-end through the existing validate + signup paths. (#224)
+
 ## [1.2.0] - 2026-06-09
 
 ### Changed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/admin/users/AdminUsersList.tsx
+++ b/frontend/src/app/admin/users/AdminUsersList.tsx
@@ -31,7 +31,12 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { useAuthContext } from '@/providers/AuthProvider';
-import { EMAIL_REGEX, PASSWORD_MIN_LENGTH, USERNAME_REGEX } from '@/lib/constants';
+import {
+  EMAIL_REGEX,
+  PASSWORD_MIN_LENGTH,
+  REFERRAL_CODE_REGEX,
+  USERNAME_REGEX,
+} from '@/lib/constants';
 
 interface AdminUser {
   id: string;
@@ -61,7 +66,7 @@ async function readError(res: Response): Promise<string> {
 
 export function AdminUsersList() {
   const queryClient = useQueryClient();
-  const { user: currentUser } = useAuthContext();
+  const { user: currentUser, profile } = useAuthContext();
   const [search, setSearch] = React.useState('');
   const [debounced, setDebounced] = React.useState('');
   const [page, setPage] = React.useState(1);
@@ -275,6 +280,7 @@ export function AdminUsersList() {
       />
       <EditUserDialog
         target={editTarget}
+        canEditReferralCode={!!profile?.isSuperAdmin}
         onOpenChange={(open) => !open && setEditTarget(null)}
         onSaved={refetchUsers}
       />
@@ -436,10 +442,12 @@ function CreateUserDialog({
 
 function EditUserDialog({
   target,
+  canEditReferralCode,
   onOpenChange,
   onSaved,
 }: {
   target: AdminUser | null;
+  canEditReferralCode: boolean;
   onOpenChange: (open: boolean) => void;
   onSaved: () => void;
 }) {
@@ -547,8 +555,112 @@ function EditUserDialog({
             </Button>
           </DialogFooter>
         </form>
+        {canEditReferralCode && target && (
+          <ReferralCodeSection userId={target.id} open={open} />
+        )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+// Super-admin-only referral-code override, shown inside the Edit user dialog.
+// Independent of the username form (its own Save), so it never piggybacks on
+// the profile PATCH. The PATCH route's coarse gate is is_admin; the super-admin
+// requirement is enforced in the admin_set_referral_code RPC.
+function ReferralCodeSection({ userId, open }: { userId: string; open: boolean }) {
+  const query = useQuery<{ overview: { referralCode: string | null } }>({
+    queryKey: ['admin-referral-code', userId],
+    enabled: open,
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/referrals?userId=${userId}`);
+      if (!res.ok) throw new Error('Failed to load referral code');
+      return res.json();
+    },
+  });
+  const currentCode = query.data?.overview.referralCode ?? null;
+
+  const [codeInput, setCodeInput] = React.useState('');
+  const [note, setNote] = React.useState('');
+  const [busy, setBusy] = React.useState(false);
+
+  // Seed the input with the current code once it loads (and after a save).
+  React.useEffect(() => {
+    if (currentCode) setCodeInput(currentCode);
+  }, [currentCode]);
+
+  const trimmedCode = codeInput.trim().toUpperCase();
+  const codeValid = REFERRAL_CODE_REGEX.test(trimmedCode);
+  const unchanged = currentCode != null && trimmedCode === currentCode.toUpperCase();
+  const canSave = codeValid && note.trim().length > 0 && !unchanged && !busy;
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/admin/users/${userId}/referral-code`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: trimmedCode, note: note.trim() }),
+      });
+      if (!res.ok) throw new Error(await readError(res));
+      toast.success(`Referral code set to ${trimmedCode}`);
+      setNote('');
+      await query.refetch();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-2 space-y-3 border-t pt-4">
+      <div>
+        <p className="text-sm font-medium">Referral code (super admin)</p>
+        <p className="text-muted-foreground text-xs">
+          Override the auto-generated code with a vanity code, e.g. an influencer&apos;s handle.
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-muted-foreground text-xs">Current code</Label>
+        <p className="font-mono text-sm font-medium">
+          {query.isLoading ? '…' : (currentCode ?? '—')}
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="edit-referral-code">New code (4–32 chars, A–Z and 0–9)</Label>
+        <Input
+          id="edit-referral-code"
+          value={codeInput}
+          onChange={(e) => setCodeInput(e.target.value.toUpperCase().replace(/\s+/g, ''))}
+          maxLength={32}
+          disabled={busy}
+          className="font-mono uppercase tracking-widest"
+          placeholder="e.g. GIUSEPPETHEMC"
+          aria-invalid={codeInput.length > 0 && !codeValid ? true : undefined}
+        />
+        {codeInput.length > 0 && !codeValid && (
+          <FieldError
+            id="edit-referral-code-error"
+            message="Code must be 4–32 characters, using only A–Z and 0–9."
+          />
+        )}
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="edit-referral-note">Reason (audit note, required)</Label>
+        <Input
+          id="edit-referral-note"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          disabled={busy}
+          placeholder="e.g. influencer vanity code"
+        />
+      </div>
+      <div className="flex justify-end">
+        <Button type="button" size="sm" onClick={save} disabled={!canSave}>
+          {busy ? 'Saving…' : 'Save code'}
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -24,8 +24,6 @@ import {
 } from '@/components/ui/dialog';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
 import { fetchJSON } from '@/lib/api/fetchJSON';
-import { useAuthContext } from '@/providers/AuthProvider';
-import { REFERRAL_CODE_REGEX } from '@/lib/constants';
 
 interface AdminPrediction {
   id: string;
@@ -156,113 +154,8 @@ function PaymentRow({
   );
 }
 
-// Super-admin-only tool to overwrite a user's auto-generated referral code with
-// a recognizable vanity code (e.g. an influencer's handle). The PATCH route's
-// coarse gate is is_admin; the super-admin requirement is enforced both here
-// (the card only renders for super-admins) and in the admin_set_referral_code
-// RPC (which raises 'forbidden' otherwise).
-function ReferralCodeCard({ userId }: { userId: string }) {
-  const query = useQuery<{ overview: { referralCode: string | null } }>({
-    queryKey: ['admin-referral-code', userId],
-    queryFn: () => fetchJSON(`/api/admin/referrals?userId=${userId}`),
-  });
-  const currentCode = query.data?.overview.referralCode ?? null;
-
-  const [codeInput, setCodeInput] = React.useState('');
-  const [note, setNote] = React.useState('');
-  const [busy, setBusy] = React.useState(false);
-
-  // Seed the input with the current code once it loads (and whenever it
-  // changes after a successful save).
-  React.useEffect(() => {
-    if (currentCode) setCodeInput(currentCode);
-  }, [currentCode]);
-
-  const trimmedCode = codeInput.trim().toUpperCase();
-  const codeValid = REFERRAL_CODE_REGEX.test(trimmedCode);
-  const unchanged = currentCode != null && trimmedCode === currentCode.toUpperCase();
-  const canSave = codeValid && note.trim().length > 0 && !unchanged && !busy;
-
-  const save = async () => {
-    setBusy(true);
-    try {
-      const res = await fetch(`/api/admin/users/${userId}/referral-code`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code: trimmedCode, note: note.trim() }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(String(body.error ?? 'Failed'));
-      }
-      toast.success(`Referral code set to ${trimmedCode}`);
-      setNote('');
-      await query.refetch();
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed');
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  return (
-    <Card className="mb-4">
-      <CardHeader>
-        <CardTitle className="text-base">Referral code (super-admin)</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <div>
-          <p className="text-muted-foreground text-xs uppercase tracking-wide">Current code</p>
-          <p className="font-mono text-sm font-medium">
-            {query.isLoading ? '…' : (currentCode ?? '—')}
-          </p>
-        </div>
-        <div className="flex flex-wrap items-end gap-2">
-          <div className="space-y-1">
-            <label className="text-muted-foreground text-xs" htmlFor="referral-code-input">
-              New code (4–32 chars, A–Z and 0–9)
-            </label>
-            <Input
-              id="referral-code-input"
-              value={codeInput}
-              onChange={(e) => setCodeInput(e.target.value.toUpperCase().replace(/\s+/g, ''))}
-              maxLength={32}
-              disabled={busy}
-              className="w-64 font-mono uppercase tracking-widest"
-              placeholder="e.g. GIUSEPPETHEMC"
-              aria-invalid={codeInput.length > 0 && !codeValid ? true : undefined}
-            />
-          </div>
-          <div className="space-y-1">
-            <label className="text-muted-foreground text-xs" htmlFor="referral-code-note">
-              Reason (audit note, required)
-            </label>
-            <Input
-              id="referral-code-note"
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              disabled={busy}
-              className="w-64"
-              placeholder="e.g. influencer vanity code"
-            />
-          </div>
-          <Button size="sm" onClick={save} disabled={!canSave}>
-            {busy ? 'Saving…' : 'Save code'}
-          </Button>
-        </div>
-        {codeInput.length > 0 && !codeValid && (
-          <p className="text-destructive text-xs">
-            Code must be 4–32 characters, using only A–Z and 0–9.
-          </p>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
 export function AdminUserBracket({ userId }: { userId: string }) {
   const queryClient = useQueryClient();
-  const { profile } = useAuthContext();
   const [pendingDelete, setPendingDelete] = React.useState<AdminPrediction | null>(null);
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [previewId, setPreviewId] = React.useState<string | null>(null);
@@ -372,8 +265,6 @@ export function AdminUserBracket({ userId }: { userId: string }) {
           </CardContent>
         </Card>
       )}
-
-      {profile?.isSuperAdmin && <ReferralCodeCard userId={userId} />}
 
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-semibold">User predictions</h2>

--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -24,6 +24,8 @@ import {
 } from '@/components/ui/dialog';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
 import { fetchJSON } from '@/lib/api/fetchJSON';
+import { useAuthContext } from '@/providers/AuthProvider';
+import { REFERRAL_CODE_REGEX } from '@/lib/constants';
 
 interface AdminPrediction {
   id: string;
@@ -154,8 +156,113 @@ function PaymentRow({
   );
 }
 
+// Super-admin-only tool to overwrite a user's auto-generated referral code with
+// a recognizable vanity code (e.g. an influencer's handle). The PATCH route's
+// coarse gate is is_admin; the super-admin requirement is enforced both here
+// (the card only renders for super-admins) and in the admin_set_referral_code
+// RPC (which raises 'forbidden' otherwise).
+function ReferralCodeCard({ userId }: { userId: string }) {
+  const query = useQuery<{ overview: { referralCode: string | null } }>({
+    queryKey: ['admin-referral-code', userId],
+    queryFn: () => fetchJSON(`/api/admin/referrals?userId=${userId}`),
+  });
+  const currentCode = query.data?.overview.referralCode ?? null;
+
+  const [codeInput, setCodeInput] = React.useState('');
+  const [note, setNote] = React.useState('');
+  const [busy, setBusy] = React.useState(false);
+
+  // Seed the input with the current code once it loads (and whenever it
+  // changes after a successful save).
+  React.useEffect(() => {
+    if (currentCode) setCodeInput(currentCode);
+  }, [currentCode]);
+
+  const trimmedCode = codeInput.trim().toUpperCase();
+  const codeValid = REFERRAL_CODE_REGEX.test(trimmedCode);
+  const unchanged = currentCode != null && trimmedCode === currentCode.toUpperCase();
+  const canSave = codeValid && note.trim().length > 0 && !unchanged && !busy;
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/admin/users/${userId}/referral-code`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: trimmedCode, note: note.trim() }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(String(body.error ?? 'Failed'));
+      }
+      toast.success(`Referral code set to ${trimmedCode}`);
+      setNote('');
+      await query.refetch();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card className="mb-4">
+      <CardHeader>
+        <CardTitle className="text-base">Referral code (super-admin)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <p className="text-muted-foreground text-xs uppercase tracking-wide">Current code</p>
+          <p className="font-mono text-sm font-medium">
+            {query.isLoading ? '…' : (currentCode ?? '—')}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="space-y-1">
+            <label className="text-muted-foreground text-xs" htmlFor="referral-code-input">
+              New code (4–32 chars, A–Z and 0–9)
+            </label>
+            <Input
+              id="referral-code-input"
+              value={codeInput}
+              onChange={(e) => setCodeInput(e.target.value.toUpperCase().replace(/\s+/g, ''))}
+              maxLength={32}
+              disabled={busy}
+              className="w-64 font-mono uppercase tracking-widest"
+              placeholder="e.g. GIUSEPPETHEMC"
+              aria-invalid={codeInput.length > 0 && !codeValid ? true : undefined}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-muted-foreground text-xs" htmlFor="referral-code-note">
+              Reason (audit note, required)
+            </label>
+            <Input
+              id="referral-code-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              disabled={busy}
+              className="w-64"
+              placeholder="e.g. influencer vanity code"
+            />
+          </div>
+          <Button size="sm" onClick={save} disabled={!canSave}>
+            {busy ? 'Saving…' : 'Save code'}
+          </Button>
+        </div>
+        {codeInput.length > 0 && !codeValid && (
+          <p className="text-destructive text-xs">
+            Code must be 4–32 characters, using only A–Z and 0–9.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export function AdminUserBracket({ userId }: { userId: string }) {
   const queryClient = useQueryClient();
+  const { profile } = useAuthContext();
   const [pendingDelete, setPendingDelete] = React.useState<AdminPrediction | null>(null);
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [previewId, setPreviewId] = React.useState<string | null>(null);
@@ -265,6 +372,8 @@ export function AdminUserBracket({ userId }: { userId: string }) {
           </CardContent>
         </Card>
       )}
+
+      {profile?.isSuperAdmin && <ReferralCodeCard userId={userId} />}
 
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-xl font-semibold">User predictions</h2>

--- a/frontend/src/app/api/admin/users/[id]/referral-code/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/users/[id]/referral-code/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { PATCH } = require('../route');
+
+function mockAdmin(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+function patchReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/users/u1/referral-code', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ id: 'u1' }) };
+
+beforeEach(() => {
+  supabaseMock.auth.getUser.mockReset();
+  supabaseMock.from.mockReset();
+  supabaseMock.rpc.mockReset();
+});
+
+describe('PATCH /api/admin/users/[id]/referral-code', () => {
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await PATCH(patchReq({ code: 'GIUSEPPETHEMC', note: 'vip' }), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(false);
+    const res = await PATCH(patchReq({ code: 'GIUSEPPETHEMC', note: 'vip' }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for an invalid code format before hitting the RPC', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    const res = await PATCH(patchReq({ code: 'AB', note: 'vip' }), ctx);
+    expect(res.status).toBe(400);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the note is missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    const res = await PATCH(patchReq({ code: 'GIUSEPPETHEMC', note: '  ' }), ctx);
+    expect(res.status).toBe(400);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('maps the RPC super-admin gate to 403', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockResolvedValue({ error: { message: 'forbidden' } });
+    const res = await PATCH(patchReq({ code: 'GIUSEPPETHEMC', note: 'vip' }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('maps user-not-found to 404', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockResolvedValue({ error: { message: 'user not found' } });
+    const res = await PATCH(patchReq({ code: 'GIUSEPPETHEMC', note: 'vip' }), ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it('maps code-already-in-use to 409', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockResolvedValue({ error: { message: 'code already in use' } });
+    const res = await PATCH(patchReq({ code: 'GIUSEPPETHEMC', note: 'vip' }), ctx);
+    expect(res.status).toBe(409);
+  });
+
+  it('uppercases the code and calls the RPC on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'a' } } });
+    mockAdmin(true);
+    supabaseMock.rpc.mockResolvedValue({ error: null });
+    const res = await PATCH(patchReq({ code: 'giuseppethemc', note: 'vip influencer' }), ctx);
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_set_referral_code', {
+      p_user_id: 'u1',
+      p_code: 'GIUSEPPETHEMC',
+      p_note: 'vip influencer',
+    });
+    const json = await res.json();
+    expect(json.code).toBe('GIUSEPPETHEMC');
+  });
+});

--- a/frontend/src/app/api/admin/users/[id]/referral-code/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/referral-code/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+import { REFERRAL_CODE_REGEX } from '@/lib/constants';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// PATCH /api/admin/users/[id]/referral-code
+// Sets a user's referral code to a custom vanity value. The coarse is_admin
+// gate happens here; the super-admin requirement is enforced inside the
+// admin_set_referral_code RPC (which raises 'forbidden' otherwise).
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+  const { id: userId } = await context.params;
+
+  const body = (await request.json()) as { code?: string; note?: string };
+  const code = body.code?.trim().toUpperCase() ?? '';
+  const note = body.note?.trim() ?? '';
+
+  if (!REFERRAL_CODE_REGEX.test(code)) {
+    return NextResponse.json({ error: 'invalid code format' }, { status: 400 });
+  }
+  if (!note) {
+    return NextResponse.json({ error: 'note is required' }, { status: 400 });
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_set_referral_code', {
+    p_user_id: userId,
+    p_code: code,
+    p_note: note,
+  });
+
+  if (error) {
+    const msg = (error.message ?? '').toLowerCase();
+    const status = msg.includes('forbidden')
+      ? 403
+      : msg.includes('user not found') || msg.includes('row missing')
+        ? 404
+        : msg.includes('already in use')
+          ? 409
+          : 400;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+
+  return NextResponse.json({ code });
+}

--- a/frontend/src/app/register/RegisterForm.tsx
+++ b/frontend/src/app/register/RegisterForm.tsx
@@ -401,7 +401,7 @@ export function RegisterForm({ initialReferralCode }: RegisterFormProps = {}) {
               type="text"
               autoComplete="off"
               inputMode="text"
-              maxLength={8}
+              maxLength={32}
               value={referralCode}
               onChange={(e) =>
                 setReferralCode(e.target.value.toUpperCase().replace(/\s+/g, ''))
@@ -423,7 +423,7 @@ export function RegisterForm({ initialReferralCode }: RegisterFormProps = {}) {
               aria-live="polite"
             >
               {referralLookup.status === 'idle' &&
-                'Enter the 8-character code shared by a friend.'}
+                'Enter the code shared by a friend.'}
               {referralLookup.status === 'checking' && 'Checking…'}
               {referralLookup.status === 'valid' && (
                 <>

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -71,6 +71,11 @@ const KNOWN_ERROR_FRAGMENTS = [
   'referrer not found',
   'note is required',
   'referral not found',
+  // Custom referral code (migration 0065)
+  'code is required',
+  'invalid code format',
+  'code already in use',
+  'referral code row missing',
 ] as const;
 
 export function safeMessage(

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -144,8 +144,9 @@ export const CHARITIES = [
 
 export type Charity = (typeof CHARITIES)[number];
 
-/** 8 uppercase chars from a 31-symbol alphabet (no 0/O/1/I/L). */
-export const REFERRAL_CODE_REGEX = /^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{8}$/;
+/** Uppercase A–Z and digits, 4–32 chars. Auto-generated codes are 8 chars from a
+ *  restricted alphabet; admins may set longer vanity codes (e.g. GIUSEPPETHEMC). */
+export const REFERRAL_CODE_REGEX = /^[A-Z0-9]{4,32}$/;
 
 export const API_ENDPOINTS = {
   tournament: '/api/tournament',

--- a/supabase/migrations/0065_admin_set_referral_code.sql
+++ b/supabase/migrations/0065_admin_set_referral_code.sql
@@ -1,0 +1,74 @@
+-- ========== Admin: set a custom (vanity) referral code ==========
+-- Lets a super-admin overwrite a user's auto-generated referral code with a
+-- recognizable vanity code (e.g. an influencer's handle). The backend already
+-- resolves any code format (plain citext lookup in handle_new_user +
+-- resolve_referrer_username); the only missing piece was a gated write path,
+-- since RLS denies all client writes to referral_codes.
+--
+-- Gated to is_super_admin() (stricter than the is_admin() peers in
+-- 0059_admin_referrals.sql) because vanity codes are a sensitive,
+-- rarely-used override. Format mirrors the relaxed frontend
+-- REFERRAL_CODE_REGEX: 4–32 chars, uppercase A–Z + digits.
+
+-- Allow the new audit action.
+alter table public.referral_admin_audit
+    drop constraint referral_admin_audit_action_check,
+    add constraint referral_admin_audit_action_check
+        check (action in ('add', 'remove', 'set_code'));
+
+
+-- ========== RPC: admin_set_referral_code ==========
+
+create function public.admin_set_referral_code(
+    p_user_id uuid,
+    p_code text,
+    p_note text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_note text := nullif(trim(p_note), '');
+    v_code text := upper(nullif(trim(p_code), ''));
+begin
+    if not public.is_super_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if v_code is null then
+        raise exception 'code is required' using errcode = 'P0001';
+    end if;
+    if v_code !~ '^[A-Z0-9]{4,32}$' then
+        raise exception 'invalid code format' using errcode = 'P0001';
+    end if;
+    if v_note is null then
+        raise exception 'note is required' using errcode = 'P0001';
+    end if;
+    if not exists (select 1 from public.profiles where id = p_user_id) then
+        raise exception 'user not found' using errcode = 'P0001';
+    end if;
+    -- citext column, so this comparison is case-insensitive (matches the
+    -- unique index behaviour) and guards against collisions with other users.
+    if exists (
+        select 1 from public.referral_codes
+         where code = v_code and user_id <> p_user_id
+    ) then
+        raise exception 'code already in use' using errcode = 'P0001';
+    end if;
+
+    update public.referral_codes set code = v_code where user_id = p_user_id;
+    if not found then
+        -- Every profile is backfilled (0035) + trigger-created, so this should
+        -- be unreachable; surface it rather than silently no-op.
+        raise exception 'referral code row missing' using errcode = 'P0001';
+    end if;
+
+    insert into public.referral_admin_audit
+        (actor_id, action, referee_id, note)
+    values
+        (auth.uid(), 'set_code', p_user_id, 'set code ' || v_code || ' — ' || v_note);
+end;
+$$;
+
+grant execute on function public.admin_set_referral_code(uuid, text, text) to authenticated;


### PR DESCRIPTION
## What & why

We want to give the influencer **Giuseppethemc@gmail.com** the recognizable referral code `GIUSEPPETHEMC` so his share link `/register?ref=GIUSEPPETHEMC` is memorable. Today, referral codes are auto-generated at signup (8 chars from a restricted alphabet) with no way to change them, and the frontend `REFERRAL_CODE_REGEX` rejects anything that isn't exactly 8 chars from that alphabet — so a vanity code would never resolve even if set in the DB.

The **backend already accepts any code format** (`handle_new_user` linkage + `resolve_referrer_username` do a plain citext lookup, no CHECK constraint). So the work is just: a gated write path + loosening the frontend validation.

## Changes

- **`0065_admin_set_referral_code.sql`** — new `admin_set_referral_code(p_user_id, p_code, p_note)` RPC, **gated to `is_super_admin()`**, validates format `^[A-Z0-9]{4,32}$`, enforces case-insensitive uniqueness, writes an audit row (extends the `referral_admin_audit` action CHECK to allow `set_code`).
- **`REFERRAL_CODE_REGEX`** loosened to `/^[A-Z0-9]{4,32}$/` — one constant feeds all four gates (deep-link, debounced lookup, submit passthrough, `/api/referrals/validate`), so vanity codes resolve end-to-end. Auto-generated 8-char codes still match.
- **Register form** — `maxLength` 8→32, dropped the "8-character" copy.
- **New `PATCH /api/admin/users/[id]/referral-code`** — `requireAdmin` coarse gate; the super-admin requirement is enforced in the RPC. Maps RPC errors to 400/403/404/409.
- **Admin UI** — a super-admin-only "Referral code" card on `/admin/users/[id]` showing the current code + an input + required audit note + save.

## Decisions (confirmed with requester)

- Build a reusable admin feature (not a one-off SQL write)
- Gate to **super-admins** only
- Allow `/^[A-Z0-9]{4,32}$/`
- Requester sets Giuseppe's code himself via the live admin UI after deploy — no manual SQL, no prod access during development

## Verification

- `npm test` (518 pass, incl. new route tests), `npm run typecheck`, `npm run lint` all green.
- RPC behavior verified against **local** Supabase in a rolled-back transaction: super-admin success → `GIUSEPPETHEMC`; too-short → `invalid code format`; lowercase collision → `code already in use` (confirms uppercase normalize + citext uniqueness); unknown user → `user not found`; non-super-admin actor → `forbidden`.
- Never run against production.

## After merge

Log in as super-admin → open Giuseppe's user page → set `GIUSEPPETHEMC` → Save. Versioning: ships an `### Added` feature → MINOR bump at next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
