### PR TITLE
feat(phase1-winners): snapshot Phase 1 top 3 and surface in prize modules

### DIFF
--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -103,6 +103,7 @@ export function TournamentSettingsForm() {
   const [championGoals, setChampionGoals] = React.useState('');
   const [savingSettings, setSavingSettings] = React.useState(false);
   const [savingPhase1, setSavingPhase1] = React.useState(false);
+  const [snapshotting, setSnapshotting] = React.useState(false);
   const [busyPhase2, setBusyPhase2] = React.useState(false);
   const [resetDialogOpen, setResetDialogOpen] = React.useState(false);
   const [resetConfirm, setResetConfirm] = React.useState('');
@@ -189,6 +190,28 @@ export function TournamentSettingsForm() {
       toast.error(e instanceof Error ? e.message : 'Failed to save');
     } finally {
       setSavingPhase1(false);
+    }
+  };
+
+  const handleSnapshotPhase1Winners = async () => {
+    if (!tournament.data) return;
+    setSnapshotting(true);
+    try {
+      const res = await fetch('/api/admin/tournament/snapshot-phase1-winners', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: tournament.data.id }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? 'Failed to snapshot');
+      }
+      toast.success('Phase 1 winners snapshotted');
+      await queryClient.invalidateQueries({ queryKey: ['phase1-winners'] });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to snapshot');
+    } finally {
+      setSnapshotting(false);
     }
   };
 
@@ -439,6 +462,21 @@ export function TournamentSettingsForm() {
             <Button onClick={handleSavePhase1Lock} disabled={savingPhase1}>
               {savingPhase1 ? 'Saving…' : 'Save Phase 1 lock time'}
             </Button>
+
+            <div className="space-y-1 border-t pt-3">
+              <Button
+                variant="outline"
+                onClick={handleSnapshotPhase1Winners}
+                disabled={snapshotting || !tournament.data}
+              >
+                {snapshotting ? 'Snapshotting…' : 'Snapshot Phase 1 Winners'}
+              </Button>
+              <p className="text-muted-foreground text-xs">
+                Freezes the current group-stage top 3 (group + advancer points) for the
+                Phase 1 prize and shows it on the leaderboard + prizes page. Run after group
+                standings + advancers are final; safe to re-run (overwrites).
+              </p>
+            </div>
           </CardContent>
         </Card>
 

--- a/frontend/src/app/api/admin/tournament/snapshot-phase1-winners/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/tournament/snapshot-phase1-winners/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function postReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/tournament/snapshot-phase1-winners', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('POST /api/admin/tournament/snapshot-phase1-winners', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when caller is not admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({}));
+    expect(res.status).toBe(400);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when RPC raises forbidden', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ error: { message: 'forbidden' } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when RPC raises tournament not found', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ error: { message: 'tournament not found' } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 and calls RPC on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ error: null });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_snapshot_phase1_winners', {
+      p_tournament_id: 't1',
+    });
+  });
+});

