### PR TITLE
fix(lock-banner): decouple knockout-lock message from best-3rd advancers

### DIFF
--- a/frontend/src/app/api/tournament/route.ts
+++ b/frontend/src/app/api/tournament/route.ts
@@ -22,18 +22,6 @@ export async function GET() {
     return NextResponse.json({ error: 'No active tournament' }, { status: 404 });
   }
 
-  // Whether the admin has finished posting the 8 ranked 3rd-place
-  // advancers. Used by the banner to differentiate phase1_locked states:
-  //   * advancers not yet set → "Waiting for admin to post the advancers"
-  //   * advancers set + phase 2 closed → "Knockout predictions paused"
-  // tournament_advancers has a public SELECT policy so this works for
-  // unauthenticated visitors too.
-  const advancersCountRes = await supabase
-    .from('tournament_advancers')
-    .select('rank', { count: 'exact', head: true })
-    .eq('tournament_id', tournamentRes.data.id);
-  const advancersSet = (advancersCountRes.count ?? 0) === 8;
-
   const data = tournamentRes.data as {
     id: string;
     slug: string;
@@ -93,7 +81,6 @@ export async function GET() {
     lockTime: data.lock_time,
     knockoutLockTime: data.knockout_lock_time,
     knockoutUnlocked: data.knockout_unlocked,
-    advancersSet,
     phase,
     totalEntries,
     cashPaidPredictionCount,

--- a/frontend/src/app/predictions/PredictionsListPage.tsx
+++ b/frontend/src/app/predictions/PredictionsListPage.tsx
@@ -110,13 +110,16 @@ export function PredictionsListPage() {
 
   // Skew-adjusted phase state — robust to client clock manipulation. The
   // server-side RPC enforces the actual write boundary; this is purely UX.
-  const { isLocked, phase, advancersSet } = useTournamentLock();
+  const { isLocked, phase, knockoutLockTime } = useTournamentLock();
   const isSuperAdmin = profile?.isSuperAdmin === true;
   // Once the knockout stage has begun (phase2 closed naturally, or admin
-  // closed phase2 after posting advancers) there's nothing for a regular
-  // user to edit. The Preview button still covers viewing the bracket.
+  // opened then closed phase2) there's nothing for a regular user to edit.
+  // The Preview button still covers viewing the bracket. `knockout_lock_time`
+  // is set only by opening Phase 2 and never cleared, so a non-null value
+  // during phase1_locked marks an opened-then-closed Phase 2.
   const knockoutStageLocked =
-    phase === 'phase2_locked' || (phase === 'phase1_locked' && advancersSet);
+    phase === 'phase2_locked' ||
+    (phase === 'phase1_locked' && knockoutLockTime !== null);
 
   const predictions = query.data?.predictions ?? [];
   // Unpaid entries that would rank once paid — drive the red payment notice +

--- a/frontend/src/components/layout/LockStatusBanner.tsx
+++ b/frontend/src/components/layout/LockStatusBanner.tsx
@@ -35,7 +35,7 @@ export function LockStatusBanner() {
     remainingMs,
     hasActiveDeadline,
     clockSuspect,
-    advancersSet,
+    knockoutLockTime,
   } = useTournamentLock();
   const { profile } = useAuth();
   const [dismissed, setDismissed] = React.useState(false);
@@ -71,11 +71,15 @@ export function LockStatusBanner() {
   const urgent =
     (phase === 'phase1' || phase === 'phase2_open') && remainingMs <= ONE_DAY_MS;
 
-  // Once advancers are posted, phase1_locked means the admin opened and
-  // then closed phase 2 (or hasn't reopened it yet). The knockout stage is
-  // now underway either way, so we display it the same as phase2_locked.
+  // The knockout stage has begun once Phase 2 was opened (a knockout lock
+  // time was set) and is no longer accepting writes. `knockout_lock_time` is
+  // only ever written by opening Phase 2 and is never cleared on close, so a
+  // non-null value during phase1_locked means the admin opened then closed
+  // Phase 2 (or hasn't reopened it). Entering best-3rd advancers no longer
+  // factors in — it's a scoring input that can be filled mid-group-stage.
   const knockoutLocked =
-    phase === 'phase2_locked' || (phase === 'phase1_locked' && advancersSet);
+    phase === 'phase2_locked' ||
+    (phase === 'phase1_locked' && knockoutLockTime !== null);
 
   // Tone + icon per phase.
   let tone: 'open' | 'urgent' | 'between' | 'locked' = 'open';
@@ -103,8 +107,8 @@ export function LockStatusBanner() {
           <span className="font-medium">
             {phase === 'phase1' &&
               `You have ${formatRemaining(remainingMs)} left to choose your group + best-3rd picks before the tournament starts! Don't miss out!`}
-            {phase === 'phase1_locked' && !advancersSet &&
-              'Group stage in progress. Knockout predictions will open once the admin posts the best-3rd advancers.'}
+            {phase === 'phase1_locked' && !knockoutLocked &&
+              'Group stage in progress. Knockout predictions will open once the knockout bracket is determined.'}
             {phase === 'phase2_open' && hasActiveDeadline &&
               `You have ${formatRemaining(remainingMs)} left to make your knockout picks!`}
             {phase === 'phase2_open' && !hasActiveDeadline &&

--- a/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
@@ -31,12 +31,12 @@ function mockTournament({
   lockOffsetMs,
   serverOffsetMs = 0,
   phase,
-  advancersSet = false,
+  knockoutLockTime = null,
 }: {
   lockOffsetMs: number;
   serverOffsetMs?: number;
   phase?: 'phase1' | 'phase1_locked' | 'phase2_open' | 'phase2_locked';
-  advancersSet?: boolean;
+  knockoutLockTime?: string | null;
 }) {
   const lockTime = new Date(Date.now() + lockOffsetMs).toISOString();
   const serverTime = new Date(Date.now() + serverOffsetMs).toISOString();
@@ -51,9 +51,8 @@ function mockTournament({
       name: 'WC',
       status: 'upcoming',
       lockTime,
-      knockoutLockTime: null,
+      knockoutLockTime,
       knockoutUnlocked: false,
-      advancersSet,
       phase: phase ?? inferredPhase,
       totalEntries: 0,
       serverTime,
@@ -83,16 +82,31 @@ describe('LockStatusBanner', () => {
     expect(screen.getByRole('status').className).toContain('bg-amber-600');
   });
 
-  it('renders the between-phases state when phase 1 has ended and advancers not yet posted', async () => {
+  it('renders the between-phases state when phase 1 has ended and phase 2 not yet opened', async () => {
     mockTournament({ lockOffsetMs: -60_000 });
     render(wrap(<LockStatusBanner />));
     await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
     expect(screen.getByRole('status')).toHaveTextContent(/Group stage in progress/i);
+    expect(screen.getByRole('status')).toHaveTextContent(/knockout bracket is determined/i);
+    expect(screen.getByRole('status').className).toContain('bg-slate-600');
+  });
+
+  it('stays in the between-phases state when advancers are posted but phase 2 never opened', async () => {
+    // Regression: posting best-3rd advancers mid-group-stage must NOT trip the
+    // "knockout has begun" message. The only signal that matters is whether
+    // Phase 2 was ever opened (knockoutLockTime non-null).
+    mockTournament({ lockOffsetMs: -60_000, phase: 'phase1_locked', knockoutLockTime: null });
+    render(wrap(<LockStatusBanner />));
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    expect(screen.getByRole('status')).toHaveTextContent(/Group stage in progress/i);
+    expect(screen.getByRole('status')).not.toHaveTextContent(/knockout stage has begun/i);
     expect(screen.getByRole('status').className).toContain('bg-slate-600');
   });
 
   it('renders the knockout-stage message when phase 2 was opened and then closed by admin', async () => {
-    mockTournament({ lockOffsetMs: -60_000, phase: 'phase1_locked', advancersSet: true });
+    // Manual close reverts the phase to phase1_locked but leaves knockoutLockTime set.
+    const knockoutLockTime = new Date(Date.now() - 30_000).toISOString();
+    mockTournament({ lockOffsetMs: -60_000, phase: 'phase1_locked', knockoutLockTime });
     render(wrap(<LockStatusBanner />));
     await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
     expect(screen.getByRole('status')).toHaveTextContent(/knockout stage has begun/i);

--- a/frontend/src/hooks/useTournamentLock.ts
+++ b/frontend/src/hooks/useTournamentLock.ts
@@ -13,7 +13,6 @@ interface TournamentResponse {
   lockTime: string;
   knockoutLockTime: string | null;
   knockoutUnlocked: boolean;
-  advancersSet: boolean;
   phase: Phase;
   totalEntries: number;
   serverTime: string;
@@ -24,8 +23,6 @@ export interface TournamentLockState {
   lockTime: Date | null;
   knockoutLockTime: Date | null;
   knockoutUnlocked: boolean;
-  /** True when all 8 ranked 3rd-place advancers have been set by the admin. */
-  advancersSet: boolean;
   phase: Phase;
   isLoading: boolean;
   /** Server-time minus client-time, in ms. 0 if data not loaded. */
@@ -91,7 +88,6 @@ export function useTournamentLock(): TournamentLockState {
 
   const phase: Phase = data?.phase ?? 'phase1';
   const knockoutUnlocked = data?.knockoutUnlocked ?? false;
-  const advancersSet = data?.advancersSet ?? false;
 
   // The relevant deadline for "remainingMs" depends on phase:
   //   phase1 → lockTime
@@ -117,7 +113,6 @@ export function useTournamentLock(): TournamentLockState {
     lockTime,
     knockoutLockTime,
     knockoutUnlocked,
-    advancersSet,
     phase,
     isLoading: query.isLoading,
     skewMs,


### PR DESCRIPTION
## Problem

Admins have been entering the real-world **best-3rd-place advancers** as group-stage matches finish, but **Phase 2 (knockout) was never opened**. Despite that, the app showed *"The knockout stage has begun. Predictions are locked."* even though the knockout stage hadn't started.

**Root cause:** the UI used "all 8 advancers entered" (`advancersSet`) as a proxy for *"Phase 2 was opened then closed."* That proxy was valid under the old design where advancers gated Phase 2, but migration `0052_decouple_r32_bracket.sql` decoupled them — advancers are now purely a scoring input an admin can fill at any time. So entering them mid-group-stage wrongly trips the "knockout has begun" branch.

## Fix

Use `knockoutLockTime !== null` as the discriminator instead. `knockout_lock_time` is written **only** by opening Phase 2 (`admin_set_phase_two(unlocked=true)`) and is **never cleared on close**, so a non-null value reliably means Phase 2 was opened at least once.

- **`LockStatusBanner.tsx`** — `knockoutLocked` now keys off `knockoutLockTime`; the `phase1_locked` (Phase 2 never opened) message becomes: *"Group stage in progress. Knockout predictions will open once the knockout bracket is determined."*
- **`PredictionsListPage.tsx`** — same discriminator for hiding the Edit link.
- **Cleanup** — `advancersSet` is now fully dead, so removed it from the hook and dropped the per-request `tournament_advancers` count query on the frequently-polled `/api/tournament`.

## Phase 2 open/close (reviewed, no change needed)

- **Opening:** the only writer that sets `knockout_unlocked = true` is `admin_set_phase_two(unlocked=true)`; the admin flow requires a future Phase 2 lock time + complete standings/bracket. Nothing else opens Phase 2. ✅
- **Closing:** natural expiry → `phase2_locked`; manual close → `phase1_locked` with `knockoutLockTime` still set. Both block writes (`isLocked`, plus the `submit_predictions` RPC) and now both show "knockout stage has begun" correctly. ✅

## Testing

- `npm test` → 544 passed (added a regression test: advancers posted + Phase 2 never opened → stays "Group stage in progress").
- `npm run typecheck` clean; `npm run lint` clean (2 pre-existing unrelated warnings in `jest.setup.tsx`).
- No DB migration — frontend display-logic fix + dead-field cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)