### PR TITLE
feat(predictions): 'Phase 1 Complete' status + resume uncommitted drafts

### DIFF
--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -3,7 +3,17 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowRight, CheckCircle2, Clock, Eye, FileEdit, Gift, Plus, Trash2 } from 'lucide-react';
+import {
+  ArrowRight,
+  CheckCircle2,
+  Clock,
+  Eye,
+  FileEdit,
+  Gift,
+  Pencil,
+  Plus,
+  Trash2,
+} from 'lucide-react';
 import { toast } from 'sonner';
 
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -23,6 +33,7 @@ import { useAuthContext } from '@/providers/AuthProvider';
 import {
   NEW_PREDICTION_SENTINEL,
   clearDraftForPrediction,
+  useDraftPersistence,
 } from '@/hooks/useDraftPersistence';
 import { useTournamentLock } from '@/hooks/useTournamentLock';
 import {
@@ -35,6 +46,10 @@ import { UnpaidPaymentNotice } from '@/components/predictions/UnpaidPaymentNotic
 import { PRICING, ROUTES } from '@/lib/constants';
 import { fetchJSON } from '@/lib/api/fetchJSON';
 import { isPhase1StagesComplete, needsPayment } from '@/lib/predictions/paymentStatus';
+import {
+  newDraftHasContent,
+  type NewDraftData,
+} from '@/lib/predictions/draftSummary';
 import { cn } from '@/lib/utils';
 
 interface ApiPrediction {
@@ -101,6 +116,33 @@ export function PredictionsListPage() {
     : !canCreate
       ? 'New predictions are only accepted during the group stage'
       : undefined;
+
+  // A new prediction lives only in localStorage until its first server save
+  // (gated on the champion pick — the last Phase 1 step), so a user who enters
+  // some picks and navigates away has no DB row and nothing in this list. Read
+  // that `:new` slot and offer to resume it. Only meaningful while the user can
+  // still create (phase 1 / super admin); the wizard discards it once locked.
+  const tournamentId = query.data?.tournament.id ?? null;
+  const { loadDraft: loadNewDraft, clearDraft: clearNewDraft } =
+    useDraftPersistence<NewDraftData>(user?.id, tournamentId, NEW_PREDICTION_SENTINEL);
+  const [newDraft, setNewDraft] = React.useState<{ savedAt: string } | null>(null);
+  React.useEffect(() => {
+    if (!user?.id || !tournamentId || !canCreate) {
+      setNewDraft(null);
+      return;
+    }
+    const payload = loadNewDraft();
+    setNewDraft(
+      payload && newDraftHasContent(payload.data) ? { savedAt: payload.savedAt } : null
+    );
+    // query.dataUpdatedAt re-checks after a create clears the `:new` slot.
+  }, [user?.id, tournamentId, canCreate, loadNewDraft, query.dataUpdatedAt]);
+
+  const handleDiscardNewDraft = () => {
+    clearNewDraft();
+    setNewDraft(null);
+    toast.success('Unsaved draft discarded');
+  };
 
   const handleRedeem = async (prediction: ApiPrediction) => {
     if (redeemingId) return;
@@ -222,6 +264,41 @@ export function PredictionsListPage() {
         <FreePickBanner />
       </div>
 
+      {newDraft && (
+        <Card className="mb-3 border-blue-500/40 bg-blue-500/5 dark:bg-blue-500/10">
+          <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-lg font-semibold">Unsaved draft</h2>
+                <Badge variant="outline" className="gap-1">
+                  <FileEdit className="h-3 w-3" /> This device
+                </Badge>
+              </div>
+              <p className="text-muted-foreground mt-1 text-sm">
+                You have a prediction in progress, saved only in this browser. Finish it
+                to add it to your predictions. Last edited {formatTime(newDraft.savedAt)}.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button asChild size="sm">
+                <Link href={`${ROUTES.predictions}/${NEW_PREDICTION_SENTINEL}`}>
+                  <Pencil className="mr-2 h-4 w-4" /> Resume
+                </Link>
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleDiscardNewDraft}
+                title="Discard this unsaved draft"
+              >
+                <Trash2 className="h-4 w-4" />
+                <span className="sr-only">Discard</span>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {query.isLoading ? (
         <div className="space-y-3">
           {Array.from({ length: 3 }).map((_, i) => (
@@ -292,7 +369,7 @@ export function PredictionsListPage() {
                     {p.submittedAt
                       ? `Submitted ${formatTime(p.submittedAt)}`
                       : isPhase1StagesComplete(p)
-                        ? 'Phase 1 complete — submit before lock to qualify for the leaderboard'
+                        ? 'Phase 1 complete — your group-stage predictions qualify for the group stage lock'
                         : 'Saved as draft — submit to qualify for the leaderboard'}
                   </div>
                 </div>

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -34,13 +34,14 @@ import { FreePickBanner } from '@/components/predictions/FreePickBanner';
 import { UnpaidPaymentNotice } from '@/components/predictions/UnpaidPaymentNotice';
 import { PRICING, ROUTES } from '@/lib/constants';
 import { fetchJSON } from '@/lib/api/fetchJSON';
-import { needsPayment } from '@/lib/predictions/paymentStatus';
+import { isPhase1StagesComplete, needsPayment } from '@/lib/predictions/paymentStatus';
 import { cn } from '@/lib/utils';
 
 interface ApiPrediction {
   id: string;
   name: string;
   totalGoals: number | null;
+  championTeamId: string | null;
   submittedAt: string | null;
   isPaid: boolean;
   paidAt: string | null;
@@ -261,6 +262,13 @@ export function PredictionsListPage() {
                       <Badge variant="secondary" className="gap-1">
                         <CheckCircle2 className="h-3 w-3" /> Submitted
                       </Badge>
+                    ) : isPhase1StagesComplete(p) ? (
+                      <Badge
+                        variant="secondary"
+                        className="gap-1 bg-blue-600/15 text-blue-700 hover:bg-blue-600/15 dark:bg-blue-400/15 dark:text-blue-300"
+                      >
+                        <CheckCircle2 className="h-3 w-3" /> Phase 1 Complete
+                      </Badge>
                     ) : (
                       <Badge variant="outline" className="gap-1">
                         <FileEdit className="h-3 w-3" /> Draft
@@ -283,7 +291,9 @@ export function PredictionsListPage() {
                   <div className="text-muted-foreground mt-1 text-sm">
                     {p.submittedAt
                       ? `Submitted ${formatTime(p.submittedAt)}`
-                      : 'Saved as draft — submit to qualify for the leaderboard'}
+                      : isPhase1StagesComplete(p)
+                        ? 'Phase 1 complete — submit before lock to qualify for the leaderboard'
+                        : 'Saved as draft — submit to qualify for the leaderboard'}
                   </div>
                 </div>
                 <div className="flex items-center gap-2">

--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -18,6 +18,7 @@ import { GroupStandingsResults } from '@/components/results/GroupStandingsResult
 import { AdvancersResults } from '@/components/results/AdvancersResults';
 import { TeamFlag } from '@/components/shared/TeamFlag';
 import { fetchJSON } from '@/lib/api/fetchJSON';
+import { isPhase1StagesComplete } from '@/lib/predictions/paymentStatus';
 import type {
   Group,
   GroupStanding,
@@ -125,9 +126,18 @@ export function BracketPreviewDialog({
             {predictionQuery.data?.name ?? 'Bracket'}
             {predictionQuery.data && (
               <>
-                <Badge variant={predictionQuery.data.submittedAt ? 'secondary' : 'outline'}>
-                  {predictionQuery.data.submittedAt ? 'Submitted' : 'Draft'}
-                </Badge>
+                {predictionQuery.data.submittedAt ? (
+                  <Badge variant="secondary">Submitted</Badge>
+                ) : isPhase1StagesComplete(predictionQuery.data) ? (
+                  <Badge
+                    variant="secondary"
+                    className="bg-blue-600/15 text-blue-700 hover:bg-blue-600/15 dark:bg-blue-400/15 dark:text-blue-300"
+                  >
+                    Phase 1 Complete
+                  </Badge>
+                ) : (
+                  <Badge variant="outline">Draft</Badge>
+                )}
                 {predictionQuery.data.isPaid ? (
                   <Badge
                     variant="default"

--- a/frontend/src/lib/predictions/__tests__/draftSummary.test.ts
+++ b/frontend/src/lib/predictions/__tests__/draftSummary.test.ts
@@ -1,0 +1,50 @@
+import { newDraftHasContent, type NewDraftData } from '../draftSummary';
+
+const emptyGroups: NewDraftData['groupPredictions'] = Array.from({ length: 12 }, () => ({
+  positions: { first: null, second: null, third: null, fourth: null },
+}));
+
+describe('newDraftHasContent', () => {
+  it('is false for null/undefined', () => {
+    expect(newDraftHasContent(null)).toBe(false);
+    expect(newDraftHasContent(undefined)).toBe(false);
+  });
+
+  it('is false for a bare skeleton draft (all-null slots, no name)', () => {
+    expect(
+      newDraftHasContent({
+        predictionName: '   ',
+        championTeamId: null,
+        totalGoals: null,
+        groupPredictions: emptyGroups,
+        advancerPredictions: [],
+        knockoutPredictions: [{ winnerId: null }],
+      })
+    ).toBe(false);
+  });
+
+  it('is true when a prediction name is entered', () => {
+    expect(newDraftHasContent({ predictionName: 'My Bracket' })).toBe(true);
+  });
+
+  it('is true when a group slot is filled', () => {
+    expect(
+      newDraftHasContent({
+        groupPredictions: [{ positions: { first: 't1', second: null, third: null, fourth: null } }],
+      })
+    ).toBe(true);
+  });
+
+  it('is true when an advancer is picked', () => {
+    expect(newDraftHasContent({ advancerPredictions: [{ rank: 1, teamId: 't1' }] })).toBe(true);
+  });
+
+  it('is true when the champion or tiebreaker is set', () => {
+    expect(newDraftHasContent({ championTeamId: 't1' })).toBe(true);
+    expect(newDraftHasContent({ totalGoals: 12 })).toBe(true);
+  });
+
+  it('is true when a knockout winner is picked', () => {
+    expect(newDraftHasContent({ knockoutPredictions: [{ winnerId: 't1' }] })).toBe(true);
+  });
+});

--- a/frontend/src/lib/predictions/__tests__/paymentStatus.test.ts
+++ b/frontend/src/lib/predictions/__tests__/paymentStatus.test.ts
@@ -1,4 +1,4 @@
-import { isPhase1Complete, needsPayment } from '../paymentStatus';
+import { isPhase1Complete, isPhase1StagesComplete, needsPayment } from '../paymentStatus';
 import { ADVANCER_COUNT, TOURNAMENT_CONFIG } from '@/lib/constants';
 
 const fullGroups = Array.from({ length: TOURNAMENT_CONFIG.totalGroups }, (_, i) => ({
@@ -22,6 +22,44 @@ describe('isPhase1Complete', () => {
     ).toBe(false);
     expect(
       isPhase1Complete({ isPaid: false, submittedAt: null, groups: fullGroups, advancers: [] })
+    ).toBe(false);
+  });
+});
+
+describe('isPhase1StagesComplete', () => {
+  it('is true with all groups + advancers + a champion pick', () => {
+    expect(
+      isPhase1StagesComplete({
+        isPaid: false,
+        submittedAt: null,
+        groups: fullGroups,
+        advancers: fullAdvancers,
+        championTeamId: 'team-x',
+      })
+    ).toBe(true);
+  });
+
+  it('is false when the champion pick is missing (even if groups + advancers are full)', () => {
+    expect(
+      isPhase1StagesComplete({
+        isPaid: false,
+        submittedAt: null,
+        groups: fullGroups,
+        advancers: fullAdvancers,
+        championTeamId: null,
+      })
+    ).toBe(false);
+  });
+
+  it('is false when groups or advancers are incomplete', () => {
+    expect(
+      isPhase1StagesComplete({
+        isPaid: false,
+        submittedAt: null,
+        groups: fullGroups.slice(0, 5),
+        advancers: fullAdvancers,
+        championTeamId: 'team-x',
+      })
     ).toBe(false);
   });
 });

--- a/frontend/src/lib/predictions/draftSummary.ts
+++ b/frontend/src/lib/predictions/draftSummary.ts
@@ -1,0 +1,53 @@
+/**
+ * A new prediction lives only in `localStorage` (under the `:new` slot) until
+ * its first successful server save, which is gated on the champion pick — the
+ * last Phase 1 step. So a user who enters groups/best-3rds and navigates away
+ * leaves an uncommitted draft that never reached the DB and so never appears in
+ * the predictions list. The list page reads that `:new` slot to offer a
+ * "Resume unsaved draft" affordance.
+ *
+ * This shape is a deliberately loose, defensive mirror of the wizard's
+ * `DraftData` (untrusted localStorage JSON), so we don't pull the whole wizard
+ * module into the list page bundle just to read it.
+ */
+export interface NewDraftData {
+  predictionName?: string;
+  championTeamId?: string | null;
+  totalGoals?: number | null;
+  groupPredictions?: Array<{
+    positions?: {
+      first?: string | null;
+      second?: string | null;
+      third?: string | null;
+      fourth?: string | null;
+    };
+  }>;
+  advancerPredictions?: ReadonlyArray<unknown>;
+  knockoutPredictions?: Array<{ winnerId?: string | null }>;
+}
+
+/**
+ * True when a `:new` draft holds anything worth resuming — any named entry,
+ * champion pick, tiebreaker, advancer, group slot, or knockout winner. A bare
+ * skeleton draft (all-null slots, written the moment the wizard mounts) returns
+ * false so we don't surface a "resume" card for work the user never started.
+ */
+export function newDraftHasContent(data: NewDraftData | null | undefined): boolean {
+  if (!data) return false;
+  if (data.predictionName?.trim()) return true;
+  if (data.championTeamId) return true;
+  if (data.totalGoals != null) return true;
+  if ((data.advancerPredictions?.length ?? 0) > 0) return true;
+  if (
+    data.groupPredictions?.some(
+      (g) =>
+        g.positions?.first ||
+        g.positions?.second ||
+        g.positions?.third ||
+        g.positions?.fourth
+    )
+  )
+    return true;
+  if (data.knockoutPredictions?.some((k) => k.winnerId)) return true;
+  return false;
+}

--- a/frontend/src/lib/predictions/paymentStatus.ts
+++ b/frontend/src/lib/predictions/paymentStatus.ts
@@ -9,6 +9,7 @@ export interface PaymentStatusInput {
   submittedAt: string | null;
   groups?: ReadonlyArray<unknown>;
   advancers?: ReadonlyArray<unknown>;
+  championTeamId?: string | null;
 }
 
 /**
@@ -22,6 +23,19 @@ export function isPhase1Complete(p: PaymentStatusInput): boolean {
     (p.groups?.length ?? 0) === TOURNAMENT_CONFIG.totalGroups &&
     (p.advancers?.length ?? 0) === ADVANCER_COUNT
   );
+}
+
+/**
+ * True when *all* Phase 1 stages are filled: groups + advancers (per
+ * {@link isPhase1Complete}) **plus** the gut-feeling champion pick. Distinct
+ * from `isPhase1Complete`, which omits the champion to mirror the DB
+ * `prediction_phase1_complete` leaderboard-eligibility filter. Used to drive
+ * the "Phase 1 Complete" badge so a fully-finished-but-not-yet-submitted entry
+ * no longer reads as "Draft" — matching the wizard's own completeness check
+ * (`isChampionPickComplete && isGroupsComplete && isAdvancersComplete`).
+ */
+export function isPhase1StagesComplete(p: PaymentStatusInput): boolean {
+  return isPhase1Complete(p) && p.championTeamId != null;
 }
 
 /**


### PR DESCRIPTION
Two related improvements to how in-progress / completed predictions surface on the predictions list.

## 1. "Phase 1 Complete" status between Draft and Submitted

A user was confused that a fully-completed Phase 1 entry still showed a **"Draft"** badge. The badge was a naive binary (`submitted_at ? "Submitted" : "Draft"`), so any entry without `submitted_at` stamped read as "Draft" — even when every Phase 1 stage (group standings + best 3rds + gut-feeling champion) was filled in.

The DB has **no status column** — only a nullable `submitted_at`. No DB change needed: the predictions API already returns `championTeamId`, `groups`, and `advancers`, so a complete Phase 1 pick set is detectable on the client.

Three distinct badge states: `Draft` (incomplete) → **`Phase 1 Complete`** (all stages filled, `submitted_at` null) → `Submitted` (`submitted_at` set).

- **`lib/predictions/paymentStatus.ts`** — new `isPhase1StagesComplete()` (12 groups + 8 advancers + champion pick). Kept separate from `isPhase1Complete()`, which mirrors the DB `prediction_phase1_complete` leaderboard-eligibility filter (groups + advancers only) and is left untouched.
- **`PredictionsListPage.tsx`** / **`BracketPreviewDialog.tsx`** — three-state badge. Subtext for the complete state corrected: a Phase-1-complete entry already qualifies at the group-stage lock, so it no longer tells users to "submit before lock to qualify."

## 2. Resume uncommitted localStorage drafts

A brand-new prediction lives **only in `localStorage`** (under the `:new` slot) until its first successful server save — and that save is gated on the champion pick, the *last* Phase 1 step (the `submit_predictions` RPC requires `champion_team_id` on create). So a user who enters group/best-3rds picks and navigates away has **no DB row**, and the list (which reads the DB) shows nothing.

Frontend-only fix: read the `:new` slot and show a **"Unsaved draft · This device"** card with **Resume** (deep-links to `/predictions/new`, which restores the draft) and **Discard**. It's browser-local by design, only shown while the user can still create, and clears automatically once the prediction is saved to the DB.

- **`lib/predictions/draftSummary.ts`** (new) — `newDraftHasContent()`, a defensive check so a bare skeleton draft doesn't trigger a card.
- **`PredictionsListPage.tsx`** — resume-draft card via the existing `useDraftPersistence` hook (read in an effect → no hydration mismatch).

## Verification

- `npm test` — 528 passed (new: `paymentStatus` + `draftSummary` cases)
- `npm run typecheck` — clean
- `npm run lint` — only pre-existing `jest.setup.tsx` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)