### PR TITLE
chore(audit): remove Software Services (AI / tooling) operating-cost line

### DIFF
--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -74,7 +74,6 @@ export const OPERATING_COSTS = {
   recurring: [
     { label: 'Domain', amount: 150 },
     { label: 'Hosting / Email', amount: 124 },
-    { label: 'Software Services (AI / tooling)', amount: 78.5 },
   ],
 } as const;
 


### PR DESCRIPTION
## What

Removes the `Software Services (AI / tooling)` line ($78.50) from the `/audit` page operating-cost model (`OPERATING_COSTS.recurring` in `frontend/src/lib/constants.ts`).

## Why

Per request — this cost should no longer appear in the public audit ledger.

## Impact

- The audit ledger now lists only **Domain** ($150) and **Hosting / Email** ($124) as flat recurring costs, plus the per-submission Development / Management line.
- Net payout / retained margin rises by $78.50 accordingly (derived automatically).

## Verification

- `npm test -- audit` → 12 passed (page, accounting lib, and stats route). Tests derive figures from `OPERATING_COSTS`, so no hardcoded assertions broke.
- `npm run typecheck` → clean.
- `npm run lint` → only 2 pre-existing warnings in `jest.setup.tsx`, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)