### PR TITLE
fix(ci): pass NEXT_PUBLIC_GTM_ID to the Cloudflare deploy build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,3 +39,4 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+          NEXT_PUBLIC_GTM_ID: ${{ secrets.NEXT_PUBLIC_GTM_ID }}


### PR DESCRIPTION
## Problem

On the deployed site, Google reported **\"Your Google tag wasn't detected on your website\"** even though the GTM container and GA4 tag are correctly published.

Root cause: \`NEXT_PUBLIC_*\` variables are **inlined at build time**. The deploy workflow passed Supabase + app URL vars to the \`npm run deploy\` build step, but **not** \`NEXT_PUBLIC_GTM_ID\`. The local \`.env\` that holds the ID is gitignored, so CI never saw it. Result: production builds had \`gtmId === undefined\`, and \`layout.tsx\` rendered no \`<GoogleTagManager>\` tag.

## Fix

Add \`NEXT_PUBLIC_GTM_ID\` to the deploy step \`env:\`, sourced from a new \`NEXT_PUBLIC_GTM_ID\` GitHub Actions secret (already created), matching how the other public vars are supplied.

## Notes

- Must be a **build-time** var (workflow \`env:\`), not a Cloudflare Worker runtime var — runtime vars don't work for \`NEXT_PUBLIC_*\`.
- After merge, the deploy workflow re-runs on \`main\` and bakes the ID in; the tag will then be detectable.
- Locally verifiable via \`npm run preview\` (real production build that reads local \`.env\`).