--- a/frontend/src/app/api/admin/tournament/snapshot-phase1-winners/route.ts
+++ b/frontend/src/app/api/admin/tournament/snapshot-phase1-winners/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+interface Body {
+  id?: string;
+}
+
+/**
+ * Freeze the Phase 1 (group + advancer) top 3 for the active tournament into the
+ * phase1_winners table. Admin-gated; calls admin_snapshot_phase1_winners, which
+ * overwrites any prior snapshot for the tournament. See migration 0070.
+ */
+export async function POST(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json()) as Body;
+  if (!body.id) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 });
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_snapshot_phase1_winners', {
+    p_tournament_id: body.id,
+  });
+
+  if (error) {
+    const msg = (error.message ?? '').toLowerCase();
+    let status = 400;
+    if (msg.includes('forbidden')) status = 403;
+    else if (msg.includes('not found')) status = 404;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/api/leaderboard/phase1-winners/__tests__/route.test.ts
+++ b/frontend/src/app/api/leaderboard/phase1-winners/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ */
+export {};
+
+const supabaseMock = {
+  from: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { GET } = require('../route');
+
+/**
+ * The route hits two tables: `tournaments` (select→eq→maybeSingle) for the active
+ * tournament, then `phase1_winners` (select→eq→order) for the rows. Branch the
+ * `from` mock on the table name.
+ */
+function mockTables(opts: {
+  tournament: { id: string } | null;
+  tournamentError?: unknown;
+  winners?: Array<Record<string, unknown>>;
+  winnersError?: unknown;
+}) {
+  supabaseMock.from.mockImplementation((table: string) => {
+    if (table === 'tournaments') {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data: opts.tournament,
+              error: opts.tournamentError ?? null,
+            }),
+          }),
+        }),
+      };
+    }
+    // phase1_winners
+    return {
+      select: () => ({
+        eq: () => ({
+          order: async () => ({
+            data: opts.winners ?? [],
+            error: opts.winnersError ?? null,
+          }),
+        }),
+      }),
+    };
+  });
+}
+
+describe('GET /api/leaderboard/phase1-winners', () => {
+  beforeEach(() => {
+    supabaseMock.from.mockReset();
+  });
+
+  it('returns an empty list when there is no active tournament', async () => {
+    mockTables({ tournament: null });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ winners: [] });
+  });
+
+  it('returns an empty list when no snapshot exists', async () => {
+    mockTables({ tournament: { id: 't1' }, winners: [] });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ winners: [] });
+  });
+
+  it('maps snapshot rows into the camelCase shape', async () => {
+    mockTables({
+      tournament: { id: 't1' },
+      winners: [
+        {
+          rank: 1,
+          prediction_id: 'p1',
+          prediction_name: 'Lucky Bracket',
+          username: 'dave',
+          group_points: 110,
+          advancer_points: 15.5,
+          phase1_points: 125.5,
+        },
+      ],
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      winners: [
+        {
+          rank: 1,
+          predictionId: 'p1',
+          predictionName: 'Lucky Bracket',
+          username: 'dave',
+          groupPoints: 110,
+          advancerPoints: 15.5,
+          phase1Points: 125.5,
+        },
+      ],
+    });
+  });
+
+  it('returns 500 when the winners query errors', async () => {
+    mockTables({ tournament: { id: 't1' }, winnersError: { message: 'boom' } });
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/frontend/src/app/api/leaderboard/phase1-winners/route.ts
+++ b/frontend/src/app/api/leaderboard/phase1-winners/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { getServerSupabase } from '@/lib/supabase/server';
+import type { Phase1Winner } from '@/types/tournament';
+
+/**
+ * Public read of the frozen Phase 1 (group + advancer) top 3 for the active
+ * tournament. Populated by an admin snapshot (admin_snapshot_phase1_winners,
+ * migration 0070). Returns an empty array until a snapshot has been taken, so
+ * the consuming card stays hidden pre-snapshot. The data is non-sensitive
+ * (usernames + points), readable by anon via the phase1_winners RLS policy.
+ */
+export async function GET() {
+  const supabase = await getServerSupabase();
+
+  const { data: tournament, error: tournamentError } = await supabase
+    .from('tournaments')
+    .select('id')
+    .eq('is_active', true)
+    .maybeSingle();
+  if (tournamentError) {
+    return NextResponse.json({ error: 'request failed' }, { status: 500 });
+  }
+  if (!tournament) {
+    return NextResponse.json({ winners: [] });
+  }
+
+  const { data, error } = await supabase
+    .from('phase1_winners')
+    .select(
+      'rank, prediction_id, prediction_name, username, group_points, advancer_points, phase1_points',
+    )
+    .eq('tournament_id', tournament.id)
+    .order('rank');
+  if (error) {
+    return NextResponse.json({ error: 'request failed' }, { status: 500 });
+  }
+
+  const winners: Phase1Winner[] = (data ?? []).map((row) => ({
+    rank: row.rank,
+    predictionId: row.prediction_id,
+    predictionName: row.prediction_name,
+    username: row.username,
+    groupPoints: row.group_points,
+    advancerPoints: Number(row.advancer_points),
+    phase1Points: Number(row.phase1_points),
+  }));
+
+  return NextResponse.json({ winners });
+}

--- a/frontend/src/components/leaderboard/Phase1WinnersCard.tsx
+++ b/frontend/src/components/leaderboard/Phase1WinnersCard.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { Trophy } from 'lucide-react';
+
+import { getRankBadge } from '@/components/leaderboard/rankBadge';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { usePhase1Winners } from '@/hooks/usePhase1Winners';
+import { PRIZES, formatPrizeCAD } from '@/lib/constants';
+import { cn } from '@/lib/utils';
+
+/**
+ * The frozen Phase 1 (group + advancer) top 3, snapshotted by an admin when Phase
+ * 2 opens. Renders nothing until a snapshot exists, so it only appears once the
+ * winners are locked in. Styled to match PrizeCard in shared/PrizeTables.tsx.
+ */
+export function Phase1WinnersCard({ className }: { className?: string }) {
+  const { winners } = usePhase1Winners();
+
+  if (winners.length === 0) return null;
+
+  return (
+    <Card className={cn('border-primary ring-primary/30 ring-1', className)}>
+      <CardHeader>
+        <CardTitle className="flex flex-wrap items-center gap-2">
+          <Trophy className="text-primary h-5 w-5" />
+          Phase 1 Winners
+          <Badge variant="secondary">Final</Badge>
+        </CardTitle>
+        <p className="text-muted-foreground text-sm">
+          Frozen top 3 on the group-stage standings (group + Best&nbsp;3rds advancer points).
+        </p>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-24">Place</TableHead>
+              <TableHead>Entry</TableHead>
+              <TableHead className="text-right">Points</TableHead>
+              <TableHead className="text-right">Prize</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {winners.map((winner) => {
+              const badge = getRankBadge(winner.rank);
+              const prize = PRIZES.phase1.find((p) => p.rank === winner.rank);
+              return (
+                <TableRow key={winner.predictionId}>
+                  <TableCell>
+                    {badge && (
+                      <Badge className={cn('gap-1', badge.color)}>
+                        <Trophy className="h-3 w-3" />
+                        {badge.label}
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <span className="font-medium">{winner.predictionName}</span>
+                    <span className="text-muted-foreground ml-1 text-xs">
+                      @{winner.username}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {winner.phase1Points}
+                  </TableCell>
+                  <TableCell className="text-right font-semibold">
+                    {prize ? formatPrizeCAD(prize.amountCAD) : '—'}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/shared/PrizeTables.tsx
+++ b/frontend/src/components/shared/PrizeTables.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import { Trophy } from 'lucide-react';
 
@@ -12,6 +14,8 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { getRankBadge } from '@/components/leaderboard/rankBadge';
+import { Phase1WinnersCard } from '@/components/leaderboard/Phase1WinnersCard';
+import { usePhase1Winners } from '@/hooks/usePhase1Winners';
 import { PRIZES, ROUTES, formatPrizeCAD } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
@@ -85,13 +89,21 @@ export interface PrizeTablesProps {
 
 /**
  * Side-by-side Phase 1 / Phase 2 prize tables. Single source of truth for prize
- * rendering, shared by the /prizes page and the leaderboard.
+ * rendering, shared by the /prizes page and the leaderboard. Once an admin has
+ * snapshotted the Phase 1 winners, the actual winners table replaces the generic
+ * Phase 1 prize card in place (Phase 2 stays a prize card until its own results).
  */
 export function PrizeTables({ activePhase, className }: PrizeTablesProps) {
+  const { winners } = usePhase1Winners();
+  const hasPhase1Winners = winners.length > 0;
   return (
     <div className={className}>
       <div className="grid gap-4 sm:grid-cols-2">
-        <PrizeCard phase="phase1" active={activePhase === 'phase1'} />
+        {hasPhase1Winners ? (
+          <Phase1WinnersCard />
+        ) : (
+          <PrizeCard phase="phase1" active={activePhase === 'phase1'} />
+        )}
         <PrizeCard phase="phase2" active={activePhase === 'phase2'} />
       </div>
       <p className="text-muted-foreground mt-3 text-xs">

--- a/frontend/src/components/shared/__tests__/PrizeTables.test.tsx
+++ b/frontend/src/components/shared/__tests__/PrizeTables.test.tsx
@@ -1,7 +1,28 @@
 import { render, screen } from '@testing-library/react';
 import { PrizeTables } from '../PrizeTables';
+import { usePhase1Winners } from '@/hooks/usePhase1Winners';
+import type { Phase1Winner } from '@/types/tournament';
+
+jest.mock('@/hooks/usePhase1Winners', () => ({
+  usePhase1Winners: jest.fn(),
+}));
+
+const mockUsePhase1Winners = usePhase1Winners as jest.MockedFunction<typeof usePhase1Winners>;
+
+function setWinners(winners: Phase1Winner[]) {
+  mockUsePhase1Winners.mockReturnValue({
+    winners,
+    isLoading: false,
+    refetch: jest.fn(),
+  } as unknown as ReturnType<typeof usePhase1Winners>);
+}
 
 describe('PrizeTables', () => {
+  beforeEach(() => {
+    // Default: no snapshot yet, so the generic Phase 1 prize card shows.
+    setWinners([]);
+  });
+
   it('renders both phase headings', () => {
     render(<PrizeTables />);
     expect(screen.getByText('Phase 1 — Group Stage')).toBeInTheDocument();
@@ -47,5 +68,39 @@ describe('PrizeTables', () => {
       'href',
       '/audit'
     );
+  });
+
+  it('replaces the Phase 1 prize card with the winners table once snapshotted', () => {
+    setWinners([
+      {
+        rank: 1,
+        predictionId: 'p-dave',
+        predictionName: 'Dave Picks',
+        username: 'dave',
+        groupPoints: 125,
+        advancerPoints: 20,
+        phase1Points: 145,
+      },
+      {
+        rank: 2,
+        predictionId: 'p-carol',
+        predictionName: 'Carol Picks',
+        username: 'carol',
+        groupPoints: 117,
+        advancerPoints: 16,
+        phase1Points: 133,
+      },
+    ]);
+    render(<PrizeTables activePhase="phase2" />);
+
+    // Winners table takes the Phase 1 slot; the generic Phase 1 card is gone.
+    expect(screen.getByText('Phase 1 Winners')).toBeInTheDocument();
+    expect(screen.queryByText('Phase 1 — Group Stage')).not.toBeInTheDocument();
+    expect(screen.getByText('Dave Picks')).toBeInTheDocument();
+    expect(screen.getByText('145')).toBeInTheDocument(); // Dave's Phase 1 points (unique)
+    // $400 = Dave's 1st-place Phase 1 prize AND the Phase 2 3rd-place prize.
+    expect(screen.getAllByText('$400')).toHaveLength(2);
+    // Phase 2 prize card still renders alongside it.
+    expect(screen.getByText('Phase 2 — Knockout')).toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/usePhase1Winners.ts
+++ b/frontend/src/hooks/usePhase1Winners.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { Phase1Winner } from '@/types/tournament';
+
+export const PHASE1_WINNERS_QUERY_KEY = ['phase1-winners'] as const;
+
+interface Phase1WinnersResponse {
+  winners: Phase1Winner[];
+}
+
+/**
+ * Public read of the frozen Phase 1 top 3 (group + advancer), backed by
+ * `/api/leaderboard/phase1-winners`. Empty until an admin snapshots the
+ * standings; the admin snapshot button invalidates the ['phase1-winners'] key.
+ */
+export function usePhase1Winners() {
+  const query = useQuery<Phase1WinnersResponse>({
+    queryKey: PHASE1_WINNERS_QUERY_KEY,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const res = await fetch('/api/leaderboard/phase1-winners', { cache: 'no-store' });
+      if (!res.ok) throw new Error('Failed to load Phase 1 winners');
+      return res.json();
+    },
+  });
+
+  return {
+    winners: query.data?.winners ?? [],
+    isLoading: query.isLoading,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/types/tournament.ts
+++ b/frontend/src/types/tournament.ts
@@ -127,6 +127,21 @@ export interface LeaderboardRankMatch {
   points: number;
 }
 
+/**
+ * A frozen Phase 1 (group + advancer) top-3 standing, snapshotted by an admin when
+ * Phase 2 opens. Backed by the phase1_winners table (migration 0070) and surfaced
+ * on the leaderboard + prizes page.
+ */
+export interface Phase1Winner {
+  rank: number;
+  predictionId: string;
+  predictionName: string;
+  username: string;
+  groupPoints: number;
+  advancerPoints: number;
+  phase1Points: number;
+}
+
 export interface UserEntry {
   username: string;
   predictions: Predictions;

--- a/supabase/migrations/0070_phase1_winners_snapshot.sql
+++ b/supabase/migrations/0070_phase1_winners_snapshot.sql
@@ -1,0 +1,162 @@
+-- 0070_phase1_winners_snapshot.sql
+--
+-- Snapshot the Phase 1 (group-stage + Best-3rds advancers) top 3 at the moment
+-- Phase 2 opens, freezing the standings that decide the separate Phase 1 prize.
+-- Once Phase 2 starts, the live leaderboard folds in knockout points, so the
+-- Phase 1 result is no longer visible as a standalone ranking; this persists it.
+--
+-- Phase 1 score = group_points + advancer_points ONLY. The Champion-Pick bonus is
+-- intentionally excluded — it resolves from the final (M104) result, which isn't
+-- known at Phase 2 open, so it contributes 0 and is not a Phase 1 prize component.
+--
+-- Tiebreaker: points DESC, then earliest predictions.updated_at. No goal-closeness
+-- tiebreaker — the champion's total goals aren't known yet and are irrelevant to
+-- Phase 1 (it's a Phase 2 / end-of-tournament tiebreaker).
+--
+-- Eligibility matches the leaderboard: Phase 1 complete AND paid before lock. The
+-- group_scores / advancer_scores CTEs and the eligibility predicate are lifted
+-- verbatim from get_leaderboard (0069_leaderboard_tiebreak_updated_at.sql).
+
+-- ========== snapshot table ==========
+
+create table if not exists public.phase1_winners (
+    tournament_id         uuid not null references public.tournaments(id) on delete cascade,
+    rank                  int  not null,
+    prediction_id         uuid not null references public.predictions(id) on delete cascade,
+    prediction_name       text not null,
+    username              text not null,
+    group_points          int  not null,
+    advancer_points       numeric not null,
+    phase1_points         numeric not null,
+    prediction_updated_at timestamptz,                       -- frozen tiebreaker source (display/audit)
+    snapshotted_at        timestamptz not null default now(),
+    primary key (tournament_id, rank)
+);
+
+alter table public.phase1_winners enable row level security;
+
+-- Public, non-sensitive (username + points, curated to 3 rows) — readable by the
+-- public leaderboard / prizes pages. No write policy: writes only happen via the
+-- SECURITY DEFINER RPC below.
+drop policy if exists phase1_winners_select_all on public.phase1_winners;
+create policy phase1_winners_select_all
+    on public.phase1_winners
+    for select
+    to anon, authenticated
+    using (true);
+
+-- ========== admin_snapshot_phase1_winners ==========
+
+create or replace function public.admin_snapshot_phase1_winners(p_tournament_id uuid)
+returns setof public.phase1_winners
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden';
+    end if;
+
+    if not exists (select 1 from public.tournaments where id = p_tournament_id) then
+        raise exception 'tournament not found';
+    end if;
+
+    delete from public.phase1_winners where tournament_id = p_tournament_id;
+
+    return query
+    with group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 15 else 10 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 7
+                    else
+                        case
+                            when gp.first_team_id = gs.first_team_id then 5   -- single team, correct slot
+                            when gp.second_team_id = gs.second_team_id then 5 -- single team, correct slot
+                            when gp.first_team_id = gs.second_team_id then 2  -- single team, wrong slot
+                            when gp.second_team_id = gs.first_team_id then 2  -- single team, wrong slot
+                            else 0
+                        end
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 2.5
+                    when ta_team.team_id is not null then 2.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            pr.username::text as username,
+            coalesce(gsc.group_points, 0) as group_points,
+            coalesce(asc_.advancer_points, 0)::numeric as advancer_points,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0))::numeric as phase1_points,
+            p.updated_at as prediction_updated_at,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)) desc,
+                    p.updated_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        join public.profiles pr on pr.id = p.user_id
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    ),
+    inserted as (
+        insert into public.phase1_winners (
+            tournament_id, rank, prediction_id, prediction_name, username,
+            group_points, advancer_points, phase1_points, prediction_updated_at
+        )
+        select
+            p_tournament_id, r.rank, r.prediction_id, r.prediction_name, r.username,
+            r.group_points, r.advancer_points, r.phase1_points, r.prediction_updated_at
+        from ranked r
+        where r.rank <= 3
+        returning *
+    )
+    select * from inserted order by rank;
+end;
+$$;
+
+grant execute on function public.admin_snapshot_phase1_winners(uuid) to authenticated;


### PR DESCRIPTION
## Summary

Adds an admin-triggered **snapshot of the Phase 1 top 3** (group stage + Best-3rds advancers). When Phase 2 opens, the live leaderboard starts folding in knockout points, so the standalone Phase 1 result is no longer visible — this freezes it and surfaces it everywhere prizes are shown.

An admin clicks **Snapshot Phase 1 Winners** in the admin tournament section; the frozen top 3 then appears on the leaderboard and prizes page.

## Decisions
- **Phase 1 score = group_points + advancer_points** (matches existing prize copy "Top 3 on the group-stage standings"). Champion-Pick is excluded — it resolves from the final result, which is unknown at Phase 2 open.
- **Tiebreaker = earliest `updated_at`** (points DESC, then `updated_at` ASC). No goal-closeness tiebreaker (irrelevant to Phase 1).
- **Eligibility** = same as the leaderboard (paid before lock + Phase 1 complete).
- **Re-running overwrites** the saved top 3 (idempotent).

## Changes

**Backend** — `supabase/migrations/0070_phase1_winners_snapshot.sql`
- `phase1_winners` table (PK `tournament_id, rank`) with a public-select RLS policy; writes only via RPC.
- `admin_snapshot_phase1_winners(p_tournament_id)` — `is_admin()`-gated, reuses the group/advancer scoring CTEs + eligibility predicate from `0069`, ranks top 3, overwrites.

**Frontend**
- `POST /api/admin/tournament/snapshot-phase1-winners` (mirrors the reset route).
- `GET /api/leaderboard/phase1-winners` (public) + `usePhase1Winners` hook + `Phase1Winner` type.
- `Phase1WinnersCard` styled like the prize cards.
- **Snapshot Phase 1 Winners** button in the Phase 1 card of `TournamentSettingsForm`.
- Once snapshotted, the winners table **replaces** the generic "Phase 1 — Group Stage" prize card in place (`PrizeTables`), on both `/leaderboard` and `/prizes`. Phase 2 stays a prize card until its own results.

## Testing
- New route tests (admin gate, error mapping, row mapping) + `PrizeTables` swap test.
- **555/555 tests pass**, typecheck clean, lint clean.
- Verified locally end-to-end against the Supabase stack: applied migration `0070`, seeded 4 paid predictions + actual results, confirmed ranking (Dave 145 / Carol 133 / Bob 98, Alice 38 excluded), the `updated_at` tiebreaker, top-3 cap, eligibility filtering, overwrite, admin gate (403), and not-found (404) — via both `psql` and the real REST/PostgREST path.

> Note: locally, PostgREST may need a schema-cache reload to see the new RPC (`docker restart supabase_rest_<project>` or `supabase stop && start`). On Supabase cloud this is automatic on migration apply.