### PR TITLE
feat(prizes): prize display on /prizes, leaderboard, and predictions

### DIFF
--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -7,6 +7,7 @@ import { ArrowRight, Lock, Search, Trophy, Users } from 'lucide-react';
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
+import { PrizeTables } from '@/components/shared/PrizeTables';
 import { UnpaidPredictionsTable } from '@/components/leaderboard/UnpaidPredictionsTable';
 import { UnpaidPaymentNotice } from '@/components/predictions/UnpaidPaymentNotice';
 import { Pagination, DEFAULT_ITEMS_PER_PAGE } from '@/components/shared/Pagination';
@@ -17,7 +18,7 @@ import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/hooks/useAuth';
 import { useTournamentLock } from '@/hooks/useTournamentLock';
-import { ROUTES } from '@/lib/constants';
+import { PRIZE_RANK_CUTOFF, ROUTES } from '@/lib/constants';
 import type { LeaderboardEntry, LeaderboardRankMatch } from '@/types/tournament';
 
 function LeaderboardSkeleton() {
@@ -62,7 +63,13 @@ interface PredictionsResponse {
 
 export function LeaderboardPageContent() {
   const { user, profile } = useAuth();
-  const { isLocked, phase } = useTournamentLock();
+  const { isLocked, phase, knockoutUnlocked } = useTournamentLock();
+  // Phase 2 (knockout) pays the top 5; Phase 1 (group stage) pays the top 3.
+  // Once the admin opens the knockout, flag 4th/5th as prize-winning rows.
+  const prizeRankCutoff = knockoutUnlocked
+    ? PRIZE_RANK_CUTOFF.phase2
+    : PRIZE_RANK_CUTOFF.phase1;
+  const activePrizePhase = knockoutUnlocked ? 'phase2' : 'phase1';
   const [currentPage, setCurrentPage] = React.useState(1);
   const [highlightedRank, setHighlightedRank] = React.useState<number | null>(null);
   // `search` tracks the input instantly; `debounced` (250ms) drives the fetch so
@@ -284,6 +291,19 @@ export function LeaderboardPageContent() {
         </>
       )}
 
+      <section className="mb-6">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-xl font-bold">Prizes</h2>
+          <Button variant="link" size="sm" asChild className="text-muted-foreground">
+            <Link href={ROUTES.prizes}>
+              Details
+              <ArrowRight className="ml-1 h-3.5 w-3.5" />
+            </Link>
+          </Button>
+        </div>
+        <PrizeTables activePhase={activePrizePhase} />
+      </section>
+
       <div className="relative mb-4 max-w-sm">
         <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
         <Input
@@ -316,6 +336,7 @@ export function LeaderboardPageContent() {
               canPreviewOthers={canPreviewOthers}
               // Edit deep-link only while predictions are still editable.
               enableEdit={!!user && !isLocked}
+              prizeRankCutoff={prizeRankCutoff}
             />
           )}
         </CardContent>

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -13,6 +13,7 @@ import {
   Pencil,
   Plus,
   Trash2,
+  Trophy,
 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -41,6 +42,7 @@ import {
   useRewardsStatus,
 } from '@/hooks/useRewardsStatus';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
+import { getRankBadge } from '@/components/leaderboard/rankBadge';
 import { FreePickBanner } from '@/components/predictions/FreePickBanner';
 import { UnpaidPaymentNotice } from '@/components/predictions/UnpaidPaymentNotice';
 import { PRICING, ROUTES } from '@/lib/constants';
@@ -51,6 +53,7 @@ import {
   type NewDraftData,
 } from '@/lib/predictions/draftSummary';
 import { cn } from '@/lib/utils';
+import type { LeaderboardRankMatch } from '@/types/tournament';
 
 interface ApiPrediction {
   id: string;
@@ -90,6 +93,20 @@ export function PredictionsListPage() {
     queryKey: ['predictions'],
     queryFn: () => fetchJSON('/api/predictions'),
   });
+
+  // Per-prediction leaderboard rank — only paid + ranked predictions come back,
+  // so the map naturally excludes unpaid/draft entries. Shared cache key with the
+  // leaderboard's own "find me" query.
+  const rankQuery = useQuery<{ matches: LeaderboardRankMatch[] }>({
+    queryKey: ['leaderboard-me', user?.id ?? null],
+    queryFn: () => fetchJSON('/api/leaderboard/me'),
+    enabled: !!user,
+  });
+  const rankByPrediction = React.useMemo(() => {
+    const map = new Map<string, LeaderboardRankMatch>();
+    for (const m of rankQuery.data?.matches ?? []) map.set(m.predictionId, m);
+    return map;
+  }, [rankQuery.data]);
 
   // Skew-adjusted phase state — robust to client clock manipulation. The
   // server-side RPC enforces the actual write boundary; this is purely UX.
@@ -364,6 +381,20 @@ export function PredictionsListPage() {
                         <Clock className="h-3 w-3" /> Unpaid
                       </Badge>
                     )}
+                    {(() => {
+                      const match = rankByPrediction.get(p.id);
+                      if (!match) return null;
+                      const rankColor = getRankBadge(match.rank)?.color;
+                      return (
+                        <Badge
+                          variant="secondary"
+                          className={cn('gap-1', rankColor)}
+                          title={`Currently ranked #${match.rank} on the leaderboard`}
+                        >
+                          <Trophy className="h-3 w-3" /> Rank #{match.rank}
+                        </Badge>
+                      );
+                    })()}
                   </div>
                   <div className="text-muted-foreground mt-1 text-sm">
                     {p.submittedAt

--- a/frontend/src/app/prizes/page.tsx
+++ b/frontend/src/app/prizes/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { ArrowRight } from 'lucide-react';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { PrizeTables } from '@/components/shared/PrizeTables';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ROUTES } from '@/lib/constants';
+import { getServerSupabase } from '@/lib/supabase/server';
+
+export const metadata: Metadata = {
+  title: 'Prizes | World Cup 2026',
+  description:
+    'Cash prizes for the World Cup 2026 Prediction Game — Phase 1 (group stage) rewards the top 3 and Phase 2 (knockout) rewards the top 5.',
+};
+
+export default async function PrizesPage() {
+  const supabase = await getServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`${ROUTES.login}?next=${encodeURIComponent(ROUTES.prizes)}`);
+  }
+
+  return (
+    <PageLayout>
+      <section className="py-12 text-center md:py-16">
+        <Badge variant="outline" className="mb-4">
+          Prizes
+        </Badge>
+        <h1 className="mb-4 text-3xl font-bold tracking-tight md:text-5xl">Prizes</h1>
+        <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
+          Two separate payouts. Phase 1 rewards the top of the group-stage standings, and
+          Phase 2 rewards the final knockout standings — your entry is in the running for both.
+        </p>
+      </section>
+
+      <section className="pb-8">
+        <PrizeTables />
+      </section>
+
+      <div className="flex justify-center">
+        <Button variant="outline" asChild>
+          <Link href={ROUTES.leaderboard}>
+            View the leaderboard
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </Button>
+      </div>
+    </PageLayout>
+  );
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -34,6 +34,7 @@ const navLinks: NavLink[] = [
   { label: 'Home', href: ROUTES.home, tier: 'always' },
   { label: 'Predictions', href: ROUTES.predictions, tier: 'always' },
   { label: 'Leaderboard', href: ROUTES.leaderboard, tier: 'always' },
+  { label: 'Prizes', href: ROUTES.prizes, tier: 'reveal-1' },
   { label: 'Results', href: ROUTES.results, tier: 'reveal-1' },
   { label: 'Rules & Scoring', href: ROUTES.rules, tier: 'reveal-2' },
   { label: 'About', href: ROUTES.about, tier: 'more' },

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -14,6 +14,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
+import { getRankBadge } from '@/components/leaderboard/rankBadge';
 import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 import type { LeaderboardEntry } from '@/types/tournament';
@@ -44,6 +45,13 @@ export interface LeaderboardTableProps {
    * still gated on `currentUsername` so other players' rows never get one.
    */
   enableEdit?: boolean;
+  /**
+   * Number of top finishing positions that win a prize, used to flag the
+   * prize-winning rows with a coloured rank badge. Phase 1 pays the top 3, so
+   * 4th/5th stay un-flagged; once Phase 2 begins the leaderboard passes 5 so
+   * 4th and 5th light up too. Defaults to 3.
+   */
+  prizeRankCutoff?: number;
 }
 
 function formatUpdated(value?: string | null): string | null {
@@ -56,19 +64,6 @@ function formatUpdated(value?: string | null): string | null {
     hour: 'numeric',
     minute: '2-digit',
   });
-}
-
-function getRankBadge(rank: number): { color: string; label: string } | null {
-  switch (rank) {
-    case 1:
-      return { color: 'bg-yellow-500 text-yellow-950', label: '1st' };
-    case 2:
-      return { color: 'bg-gray-400 dark:bg-gray-300 text-gray-950', label: '2nd' };
-    case 3:
-      return { color: 'bg-amber-600 text-amber-950', label: '3rd' };
-    default:
-      return null;
-  }
 }
 
 function ChangeIndicator({ change }: { change: number }) {
@@ -104,6 +99,7 @@ export function LeaderboardTable({
   enablePreview = false,
   canPreviewOthers = false,
   enableEdit = false,
+  prizeRankCutoff = 3,
 }: LeaderboardTableProps) {
   const [previewId, setPreviewId] = React.useState<string | null>(null);
 
@@ -129,7 +125,9 @@ export function LeaderboardTable({
             const isCurrentUser =
               currentUsername && entry.username.toLowerCase() === currentUsername.toLowerCase();
             const isHighlighted = highlightedRank && entry.rank === highlightedRank;
-            const rankBadge = getRankBadge(entry.rank);
+            // Only flag rows that actually win a prize this phase — beyond the
+            // cutoff the rank shows as plain text.
+            const rankBadge = entry.rank <= prizeRankCutoff ? getRankBadge(entry.rank) : null;
             const isEvenRow = index % 2 === 0;
             const canPreviewThisRow = isCurrentUser || canPreviewOthers;
 

--- a/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
+++ b/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
@@ -77,6 +77,27 @@ describe('LeaderboardTable', () => {
     expect(screen.getByText('3rd')).toBeInTheDocument();
   });
 
+  const fivePlaces: LeaderboardEntry[] = [
+    ...entries,
+    { ...entries[0], rank: 4, predictionId: 'p4', predictionName: 'Fourth', username: 'dave' },
+    { ...entries[0], rank: 5, predictionId: 'p5', predictionName: 'Fifth', username: 'erin' },
+  ];
+
+  it('does not flag 4th/5th by default (Phase 1 cutoff of 3)', () => {
+    render(<LeaderboardTable entries={fivePlaces} />);
+    expect(screen.queryByText('4th')).not.toBeInTheDocument();
+    expect(screen.queryByText('5th')).not.toBeInTheDocument();
+    // The rank still renders as plain text.
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('flags 4th and 5th when prizeRankCutoff is 5 (Phase 2)', () => {
+    render(<LeaderboardTable entries={fivePlaces} prizeRankCutoff={5} />);
+    expect(screen.getByText('4th')).toBeInTheDocument();
+    expect(screen.getByText('5th')).toBeInTheDocument();
+  });
+
   it('renders email in place of username when present (admin view)', () => {
     const adminEntries: LeaderboardEntry[] = [
       { ...entries[0], email: 'alice@example.com' },

--- a/frontend/src/components/leaderboard/rankBadge.ts
+++ b/frontend/src/components/leaderboard/rankBadge.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared rank-badge styling for the leaderboard standings and the prize tables,
+ * so both surfaces colour 1st–5th identically. 1st–3rd are the classic
+ * gold/silver/bronze; 4th/5th get distinct cool tones since they only win in
+ * Phase 2. Returns null for ranks with no prize/badge.
+ */
+export interface RankBadge {
+  color: string;
+  label: string;
+}
+
+export function getRankBadge(rank: number): RankBadge | null {
+  switch (rank) {
+    case 1:
+      return { color: 'bg-yellow-500 text-yellow-950', label: '1st' };
+    case 2:
+      return { color: 'bg-gray-400 dark:bg-gray-300 text-gray-950', label: '2nd' };
+    case 3:
+      return { color: 'bg-amber-600 text-amber-950', label: '3rd' };
+    case 4:
+      return { color: 'bg-sky-500 text-sky-950', label: '4th' };
+    case 5:
+      return { color: 'bg-violet-500 text-violet-950', label: '5th' };
+    default:
+      return null;
+  }
+}

--- a/frontend/src/components/shared/PrizeTables.tsx
+++ b/frontend/src/components/shared/PrizeTables.tsx
@@ -1,0 +1,110 @@
+import Link from 'next/link';
+import { Trophy } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { getRankBadge } from '@/components/leaderboard/rankBadge';
+import { PRIZES, ROUTES, formatPrizeCAD } from '@/lib/constants';
+import { cn } from '@/lib/utils';
+
+type PrizePhase = 'phase1' | 'phase2';
+
+const PHASE_META: Record<PrizePhase, { title: string; blurb: string }> = {
+  phase1: {
+    title: 'Phase 1 — Group Stage',
+    blurb: 'Top 3 on the group-stage standings.',
+  },
+  phase2: {
+    title: 'Phase 2 — Knockout',
+    blurb: 'Top 5 on the final knockout standings.',
+  },
+};
+
+function PrizeCard({ phase, active }: { phase: PrizePhase; active?: boolean }) {
+  const meta = PHASE_META[phase];
+  return (
+    <Card className={cn(active && 'border-primary ring-primary/30 ring-1')}>
+      <CardHeader>
+        <CardTitle className="flex flex-wrap items-center gap-2">
+          <Trophy className="text-primary h-5 w-5" />
+          {meta.title}
+          {active && <Badge variant="secondary">Active now</Badge>}
+        </CardTitle>
+        <p className="text-muted-foreground text-sm">{meta.blurb}</p>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-24">Place</TableHead>
+              <TableHead className="text-right">Prize</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {PRIZES[phase].map((prize) => {
+              const badge = getRankBadge(prize.rank);
+              return (
+                <TableRow key={prize.rank}>
+                  <TableCell>
+                    {badge && (
+                      <Badge className={cn('gap-1', badge.color)}>
+                        <Trophy className="h-3 w-3" />
+                        {badge.label}
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right font-semibold">
+                    {formatPrizeCAD(prize.amountCAD)}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export interface PrizeTablesProps {
+  /**
+   * Optionally emphasize the currently-active phase's card with a ring + "Active
+   * now" badge. Omit (e.g. on the dedicated /prizes page) to render both neutrally.
+   */
+  activePhase?: PrizePhase;
+  className?: string;
+}
+
+/**
+ * Side-by-side Phase 1 / Phase 2 prize tables. Single source of truth for prize
+ * rendering, shared by the /prizes page and the leaderboard.
+ */
+export function PrizeTables({ activePhase, className }: PrizeTablesProps) {
+  return (
+    <div className={className}>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <PrizeCard phase="phase1" active={activePhase === 'phase1'} />
+        <PrizeCard phase="phase2" active={activePhase === 'phase2'} />
+      </div>
+      <p className="text-muted-foreground mt-3 text-xs">
+        These amounts already have the per-entry portion sent to{' '}
+        <Link href={ROUTES.charities} className="hover:text-foreground underline">
+          charity
+        </Link>{' '}
+        and{' '}
+        <Link href={ROUTES.audit} className="hover:text-foreground underline">
+          management fees
+        </Link>{' '}
+        deducted.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/shared/__tests__/PrizeTables.test.tsx
+++ b/frontend/src/components/shared/__tests__/PrizeTables.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { PrizeTables } from '../PrizeTables';
+
+describe('PrizeTables', () => {
+  it('renders both phase headings', () => {
+    render(<PrizeTables />);
+    expect(screen.getByText('Phase 1 — Group Stage')).toBeInTheDocument();
+    expect(screen.getByText('Phase 2 — Knockout')).toBeInTheDocument();
+  });
+
+  it('renders the Phase 1 (top 3) prize amounts', () => {
+    render(<PrizeTables />);
+    expect(screen.getByText('$200')).toBeInTheDocument();
+    expect(screen.getByText('$100')).toBeInTheDocument();
+  });
+
+  it('renders the Phase 2 (top 5) prize amounts including 4th and 5th', () => {
+    render(<PrizeTables />);
+    expect(screen.getByText('$2,000')).toBeInTheDocument();
+    expect(screen.getByText('$700')).toBeInTheDocument();
+    expect(screen.getByText('$215')).toBeInTheDocument();
+    expect(screen.getByText('$142')).toBeInTheDocument();
+  });
+
+  it('shows place badges through 5th', () => {
+    render(<PrizeTables />);
+    // 4th/5th only exist in Phase 2; 1st–3rd appear in both phases.
+    expect(screen.getByText('4th')).toBeInTheDocument();
+    expect(screen.getByText('5th')).toBeInTheDocument();
+    expect(screen.getAllByText('1st')).toHaveLength(2);
+  });
+
+  it('flags the active phase with an "Active now" badge', () => {
+    render(<PrizeTables activePhase="phase2" />);
+    expect(screen.getByText('Active now')).toBeInTheDocument();
+  });
+
+  it('renders no active badge when activePhase is omitted', () => {
+    render(<PrizeTables />);
+    expect(screen.queryByText('Active now')).not.toBeInTheDocument();
+  });
+
+  it('shows the charity / management-fee deduction footnote with links', () => {
+    render(<PrizeTables />);
+    expect(screen.getByRole('link', { name: 'charity' })).toHaveAttribute('href', '/charities');
+    expect(screen.getByRole('link', { name: 'management fees' })).toHaveAttribute(
+      'href',
+      '/audit'
+    );
+  });
+});

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -51,6 +51,41 @@ export const PRICING = {
 } as const;
 
 /**
+ * Fixed cash prizes per finishing position, in CAD. Two independent payouts:
+ * Phase 1 rewards the top of the group-stage standings (top 3); Phase 2 rewards
+ * the final knockout standings (top 5). Values are set by the pool organizer and
+ * are not pot-derived, so they live here as a static source of truth surfaced on
+ * the /prizes page, the leaderboard, and the predictions list. `rank` mirrors the
+ * leaderboard rank a prediction must hold to win that amount.
+ */
+export const PRIZES = {
+  phase1: [
+    { rank: 1, amountCAD: 400 },
+    { rank: 2, amountCAD: 200 },
+    { rank: 3, amountCAD: 100 },
+  ],
+  phase2: [
+    { rank: 1, amountCAD: 2000 },
+    { rank: 2, amountCAD: 700 },
+    { rank: 3, amountCAD: 400 },
+    { rank: 4, amountCAD: 215 },
+    { rank: 5, amountCAD: 142 },
+  ],
+} as const;
+
+/** Number of prize-winning leaderboard positions per phase (Phase 1 pays top 3,
+ *  Phase 2 pays top 5). Drives how many standings rows the leaderboard flags. */
+export const PRIZE_RANK_CUTOFF = {
+  phase1: PRIZES.phase1.length,
+  phase2: PRIZES.phase2.length,
+} as const;
+
+/** Format a whole-dollar CAD prize amount, e.g. 2000 → "$2,000". */
+export function formatPrizeCAD(amount: number): string {
+  return `$${amount.toLocaleString('en-CA')}`;
+}
+
+/**
  * Address for out-of-band entry payments (Interac e-transfer / PayPal). Surfaced
  * in the rules page and the unpaid-prediction payment notice. Single source so
  * the email only ever lives in one place.
@@ -98,6 +133,7 @@ export const ROUTES = {
   home: '/',
   predictions: '/predictions',
   leaderboard: '/leaderboard',
+  prizes: '/prizes',
   results: '/results',
   login: '/login',
   register: '/register',


### PR DESCRIPTION
## Summary

Surfaces the finalized fixed cash prizes across three locations.

**Prize structure (CAD):**

| Place | Phase 1 (group stage) | Phase 2 (knockout) |
|------:|----------------------:|-------------------:|
| 1st   | $400                  | $2,000             |
| 2nd   | $200                  | $700               |
| 3rd   | $100                  | $400               |
| 4th   | —                     | $215               |
| 5th   | —                     | $142               |

Values are fixed (not pot-derived), so they live as a static constant — no DB migration.

## Changes

- **Prize data**: `PRIZES`, `PRIZE_RANK_CUTOFF`, `formatPrizeCAD`, and `ROUTES.prizes` in `constants.ts`.
- **Shared `<PrizeTables />`**: side-by-side Phase 1 / Phase 2 tables, the single source of truth for prize rendering. Includes a footnote that the amounts already have the per-entry charity portion and management fees deducted (links to `/charities` and `/audit`).
- **`/prizes` page**: auth-gated (redirects to `/login?next=/prizes`), plus a **Prizes** nav link.
- **Leaderboard**: renders the prize tables above the filter row, and flags the prize-winning standings rows — top 3 in Phase 1, top **5** once Phase 2 (knockout) opens (`knockoutUnlocked`) — via a new `prizeRankCutoff` prop. Rank-badge styling extracted to `rankBadge.ts` and extended to 4th/5th.
- **Predictions list**: each paid prediction shows its current leaderboard rank inline, reusing the existing `/api/leaderboard/me` data (no API/RPC changes).

## Testing

- `npm test` — 543 passing (added `PrizeTables` tests + `LeaderboardTable` cutoff tests)
- `npm run typecheck` — clean
- `npm run lint` — clean (pre-existing `jest.setup.tsx` warnings only)
