### PR TITLE
chore(deps): sync package-lock version field to 1.5.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "dependencies": {
         "@next/third-parties": "^16.2.6",
         "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## What

Regenerate \`frontend/package-lock.json\` so its \`version\` field matches \`package.json\` (\`1.5.0\`).

## Why

The Google Tag Manager branch (#178) was rebased onto \`main\`, and the rebase carried over the branch's older lockfile header (\`version: 1.3.0\`) while \`package.json\` is \`1.5.0\`. The mismatch is cosmetic and npm self-heals it on the next \`npm install\`, but this tidies it explicitly.

## Diff

Two lines only — both \`version\` fields \`1.3.0 → 1.5.0\`. **No dependency additions, removals, or version changes.**