### PR TITLE
feat(admin): super-admin Mark Free for comped free entries

### DIFF
--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -35,6 +35,7 @@ interface AdminPrediction {
   isPaid: boolean;
   paidAt: string | null;
   markedBy: string | null;
+  isFreePaid: boolean;
 }
 
 interface AdminUserSummary {
@@ -80,7 +81,7 @@ function PaymentRow({
   // The RPC enforces this; here we simply hide the controls for everyone else.
   const paymentsLocked = !lockLoading && !isPhase1Open && !profile?.isSuperAdmin;
 
-  const submit = async (paid: boolean, paidAt: string | null) => {
+  const submit = async (paid: boolean, paidAt: string | null, isFree = false) => {
     setBusy(true);
     try {
       const res = await fetch(
@@ -88,14 +89,14 @@ function PaymentRow({
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ paid, paidAt }),
+          body: JSON.stringify({ paid, paidAt, isFree }),
         }
       );
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
         throw new Error(String(body.error ?? 'Failed'));
       }
-      toast.success(`Marked ${paid ? 'paid' : 'unpaid'}`);
+      toast.success(`Marked ${isFree ? 'free' : paid ? 'paid' : 'unpaid'}`);
       onChanged();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed');
@@ -115,10 +116,12 @@ function PaymentRow({
       <div className="flex items-center gap-2 text-sm">
         {prediction.isPaid ? (
           isLate ? (
-            <Badge variant="destructive">paid (after lock — not eligible)</Badge>
+            <Badge variant="destructive">
+              {prediction.isFreePaid ? 'free' : 'paid'} (after lock — not eligible)
+            </Badge>
           ) : (
             <Badge variant="default" className="bg-green-600 hover:bg-green-600/90">
-              paid — eligible
+              {prediction.isFreePaid ? 'free' : 'paid'} — eligible
             </Badge>
           )
         ) : (
@@ -156,6 +159,18 @@ function PaymentRow({
           >
             Mark paid
           </Button>
+          {profile?.isSuperAdmin && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() =>
+                submit(true, paidAtInput ? new Date(paidAtInput).toISOString() : null, true)
+              }
+              disabled={busy}
+            >
+              Mark free
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"

--- a/frontend/src/app/api/admin/predictions/[predictionId]/payment/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/predictions/[predictionId]/payment/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { PATCH } = require('../route');
+
+function patchReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/predictions/p1/payment', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ predictionId: 'p1' }) };
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('PATCH /api/admin/predictions/[predictionId]/payment', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 403 for non-admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await PATCH(patchReq({ paid: true }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('forwards p_is_free=false by default when marking paid', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ error: null });
+
+    const res = await PATCH(patchReq({ paid: true, paidAt: '2026-06-01T00:00:00Z' }), ctx);
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_set_prediction_payment', {
+      p_prediction_id: 'p1',
+      p_paid: true,
+      p_paid_at: '2026-06-01T00:00:00.000Z',
+      p_is_free: false,
+    });
+    const body = await res.json();
+    expect(body).toMatchObject({ paid: true, isFree: false });
+  });
+
+  it('forwards p_is_free=true when marking free', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ error: null });
+
+    const res = await PATCH(
+      patchReq({ paid: true, paidAt: '2026-06-01T00:00:00Z', isFree: true }),
+      ctx
+    );
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_set_prediction_payment', {
+      p_prediction_id: 'p1',
+      p_paid: true,
+      p_paid_at: '2026-06-01T00:00:00.000Z',
+      p_is_free: true,
+    });
+    const body = await res.json();
+    expect(body).toMatchObject({ paid: true, isFree: true });
+  });
+
+  it('maps a forbidden RPC error to 403 (non-super-admin attempting free)', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ error: { message: 'forbidden' } });
+
+    const res = await PATCH(patchReq({ paid: true, isFree: true }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a non-boolean isFree', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await PATCH(patchReq({ paid: true, isFree: 'yes' }), ctx);
+    expect(res.status).toBe(400);
+  });
+});

--- a/frontend/src/app/api/admin/predictions/[predictionId]/payment/route.ts
+++ b/frontend/src/app/api/admin/predictions/[predictionId]/payment/route.ts
@@ -11,7 +11,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
 
   const { data, error } = await ctx.supabase
     .from('tournament_payments')
