### PR TITLE
feat: add read-only remote DB backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,30 @@ Key entities:
 
 The trust boundary is the `submit_predictions(jsonb)` RPC: it validates that every team belongs to the claimed group, enforces the lock time, and runs the upsert in a single transaction. The leaderboard goes through two SECURITY DEFINER RPCs (`get_leaderboard`, `get_leaderboard_rank`) so it can read across users without violating the RLS policy on `predictions`.
 
+### Backing up the remote database
+
+`scripts/backup-remote-db.sh` dumps a full, restorable snapshot (roles + schema + data) of a remote Supabase Postgres to the local filesystem. It is **read-only** — it only runs `SELECT`/`COPY` against the remote and never writes to it.
+
+The connection string is never read from git: pass it via `SUPABASE_DB_URL`. Get it from the Supabase Dashboard → **Project Settings → Database → Connection string**, using the **Session** connection (port `5432`), not the transaction pooler (`6543`).
+
+```bash
+# from frontend/
+SUPABASE_DB_URL='postgresql://postgres:...@db.<ref>.supabase.co:5432/postgres' npm run db:backup
+
+# or call the script directly from the repo root
+SUPABASE_DB_URL='postgresql://...' scripts/backup-remote-db.sh
+```
+
+Dumps land in `supabase/backups/<UTC-timestamp>/` as `roles.sql`, `schema.sql`, and `data.sql`. That folder is **gitignored** (the files contain real production data) — only its `.gitignore` is tracked.
+
+To restore into a **fresh/empty** Postgres (a recovery project or local stack — never your live DB), apply the files in order:
+
+```bash
+psql "$TARGET_DB_URL" -f roles.sql
+psql "$TARGET_DB_URL" -f schema.sql
+psql "$TARGET_DB_URL" -f data.sql
+```
+
 ## Auth
 
 Email + password via Supabase Auth. Username is collected at signup and stored in `profiles` by the `handle_new_user` trigger. The trigger raises `'username taken'` (errcode `P0001`) on collision and `'username invalid format'` on format violations; `RegisterForm` branches on these strings.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "db:backup": "bash ../scripts/backup-remote-db.sh"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/scripts/backup-remote-db.sh
