### PR TITLE
feat(leaderboard): player/prediction-name search filter

### DIFF
--- a/frontend/src/app/api/leaderboard/__tests__/route.test.ts
+++ b/frontend/src/app/api/leaderboard/__tests__/route.test.ts
@@ -119,7 +119,23 @@ describe('GET /api/leaderboard', () => {
       p_tournament_id: 't1',
       p_page: 1,
       p_page_size: 100,
+      p_search: '',
     });
+  });
+
+  it('forwards the search term to the RPC as p_search', async () => {
+    let callIdx = 0;
+    supabaseMock.from.mockImplementation(() => {
+      const handler = callIdx === 0 ? mockTournamentLookup() : mockProfileLookup(false);
+      callIdx += 1;
+      return handler;
+    });
+    supabaseMock.rpc.mockResolvedValue({ data: [], error: null });
+    await GET(req('?page=1&pageSize=25&search=alice'));
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'get_leaderboard',
+      expect.objectContaining({ p_search: 'alice' })
+    );
   });
 
   it('uses get_leaderboard (no email) for an authenticated non-admin', async () => {

--- a/frontend/src/app/api/leaderboard/route.ts
+++ b/frontend/src/app/api/leaderboard/route.ts
@@ -5,6 +5,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
   const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get('pageSize') ?? '25', 10)));
+  const search = searchParams.get('search') ?? '';
 
   const supabase = await getServerSupabase();
 
@@ -42,6 +43,7 @@ export async function GET(request: NextRequest) {
     p_tournament_id: tournament.id,
     p_page: page,
     p_page_size: pageSize,
+    p_search: search,
   });
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -13,6 +13,7 @@ import { Pagination, DEFAULT_ITEMS_PER_PAGE } from '@/components/shared/Paginati
 import { needsPayment } from '@/lib/predictions/paymentStatus';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/hooks/useAuth';
 import { useTournamentLock } from '@/hooks/useTournamentLock';