-    .select('paid_at, marked_by')
+    .select('paid_at, marked_by, is_free')
     .eq('prediction_id', predictionId)
     .maybeSingle();
 
@@ -21,6 +21,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
     paid: !!data,
     paidAt: data?.paid_at ?? null,
     markedBy: data?.marked_by ?? null,
+    isFree: data?.is_free ?? false,
   });
 }
 
@@ -29,10 +30,17 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   if (isAdminGateError(ctx)) return ctx.response;
   const { predictionId } = await context.params;
 
-  const body = (await request.json()) as { paid?: boolean; paidAt?: string | null };
+  const body = (await request.json()) as {
+    paid?: boolean;
+    paidAt?: string | null;
+    isFree?: boolean;
+  };
 
   if (typeof body.paid !== 'boolean') {
     return NextResponse.json({ error: 'paid must be a boolean' }, { status: 400 });
+  }
+  if (body.isFree !== undefined && typeof body.isFree !== 'boolean') {
+    return NextResponse.json({ error: 'isFree must be a boolean' }, { status: 400 });
   }
 
   let paidAt: string | null = null;
@@ -44,16 +52,26 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     paidAt = parsed.toISOString();
   }
 
+  const isFree = body.isFree ?? false;
+
   const { error } = await ctx.supabase.rpc('admin_set_prediction_payment', {
     p_prediction_id: predictionId,
     p_paid: body.paid,
     p_paid_at: paidAt,
+    p_is_free: isFree,
   });
 
   if (error) {
     const msg = error.message ?? '';
-    const status = msg.includes('not found') ? 404 : msg.includes('locked') ? 403 : 400;
+    const status =
+      msg.includes('not found') ? 404
+      : msg.includes('locked') || msg.includes('forbidden') ? 403
+      : 400;
     return NextResponse.json({ error: safeMessage(error) }, { status });
   }
-  return NextResponse.json({ paid: body.paid, paidAt: body.paid ? paidAt : null });
+  return NextResponse.json({
+    paid: body.paid,
+    paidAt: body.paid ? paidAt : null,
+    isFree: body.paid ? isFree : false,
+  });
 }

--- a/frontend/src/app/api/admin/users/[id]/predictions/route.ts
+++ b/frontend/src/app/api/admin/users/[id]/predictions/route.ts
@@ -59,13 +59,13 @@ export async function GET(
   const { data: predictions } = await supabase
     .from('predictions')
     .select(
-      'id, prediction_name, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at, marked_by)'
+      'id, prediction_name, total_goals, champion_team_id, submitted_at, tournament_payments!prediction_id(paid_at, marked_by, is_free)'
     )
     .eq('user_id', userId)
     .eq('tournament_id', tournament.id)
     .order('submitted_at', { ascending: true });
 
-  type Payment = { paid_at: string | null; marked_by: string | null };
+  type Payment = { paid_at: string | null; marked_by: string | null; is_free: boolean | null };
   type Pred = {
     id: string;
     prediction_name: string;
@@ -101,6 +101,7 @@ export async function GET(
         isPaid: payment != null,
         paidAt: payment?.paid_at ?? null,
         markedBy: payment?.marked_by ?? null,
+        isFreePaid: payment?.is_free === true,
       };
     }),
   });

