### PR TITLE
feat(admin): lock payment changes to super admins after lock time

### DIFF
--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -24,6 +24,8 @@ import {
 } from '@/components/ui/dialog';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
 import { fetchJSON } from '@/lib/api/fetchJSON';
+import { useAuth } from '@/hooks/useAuth';
+import { useTournamentLock } from '@/hooks/useTournamentLock';
 
 interface AdminPrediction {
   id: string;
@@ -69,6 +71,14 @@ function PaymentRow({
       : toLocalDatetimeInput(new Date().toISOString())
   );
   const [busy, setBusy] = React.useState(false);
+  const { profile } = useAuth();
+  const { isPhase1Open, isLoading: lockLoading } = useTournamentLock();
+
+  // Once the tournament lock_time has passed (any phase other than phase1),
+  // only super admins may change payment state — this keeps late/backdated
+  // payments off the leaderboard (get_leaderboard counts paid_at <= lock_time).
+  // The RPC enforces this; here we simply hide the controls for everyone else.
+  const paymentsLocked = !lockLoading && !isPhase1Open && !profile?.isSuperAdmin;
 
   const submit = async (paid: boolean, paidAt: string | null) => {
     setBusy(true);
@@ -120,36 +130,42 @@ function PaymentRow({
           </span>
         )}
       </div>
-      <div className="flex flex-wrap items-end gap-2">
-        <div className="space-y-1">
-          <label className="text-muted-foreground text-xs" htmlFor={`paid-at-${prediction.id}`}>
-            Paid at (optional)
-          </label>
-          <Input
-            id={`paid-at-${prediction.id}`}
-            type="datetime-local"
-            value={paidAtInput}
-            onChange={(e) => setPaidAtInput(e.target.value)}
-            className="w-56"
+      {paymentsLocked ? (
+        <p className="text-muted-foreground text-xs">
+          Payments are locked after lock time.
+        </p>
+      ) : (
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="space-y-1">
+            <label className="text-muted-foreground text-xs" htmlFor={`paid-at-${prediction.id}`}>
+              Paid at (optional)
+            </label>
+            <Input
+              id={`paid-at-${prediction.id}`}
+              type="datetime-local"
+              value={paidAtInput}
+              onChange={(e) => setPaidAtInput(e.target.value)}
+              className="w-56"
+              disabled={busy}
+            />
+          </div>
+          <Button
+            size="sm"
+            onClick={() => submit(true, paidAtInput ? new Date(paidAtInput).toISOString() : null)}
             disabled={busy}
-          />
+          >
+            Mark paid
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => submit(false, null)}
+            disabled={busy || !prediction.isPaid}
+          >
+            Mark unpaid
+          </Button>
         </div>
-        <Button
-          size="sm"
-          onClick={() => submit(true, paidAtInput ? new Date(paidAtInput).toISOString() : null)}
-          disabled={busy}
-        >
-          Mark paid
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => submit(false, null)}
-          disabled={busy || !prediction.isPaid}
-        >
-          Mark unpaid
-        </Button>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/api/admin/predictions/[predictionId]/payment/route.ts
+++ b/frontend/src/app/api/admin/predictions/[predictionId]/payment/route.ts
@@ -52,7 +52,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
   if (error) {
     const msg = error.message ?? '';
-    const status = msg.includes('not found') ? 404 : 400;
+    const status = msg.includes('not found') ? 404 : msg.includes('locked') ? 403 : 400;
     return NextResponse.json({ error: safeMessage(error) }, { status });
   }
   return NextResponse.json({ paid: body.paid, paidAt: body.paid ? paidAt : null });

--- a/supabase/migrations/0066_payment_super_admin_lock.sql
+++ b/supabase/migrations/0066_payment_super_admin_lock.sql
@@ -1,0 +1,64 @@
+-- Restrict payment writes to super admins after the tournament lock.
+--
+-- Supersedes the carve-out documented in 0018_super_admin_lock_bypass.sql
+-- ("Regular admins can still mark payments paid/unpaid past lock"). That is
+-- no longer the policy: once lock_time has passed, only super admins may
+-- change a prediction's payment state.
+--
+-- Rationale: the leaderboard counts a payment only when paid_at <= lock_time
+-- (get_leaderboard). Combined with the free-form "Paid at" admin field, a
+-- regular admin could mark — or backdate — a late payment and surface a
+-- post-lock entry on the leaderboard. This gate closes that hole at the
+-- trust boundary. The body is identical to 0015 except for the added
+-- is_super_admin / is_before_lock gate.
+
+create or replace function public.admin_set_prediction_payment(
+    p_prediction_id uuid,
+    p_paid boolean,
+    p_paid_at timestamptz default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_user_id uuid;
+    v_tournament_id uuid;
+    v_paid_at timestamptz := coalesce(p_paid_at, now());
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_prediction_id is null then
+        raise exception 'prediction_id is required' using errcode = 'P0001';
+    end if;
+
+    select user_id, tournament_id
+      into v_user_id, v_tournament_id
+      from public.predictions
+     where id = p_prediction_id;
+
+    if not found then
+        raise exception 'prediction not found' using errcode = 'P0001';
+    end if;
+
+    -- Past lock, only super admins may change payment state. This prevents
+    -- late (or backdated) payments from surfacing on the leaderboard.
+    if not public.is_super_admin() and not public.is_before_lock(v_tournament_id) then
+        raise exception 'payments are locked' using errcode = 'P0001';
+    end if;
+
+    if p_paid then
+        insert into public.tournament_payments (user_id, tournament_id, prediction_id, paid_at, marked_by)
+        values (v_user_id, v_tournament_id, p_prediction_id, v_paid_at, auth.uid())
+        on conflict (prediction_id) do update
+            set paid_at = excluded.paid_at,
+                marked_by = excluded.marked_by;
+    else
+        delete from public.tournament_payments where prediction_id = p_prediction_id;
+    end if;
+end;
+$$;
+
+grant execute on function public.admin_set_prediction_payment(uuid, boolean, timestamptz) to authenticated;


### PR DESCRIPTION
## Summary

Answers the question *"are Mark Paid / Mark Unpaid disabled after Phase 1 lock?"* — they were **not**. Any admin could change payment state at any time, and the free-form **Paid at** field allowed **backdating** a late payment to before lock. Since the leaderboard counts a payment only when `paid_at <= lock_time`, a backdated late payment could surface a post-lock entry. This reverses the old carve-out from `0018_super_admin_lock_bypass.sql`.

**New policy:** once the tournament `lock_time` has passed (any phase other than `phase1`), only **super admins** may change a prediction's payment state.

## Changes (defense in depth)

1. **DB / RPC (trust boundary)** — `supabase/migrations/0066_payment_super_admin_lock.sql` re-creates `admin_set_prediction_payment` with a `is_super_admin() / is_before_lock()` gate, mirroring the gate already in `admin_submit_predictions`. Raises `payments are locked` for regular admins past lock.
2. **API** — `payment/route.ts` maps the `locked` error to **403**.
3. **UI** — `AdminUserBracket` `PaymentRow` hides the Mark paid/unpaid controls + "Paid at" input for non-super-admins post-lock, replacing them with a muted "Payments are locked after lock time." note. The paid/unpaid status badge stays visible.

Super admins are unaffected (retain full control for legitimate exceptions). Pre-lock (`phase1`) behavior is unchanged for everyone.

## Verification
- `npm test` → 528 passed, `npm run typecheck` clean, `npm run lint` (only pre-existing jest.setup warnings).
- Local DB / manual checks (regular vs super admin, past vs future lock_time) are listed in the plan and best run in your environment via `supabase db reset`.

## Notes
- Migration is append-only (`0066`).
- Behavior change → `### Changed` → MINOR bump when released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)