@@ -64,6 +65,15 @@ export function LeaderboardPageContent() {
   const { isLocked, phase } = useTournamentLock();
   const [currentPage, setCurrentPage] = React.useState(1);
   const [highlightedRank, setHighlightedRank] = React.useState<number | null>(null);
+  // `search` tracks the input instantly; `debounced` (250ms) drives the fetch so
+  // we don't hit the API on every keystroke. Mirrors AdminUsersList.
+  const [search, setSearch] = React.useState('');
+  const [debounced, setDebounced] = React.useState('');
+
+  React.useEffect(() => {
+    const t = setTimeout(() => setDebounced(search.trim()), 250);
+    return () => clearTimeout(t);
+  }, [search]);
 
   const currentUsername = profile?.username ?? null;
   // Staff (admin or super-admin — the latter doesn't imply the former) can
@@ -91,10 +101,10 @@ export function LeaderboardPageContent() {
       : 'anon';
 
   const query = useQuery<LeaderboardResponse>({
-    queryKey: ['leaderboard', currentPage, viewerKey],
+    queryKey: ['leaderboard', currentPage, viewerKey, debounced],
     queryFn: async () => {
       const res = await fetch(
-        `/api/leaderboard?page=${currentPage}&pageSize=${DEFAULT_ITEMS_PER_PAGE}`
+        `/api/leaderboard?page=${currentPage}&pageSize=${DEFAULT_ITEMS_PER_PAGE}&search=${encodeURIComponent(debounced)}`
       );
       if (!res.ok) throw new Error('Failed to fetch leaderboard');
       return res.json();
@@ -262,7 +272,9 @@ export function LeaderboardPageContent() {
         </div>
       )}
 
-      {user && (
+      {/* Hide the user's own unpaid-predictions surface while a search is active —
+          it's noise unrelated to the filtered results. */}
+      {user && !debounced && (
         <>
           <UnpaidPaymentNotice
             unpaidCount={unpaidPredictions.length}
@@ -272,10 +284,29 @@ export function LeaderboardPageContent() {
         </>
       )}
 
+      <div className="relative mb-4 max-w-sm">
+        <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+        <Input
+          type="search"
+          placeholder="Search player or prediction name…"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setCurrentPage(1);
+          }}
+          className="pl-9"
+          aria-label="Search the leaderboard"
+        />
+      </div>
+
       <Card className="mb-6">
         <CardContent className="p-0">
           {isLoading ? (
             <LeaderboardSkeleton />
+          ) : debounced && entries.length === 0 ? (
+            <p className="text-muted-foreground px-4 py-12 text-center text-sm">
+              No players match &ldquo;{debounced}&rdquo;.
+            </p>
           ) : (
             <LeaderboardTable
               entries={entries}

--- a/supabase/migrations/0068_leaderboard_search.sql
+++ b/supabase/migrations/0068_leaderboard_search.sql
@@ -1,0 +1,285 @@
+-- 0068_leaderboard_search.sql
+--
+-- Add a username / prediction-name search filter to the leaderboard. Re-emits
+-- get_leaderboard (and the admin wrapper) from 0055 with an added
+-- `p_search text default null` parameter. The scoring/ranked CTE block is
+-- unchanged: row_number() still computes each prediction's TRUE global rank over
+-- the full paid set. Only the final SELECT changes — it filters the ranked rows
+-- by the search term so count(*) over () (total_count) and the OFFSET/LIMIT page
+-- the filtered subset, while `rank` stays the global position. This lets the UI
+-- search the whole leaderboard (not just the current page) and still show real
+-- ranks.
+--
+-- Search matches username + prediction_name (case-insensitive substring, mirroring
+-- admin_list_users in 0061). Email is intentionally not searchable here.
+--
+-- Adding a parameter changes the function's argument list, which CREATE OR REPLACE
+-- cannot do in place — drop both first (wrapper before base; the wrapper only calls
+-- get_leaderboard at runtime), then recreate.
+
+drop function if exists public.admin_get_leaderboard(uuid, int, int);
+drop function if exists public.get_leaderboard(uuid, int, int);
+
+create or replace function public.get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25,
+    p_search text default null
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    champion_pick_points int,
+    total_goals int,
+    updated_at timestamptz,
+    total_count bigint
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    search_term as (
+        select nullif(trim(coalesce(p_search, '')), '') as q
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 15 else 10 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 7
+                    else
+                        case
+                            when gp.first_team_id = gs.first_team_id then 5   -- single team, correct slot
+                            when gp.second_team_id = gs.second_team_id then 5 -- single team, correct slot
+                            when gp.first_team_id = gs.second_team_id then 2  -- single team, wrong slot
+                            when gp.second_team_id = gs.first_team_id then 2  -- single team, wrong slot
+                            else 0
+                        end
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 2.5
+                    when ta_team.team_id is not null then 2.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    knockout_round_totals as (
+        select s.prediction_id, coalesce(sum(s.round_points), 0)::int as round_points
+        from public.knockout_round_config() c
+        cross join lateral public.knockout_round_scores(
+            p_tournament_id, c.stage, c.correct_pts, c.wrong_pts
+        ) s
+        group by s.prediction_id
+    ),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_champion_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M104'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_third_place_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M103'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M103'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id
+                    then public.scoring_champion_pick_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(krt.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join knockout_round_totals krt on krt.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            pr.username::text as username,
+            coalesce(gsc.group_points, 0) as group_points,
+            coalesce(asc_.advancer_points, 0)::numeric as advancer_points,
+            coalesce(ksc.knockout_points, 0) as knockout_points,
+            coalesce(ksc.champion_pick_points, 0) as champion_pick_points,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            p.total_goals,
+            p.updated_at as updated_at,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.submitted_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        join public.profiles pr on pr.id = p.user_id
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        rank,
+        prediction_id,
+        prediction_name,
+        username,
+        points,
+        group_points,
+        advancer_points,
+        knockout_points,
+        champion_pick_points,
+        total_goals,
+        updated_at,
+        count(*) over () as total_count
+    from ranked, search_term
+    where search_term.q is null
+       or ranked.username ilike '%' || search_term.q || '%'
+       or ranked.prediction_name ilike '%' || search_term.q || '%'
+    order by rank
+    offset greatest(p_page - 1, 0) * greatest(p_page_size, 1)
+    limit greatest(p_page_size, 1);
+$$;
+
+grant execute on function public.get_leaderboard(uuid, int, int, text) to anon, authenticated;
+
+-- Re-emit the admin wrapper (0055) so admins get the same search + email column.
+create or replace function public.admin_get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25,
+    p_search text default null
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    email text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    champion_pick_points int,
+    total_goals int,
+    updated_at timestamptz,
+    total_count bigint
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    return query
+    select
+        lb.rank,
+        lb.prediction_id,
+        lb.prediction_name,
+        lb.username,
+        u.email::text as email,
+        lb.points,
+        lb.group_points,
+        lb.advancer_points,
+        lb.knockout_points,
+        lb.champion_pick_points,
+        lb.total_goals,
+        lb.updated_at,
+        lb.total_count
+    from public.get_leaderboard(p_tournament_id, p_page, p_page_size, p_search) lb
+    join public.predictions p on p.id = lb.prediction_id
+    left join auth.users u on u.id = p.user_id
+    order by lb.rank;
+end;
+$$;
+
+grant execute on function public.admin_get_leaderboard(uuid, int, int, text) to authenticated;


### PR DESCRIPTION
## Context

The leaderboard is paginated 25/page with no way to find a specific player or prediction — finding someone ranked deep means clicking through many pages. This adds a search **input** above the table that filters by player username or prediction name **across the whole leaderboard**, not just the current page.

Each matching row keeps its **true global rank** (e.g. searching "dave" still shows rank #142), while pagination and the participant count reflect the filtered set.

Mirrors the existing admin-users search pattern (`admin_list_users` + `AdminUsersList.tsx`) for both the SQL (ILIKE substring) and the debounced `Input` UI.

## Changes

- **`migration 0068_leaderboard_search.sql`** — re-emits `get_leaderboard` and `admin_get_leaderboard` with an added `p_search text default null` param. Scoring/`ranked` CTE is unchanged (verbatim from 0055), so `row_number()` still computes the global rank over the full paid set. Only the final SELECT changes: it filters ranked rows by `username`/`prediction_name` ILIKE so `count(*) over ()` and OFFSET/LIMIT page the filtered subset while `rank` stays global. Adding a param changes the arg list, so both functions are dropped + recreated (wrapper before base).
- **`/api/leaderboard/route.ts`** — reads `?search` and forwards it as `p_search` to both RPC branches.
- **`LeaderboardPageContent.tsx`** — debounced (250ms) search `Input`, `debounced` folded into the query key + fetch URL, page reset to 1 on input, empty-results message, and the own-unpaid-predictions surface hidden while a search is active.

Search scope is username + prediction_name only (email isn't searchable here — the admin users page already covers that).

## Verification

- `npm test` (534 pass), `npm run typecheck` (clean), `npm run lint` (only pre-existing jest.setup warnings). Added a route test asserting `?search` is forwarded as `p_search`.
- **Pending local (reviewer):** `supabase db reset` to apply 0068, then confirm `get_leaderboard('<tid>', 1, 25, 'dave')` returns only matches with global ranks preserved and `total_count` = match count; and on `/leaderboard` the input filters across pages, clears cleanly, and shows the empty state for no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)