--- a/supabase/migrations/0067_admin_mark_free.sql
+++ b/supabase/migrations/0067_admin_mark_free.sql
@@ -1,0 +1,78 @@
+-- Allow super admins to mark a prediction as a comped FREE entry.
+--
+-- Use case: a referrer earned a referral free-pick, but the qualifying referee
+-- paid after lock. The normal redeem flow (redeem_free_pick) is caller-scoped
+-- and stamps paid_at = now(), so a post-lock redemption fails the leaderboard
+-- eligibility check (paid_at <= lock_time). This adds a super-admin-only path to
+-- grant a free (is_free = true) entry with a backdated paid_at so it ranks.
+--
+-- "Mark Free" = "Mark Paid, but tagged is_free = true" — keeps the books honest
+-- (dashboard splits cash_paid_count vs free_entries) and implies no cash changed
+-- hands. This is a pure comp: it does NOT touch the referral/loyalty ledgers, so
+-- the referrer's available_credits is unaffected.
+--
+-- Re-emits admin_set_prediction_payment (last in 0066) with a new optional
+-- p_is_free param. Adding a param creates a new overload, so the old 3-arg
+-- version is dropped first to avoid an ambiguous-overload error on existing
+-- 3-named-arg PostgREST calls. Body is identical to 0066 except for the
+-- is_free wiring + the super-admin gate on free entries.
+
+drop function if exists public.admin_set_prediction_payment(uuid, boolean, timestamptz);
+
+create or replace function public.admin_set_prediction_payment(
+    p_prediction_id uuid,
+    p_paid boolean,
+    p_paid_at timestamptz default null,
+    p_is_free boolean default false
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_user_id uuid;
+    v_tournament_id uuid;
+    v_paid_at timestamptz := coalesce(p_paid_at, now());
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_prediction_id is null then
+        raise exception 'prediction_id is required' using errcode = 'P0001';
+    end if;
+
+    -- Comped free entries are a super-admin-only action, regardless of lock.
+    if p_is_free and not public.is_super_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    select user_id, tournament_id
+      into v_user_id, v_tournament_id
+      from public.predictions
+     where id = p_prediction_id;
+
+    if not found then
+        raise exception 'prediction not found' using errcode = 'P0001';
+    end if;
+
+    -- Past lock, only super admins may change payment state. This prevents
+    -- late (or backdated) payments from surfacing on the leaderboard.
+    if not public.is_super_admin() and not public.is_before_lock(v_tournament_id) then
+        raise exception 'payments are locked' using errcode = 'P0001';
+    end if;
+
+    if p_paid then
+        insert into public.tournament_payments (user_id, tournament_id, prediction_id, paid_at, marked_by, is_free)
+        values (v_user_id, v_tournament_id, p_prediction_id, v_paid_at, auth.uid(), p_is_free)
+        on conflict (prediction_id) do update
+            set paid_at = excluded.paid_at,
+                marked_by = excluded.marked_by,
+                is_free = excluded.is_free;
+    else
+        delete from public.tournament_payments where prediction_id = p_prediction_id;
+    end if;
+end;
+$$;
+
+grant execute on function public.admin_set_prediction_payment(uuid, boolean, timestamptz, boolean) to authenticated;


### PR DESCRIPTION
## Why

A referrer earned a referral free-pick, but the qualifying referee paid **after** lock. The normal redeem flow (`redeem_free_pick`) is caller-scoped and stamps `paid_at = now()`, so a post-lock redemption fails the leaderboard eligibility check (`paid_at <= lock_time`). This adds a super-admin-only way to grant a comped **free** entry with a **backdated** `paid_at` so the pick can rank.

`admin_set_prediction_payment` already supported backdating + super-admin post-lock bypass; the only gap was that it always wrote `is_free = false` (cash). "Mark Free" = "Mark Paid, tagged `is_free = true`" — keeps the books honest (dashboard splits `cash_paid_count` vs `free_entries`) and implies no cash changed hands.

## What

- **DB** `0067_admin_mark_free.sql`: re-emits `admin_set_prediction_payment` with a new optional `p_is_free boolean default false`. Free entries require `is_super_admin()` unconditionally; the upsert now also sets `is_free`. Old 3-arg overload dropped to avoid PostgREST ambiguity.
- **API** `payment/route.ts`: PATCH accepts `isFree`, forwards `p_is_free`, maps `forbidden` → 403; GET returns `isFree`.
- **API** admin predictions list: returns `isFreePaid`.
- **UI** `AdminUserBracket.tsx`: super-admin-only **Mark Free** button (reuses the "Paid at" datetime for backdating); badge shows "free — eligible" vs "paid — eligible".
- **Tests**: payment-route test covering `p_is_free` forwarding + `forbidden` → 403.

## Design decisions (confirmed with org)

- **Comp only** — no referral/loyalty ledger writes; the referrer's `available_credits` is unaffected. Acceptable for this one-off.
- **Label "Mark Free"** (not "Mark Fee", which reads like a charge).

## Verification

- `npm test` (533 pass, incl. new payment-route tests), `npm run typecheck`, `npm run lint` (clean — 2 pre-existing warnings only).
- ⚠️ Not yet run against local Supabase — please `supabase db reset` and confirm: super admin sees Mark Free + backdated free entry ranks; non-super admin gets 403 on a direct `isFree:true` PATCH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)