+++ b/scripts/backup-remote-db.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Dump a full snapshot of a remote Supabase Postgres database to the local
+# filesystem. READ-ONLY: this only runs SELECT/COPY against the remote (no
+# resets, no writes) and writes the dump files under supabase/backups/.
+#
+# Produces the Supabase-recommended 3-file restorable snapshot in a
+# timestamped folder:
+#   roles.sql   — database roles            (--role-only)
+#   schema.sql  — schema / DDL              (default dump)
+#   data.sql    — table data via COPY       (--data-only --use-copy)
+#
+# The connection string is NEVER read from git — pass it via the
+# SUPABASE_DB_URL env var or as the first argument. Get it from the Supabase
+# Dashboard → Project Settings → Database → Connection string. Use the
+# direct/session connection (port 5432), NOT the transaction pooler (6543),
+# so the dump can hold a consistent read.
+#
+# Examples:
+#   SUPABASE_DB_URL='postgresql://postgres:...@db.<ref>.supabase.co:5432/postgres' \
+#     scripts/backup-remote-db.sh
+#
+#   scripts/backup-remote-db.sh 'postgresql://postgres:...@db.<ref>.supabase.co:5432/postgres'
+#
+# Exit codes:
+#   0  snapshot written successfully
+#   2  misconfiguration (missing connection string or supabase CLI)
+
+set -euo pipefail
+
+# Repo root = parent of this script's directory, regardless of cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DB_URL="${SUPABASE_DB_URL:-${1:-}}"
+
+usage() {
+  cat <<EOF
+Usage: SUPABASE_DB_URL='postgresql://...' $0
+   or: $0 'postgresql://...'
+
+Get the connection string from the Supabase Dashboard:
+  Project Settings → Database → Connection string (Session, port 5432).
+
+This is a READ-ONLY dump. It never modifies the remote database.
+EOF
+}
+
+if [[ -z "$DB_URL" ]]; then
+  echo "error: no connection string provided." >&2
+  echo >&2
+  usage >&2
+  exit 2
+fi
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "error: the 'supabase' CLI is not on your PATH." >&2
+  echo "       Install it: https://supabase.com/docs/guides/cli" >&2
+  exit 2
+fi
+
+# UTC timestamp keeps folders sortable and tz-independent.
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_DIR="$REPO_ROOT/supabase/backups/$TIMESTAMP"
+mkdir -p "$OUT_DIR"
+
+echo "Backing up remote Supabase DB (read-only) → $OUT_DIR"
+
+echo "  [1/3] roles  → roles.sql"
+supabase db dump --db-url "$DB_URL" -f "$OUT_DIR/roles.sql" --role-only
+
+echo "  [2/3] schema → schema.sql"
+supabase db dump --db-url "$DB_URL" -f "$OUT_DIR/schema.sql"
+
+echo "  [3/3] data   → data.sql"
+supabase db dump --db-url "$DB_URL" -f "$OUT_DIR/data.sql" --data-only --use-copy
+
+echo
+echo "Done. Snapshot written to:"
+echo "  $OUT_DIR"
+echo
+echo "Restore into a fresh/empty Postgres (NOT your live DB), in order:"
+echo "  psql \"\$TARGET_DB_URL\" -f \"$OUT_DIR/roles.sql\""
+echo "  psql \"\$TARGET_DB_URL\" -f \"$OUT_DIR/schema.sql\""
+echo "  psql \"\$TARGET_DB_URL\" -f \"$OUT_DIR/data.sql\""

--- a/supabase/backups/.gitignore
+++ b/supabase/backups/.gitignore
@@ -1,0 +1,5 @@
+# Database dumps land here (scripts/backup-remote-db.sh). They contain real
+# production data and must NEVER be committed. Keep the directory, ignore
+# everything in it except this file.
+*
+!.gitignore


### PR DESCRIPTION
## Summary

Adds a committed, repeatable way to export the **remote** (production) Supabase Postgres to the local filesystem as a backup. The repo previously had no backup tooling — it was 100% local-dev focused.

`scripts/backup-remote-db.sh` dumps a full, restorable snapshot (roles + schema + data) via the Supabase CLI. It is **read-only**: it only runs `SELECT`/`COPY` against the remote and never writes to it.

## Changes

- **`scripts/backup-remote-db.sh`** (new, executable) — writes `roles.sql`, `schema.sql`, `data.sql` into `supabase/backups/<UTC-timestamp>/`. Connection string comes from `SUPABASE_DB_URL` (or first arg) — never read from git. Guards on a missing connection string / missing `supabase` CLI with exit code 2.
- **`supabase/backups/.gitignore`** (new) — ignores all dumps (`*` + `!.gitignore`) so production data is never committed, while keeping the directory in the repo.
- **`frontend/package.json`** — adds `npm run db:backup`.
- **`README.md`** — documents how to get the connection string (Dashboard → Project Settings → Database → Connection string, **Session**/port 5432), how to run it, where dumps land, and how to restore.

## Usage

```bash
# from frontend/
SUPABASE_DB_URL='postgresql://postgres:...@db.<ref>.supabase.co:5432/postgres' npm run db:backup
```

## Verification

Ran the full script end-to-end against the **local** stack (never prod, per repo policy):
- Produced all three files; `schema.sql` had 19 `CREATE TABLE`s; `data.sql` captured all 19 `public` tables plus `auth.*`, with **48 teams** matching the seed.
- `git check-ignore` confirmed the dump files are ignored; only `.gitignore` is trackable.
- Verified the missing-connection-string error path exits 2 with a clear usage message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)