### PR TITLE
feat(autofill-phase2): admin-triggered auto-fill for missing knockout brackets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ vite.config.ts.timestamp-*
 supabase/.branches/
 supabase/.temp/
 
+# Local-only dev seeds / fixtures (never committed)
+supabase/dev/
+

--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -108,6 +108,8 @@ export function TournamentSettingsForm() {
   const [resetDialogOpen, setResetDialogOpen] = React.useState(false);
   const [resetConfirm, setResetConfirm] = React.useState('');
   const [resetting, setResetting] = React.useState(false);
+  const [autofillDialogOpen, setAutofillDialogOpen] = React.useState(false);
+  const [autofilling, setAutofilling] = React.useState(false);
 
   React.useEffect(() => {
     if (!tournament.data) return;
@@ -235,6 +237,25 @@ export function TournamentSettingsForm() {
   const canOpenPhaseTwo = allStandingsSet && allAssignmentsSet;
   const phase = tournament.data?.phase ?? 'phase1';
 
+  // Bracket auto-fill preview — how many paid/Phase-1-complete entries have an
+  // unfinished bracket. Only meaningful (and only fetched) once Phase 2 is
+  // locked and the viewer is a super admin (the RPC is super-admin-gated).
+  const autofillPreview = useQuery<{
+    ok: boolean;
+    preview: { eligible_count: number; resolution_data_ok: boolean; phase: string };
+  }>({
+    queryKey: ['admin-autofill-preview', tournament.data?.id],
+    queryFn: () =>
+      fetchJSON('/api/admin/tournament/autofill-brackets/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: tournament.data!.id }),
+      }),
+    enabled: !!tournament.data?.id && isSuperAdmin && phase === 'phase2_locked',
+  });
+  const eligibleCount = autofillPreview.data?.preview.eligible_count ?? 0;
+  const resolutionOk = autofillPreview.data?.preview.resolution_data_ok ?? false;
+
   const phaseTwoLockIso = React.useMemo(() => {
     if (!phaseTwoLockInput.trim()) return null;
     const ms = new Date(phaseTwoLockInput).getTime();
@@ -322,6 +343,36 @@ export function TournamentSettingsForm() {
       toast.error(e instanceof Error ? e.message : 'Failed to reset tournament');
     } finally {
       setResetting(false);
+    }
+  };
+
+  const handleAutofill = async () => {
+    if (!tournament.data) return;
+    setAutofilling(true);
+    try {
+      const res = await fetch('/api/admin/tournament/autofill-brackets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: tournament.data.id }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? 'Failed to auto-fill brackets');
+      const s = body.summary ?? {};
+      toast.success(
+        `Auto-filled ${s.matches_filled ?? 0} matches across ${s.predictions_touched ?? 0} ${
+          (s.predictions_touched ?? 0) === 1 ? 'entry' : 'entries'
+        }`
+      );
+      setAutofillDialogOpen(false);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['leaderboard'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-autofill-preview'] }),
+      ]);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to auto-fill brackets');
+    } finally {
+      setAutofilling(false);
     }
   };
 
@@ -576,6 +627,54 @@ export function TournamentSettingsForm() {
           </CardContent>
         </Card>
 
+        {isSuperAdmin && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Auto-fill missing brackets</CardTitle>
+              <p className="text-muted-foreground text-sm">
+                Super-admin only. After the Phase 2 deadline, fill blank knockout picks for paid
+                / credited entries that completed Phase 1 but never submitted a bracket. The
+                champion pick advances along its real path (and wins the final if it gets there);
+                otherwise the team with the better real group finish wins. Never overwrites a
+                user&apos;s existing picks; safe to re-run.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm">
+                {phase !== 'phase2_locked'
+                  ? 'Available only once Phase 2 is locked (the knockout deadline has passed).'
+                  : autofillPreview.isLoading
+                    ? 'Checking eligible entries…'
+                    : autofillPreview.isError
+                      ? 'Could not load eligibility.'
+                      : `${eligibleCount} eligible ${eligibleCount === 1 ? 'entry' : 'entries'}${
+                          resolutionOk ? '' : ' · ⚠ resolution data incomplete (fill standings + bracket first)'
+                        }`}
+              </p>
+              <Button
+                onClick={() => setAutofillDialogOpen(true)}
+                disabled={
+                  autofilling ||
+                  phase !== 'phase2_locked' ||
+                  eligibleCount === 0 ||
+                  !resolutionOk
+                }
+                title={
+                  phase !== 'phase2_locked'
+                    ? 'Phase 2 must be locked first'
+                    : !resolutionOk
+                      ? 'Enter all group standings + R32 bracket assignments first'
+                      : eligibleCount === 0
+                        ? 'No eligible entries'
+                        : undefined
+                }
+              >
+                Auto-fill missing brackets
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
         <Card className="border-destructive/40">
           <CardHeader>
             <CardTitle className="text-destructive">Danger zone</CardTitle>
@@ -651,6 +750,33 @@ export function TournamentSettingsForm() {
               disabled={resetting || resetConfirm !== 'RESET'}
             >
               {resetting ? 'Resetting…' : 'Reset tournament'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={autofillDialogOpen} onOpenChange={setAutofillDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Auto-fill missing brackets</DialogTitle>
+            <DialogDescription>
+              Fill blank knockout picks for{' '}
+              <span className="font-semibold">{eligibleCount}</span> paid / credited{' '}
+              {eligibleCount === 1 ? 'entry' : 'entries'} that completed Phase 1 but never
+              finished a bracket. Existing user picks are preserved, and this can be re-run
+              safely.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setAutofillDialogOpen(false)}
+              disabled={autofilling}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleAutofill} disabled={autofilling}>
+              {autofilling ? 'Filling…' : 'Auto-fill brackets'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/app/api/admin/tournament/autofill-brackets/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/tournament/autofill-brackets/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function postReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/tournament/autofill-brackets', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('POST /api/admin/tournament/autofill-brackets', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when caller is not admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({}));
+    expect(res.status).toBe(400);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when RPC raises forbidden', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: { message: 'forbidden' } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when RPC raises tournament not found', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: { message: 'tournament not found' } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when tournament is not phase2_locked', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'tournament is not phase2_locked' },
+    });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 200 with the summary and calls RPC on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const summary = { predictions_eligible: 3, predictions_touched: 3, matches_filled: 70 };
+    supabaseMock.rpc.mockResolvedValue({ data: summary, error: null });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.summary).toEqual(summary);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_autofill_phase2_brackets', {
+      p_tournament_id: 't1',
+    });
+  });
+});

--- a/frontend/src/app/api/admin/tournament/autofill-brackets/preview/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/tournament/autofill-brackets/preview/__tests__/route.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function postReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/tournament/autofill-brackets/preview', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('POST /api/admin/tournament/autofill-brackets/preview', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when caller is not admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({}));
+    expect(res.status).toBe(400);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with the preview and calls RPC on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const preview = { eligible_count: 5, resolution_data_ok: true, phase: 'phase2_locked' };
+    supabaseMock.rpc.mockResolvedValue({ data: preview, error: null });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.preview).toEqual(preview);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_autofill_phase2_preview', {
+      p_tournament_id: 't1',
+    });
+  });
+});

--- a/frontend/src/app/api/admin/tournament/autofill-brackets/preview/route.ts
+++ b/frontend/src/app/api/admin/tournament/autofill-brackets/preview/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+interface Body {
+  id?: string;
+}
+
+/**
+ * Read-only preview for the Phase 2 bracket auto-fill: returns how many entries
+ * are eligible, whether the resolution data is complete, and the current phase.
+ * Super-admin-gated; calls admin_autofill_phase2_preview (migration 0071).
+ */
+export async function POST(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json()) as Body;
+  if (!body.id) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 });
+  }
+
+  const { data, error } = await ctx.supabase.rpc('admin_autofill_phase2_preview', {
+    p_tournament_id: body.id,
+  });
+
+  if (error) {
+    const msg = (error.message ?? '').toLowerCase();
+    let status = 400;
+    if (msg.includes('forbidden')) status = 403;
+    else if (msg.includes('not found')) status = 404;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+
+  return NextResponse.json({ ok: true, preview: data });
+}

--- a/frontend/src/app/api/admin/tournament/autofill-brackets/route.ts
+++ b/frontend/src/app/api/admin/tournament/autofill-brackets/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+interface Body {
+  id?: string;
+}
+
+/**
+ * Auto-fill missing Phase 2 (knockout) brackets for the given tournament after
+ * the knockout deadline. Super-admin-gated; calls admin_autofill_phase2_brackets
+ * (migration 0071), which fills only blank matches for paid, Phase-1-complete
+ * entries and never overwrites a user's picks. Returns a fill summary.
+ */
+export async function POST(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json()) as Body;
+  if (!body.id) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 });
+  }
+
+  const { data, error } = await ctx.supabase.rpc('admin_autofill_phase2_brackets', {
+    p_tournament_id: body.id,
+  });
+
+  if (error) {
+    const msg = (error.message ?? '').toLowerCase();
+    let status = 400;
+    if (msg.includes('forbidden')) status = 403;
+    else if (msg.includes('not found')) status = 404;
+    else if (msg.includes('not phase2_locked')) status = 409;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+
+  return NextResponse.json({ ok: true, summary: data });
+}

--- a/frontend/src/lib/__tests__/autofillParity.test.ts
+++ b/frontend/src/lib/__tests__/autofillParity.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Parity spec for the Phase 2 bracket auto-fill.
+ *
+ * The authoritative fill lives in SQL (migration 0071,
+ * admin_autofill_phase2_brackets). This test encodes the SAME rules in TS,
+ * driven by the shared resolver (knockoutResolver.resolveTeamSource), and
+ * asserts the key scenarios the SQL must reproduce:
+ *   - champion advances along its real path and wins the final
+ *   - a user pick that eliminates the champion is honored (champion can't win)
+ *   - seed ties fall to the team1 / team1_source side
+ *   - third-place (L-M..) resolves to SF losers, not winners
+ *   - a group-3rd already placed in a bracket slot is deduped (resolves null)
+ *
+ * Live SQL↔TS parity is verified manually via `supabase db reset` + seeding
+ * (see the plan's verification section); this guards the rule definitions that
+ * the SQL is a line-by-line mirror of.
+ */
+import { resolveTeamSource } from '@/lib/knockoutResolver';
+import { fixtureGroups, fixtureKnockoutMatches } from '@/test-utils/fixtures';
+import type {
+  GroupStanding,
+  KnockoutMatchPrediction,
+  R32BracketAssignment,
+} from '@/types/tournament';
+
+// Real group results: each group's 4 fixture teams in order → 1st/2nd/3rd/4th.
+const standings: GroupStanding[] = fixtureGroups.map((g) => ({
+  groupId: g.id,
+  firstTeamId: g.teams[0].id,
+  secondTeamId: g.teams[1].id,
+  thirdTeamId: g.teams[2].id,
+  fourthTeamId: g.teams[3].id,
+}));
+
+function seedOf(teamId: string): number {
+  for (const s of standings) {
+    if (s.firstTeamId === teamId) return 1;
+    if (s.secondTeamId === teamId) return 2;
+    if (s.thirdTeamId === teamId) return 3;
+    if (s.fourthTeamId === teamId) return 4;
+  }
+  return 9;
+}
+
+/** TS mirror of admin_autofill_phase2_brackets' per-prediction fill loop. */
+function autofill(
+  championId: string,
+  bracketAssignments: R32BracketAssignment[] = [],
+  existing: KnockoutMatchPrediction[] = []
+): Map<string, string> {
+  const winners = new Map<string, string>();
+  for (const e of existing) if (e.winnerId) winners.set(e.matchId, e.winnerId);
+
+  for (const m of fixtureKnockoutMatches) {
+    if (winners.has(m.id)) continue;
+    const preds: KnockoutMatchPrediction[] = Array.from(winners.entries()).map(
+      ([matchId, winnerId]) => ({ matchId, winnerId })
+    );
+    const t1 = resolveTeamSource(
+      m.team1Source,
+      fixtureKnockoutMatches,
+      [],
+      preds,
+      bracketAssignments,
+      standings
+    );
+    const t2 = resolveTeamSource(
+      m.team2Source,
+      fixtureKnockoutMatches,
+      [],
+      preds,
+      bracketAssignments,
+      standings
+    );
+
+    let w: string | null;
+    if (t1 == null && t2 == null) continue;
+    else if (t1 == null) w = t2;
+    else if (t2 == null) w = t1;
+    else if (t1 === championId) w = t1;
+    else if (t2 === championId) w = t2;
+    else if (seedOf(t1) <= seedOf(t2)) w = t1; // tie → team1 side
+    else w = t2;
+
+    if (w) winners.set(m.id, w);
+  }
+  return winners;
+}
+
+describe('Phase 2 bracket auto-fill (parity spec)', () => {
+  it('fills all 32 matches from an empty bracket', () => {
+    const winners = autofill('arg');
+    expect(winners.size).toBe(fixtureKnockoutMatches.length);
+    for (const m of fixtureKnockoutMatches) {
+      expect(winners.get(m.id)).toBeTruthy();
+    }
+  });
+
+  it('advances the champion along its real path and wins the final', () => {
+    // arg = Group J winner (1J) → M83 → M93 → M98 → M101 → M104.
+    const winners = autofill('arg');
+    expect(winners.get('M83')).toBe('arg');
+    expect(winners.get('M101')).toBe('arg');
+    expect(winners.get('M104')).toBe('arg');
+  });
+
+  it('honors a user pick that eliminates the champion', () => {
+    // User already picked 2I (sen) to beat arg in M83; champion can't advance.
+    const existing: KnockoutMatchPrediction[] = [{ matchId: 'M83', winnerId: 'sen' }];
+    const winners = autofill('arg', [], existing);
+    expect(winners.get('M83')).toBe('sen'); // user pick preserved
+    expect(winners.get('M104')).not.toBe('arg');
+  });
+
+  it('breaks a seed tie in favor of the team1 / team1_source side', () => {
+    // M89 = winner(M74)=bra(seed1) vs winner(M77)=fra(seed1); neither is champion.
+    const winners = autofill('arg');
+    expect(winners.get('M89')).toBe('bra');
+  });
+
+  it('resolves the third-place match from semifinal losers', () => {
+    const winners = autofill('arg');
+    const third = winners.get('M103');
+    expect(third).toBeTruthy();
+    // The 3rd-place winner is one of the SF losers, never an SF winner.
+    expect(third).not.toBe(winners.get('M101'));
+    expect(third).not.toBe(winners.get('M102'));
+  });
+
+  it('dedupes a group-3rd that is already placed in a bracket slot', () => {
+    // rsa = Group A 3rd. Placing it in any bracket slot makes the plain '3A'
+    // source resolve to null (it materializes via its assigned slot instead).
+    const assignments: R32BracketAssignment[] = [
+      { matchId: 'M85', slot: 1, teamId: 'rsa' },
+    ];
+    const resolved = resolveTeamSource(
+      '3A',
+      fixtureKnockoutMatches,
+      [],
+      [],
+      assignments,
+      standings
+    );
+    expect(resolved).toBeNull();
+  });
+});

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -64,6 +64,9 @@ const KNOWN_ERROR_FRAGMENTS = [
   'tournament_id is required',
   // Reset tournament (migration 0046)
   'tournament not found',
+  // Phase 2 bracket auto-fill (migration 0071)
+  'tournament is not phase2_locked',
+  'resolution data incomplete',
   // Referral admin tool (migration 0059)
   'referee account not found',
   'referee already referred',

--- a/supabase/migrations/0071_admin_autofill_phase2_brackets.sql
+++ b/supabase/migrations/0071_admin_autofill_phase2_brackets.sql
@@ -1,0 +1,395 @@
+-- 0071_admin_autofill_phase2_brackets.sql
+--
+-- Auto-fill missing Phase 2 (knockout) brackets after the knockout deadline.
+--
+-- Some users pay and complete Phase 1 (groups + best-3rds + champion pick) but
+-- forget to submit their knockout bracket before tournaments.knockout_lock_time.
+-- Rather than let those paid entries score 0 on every knockout match, an admin
+-- runs this AFTER the knockout deadline to fill the gaps with a sensible default
+-- so the entry stays competitive. It NEVER overwrites a pick the user did make.
+--
+-- This re-implements, in SQL, the bracket source resolution that otherwise lives
+-- only in the client (frontend/src/lib/knockoutResolver.ts) plus a winner rule.
+--
+--   Fill rule (per match, only when the user left it blank):
+--     1. Resolve the two real teams from admin-entered results
+--        (group_standings + r32_bracket_assignments), then from already-decided
+--        winners for later rounds, and SF losers for the third-place match.
+--     2. Champion override: if one of the two teams is the prediction's
+--        champion_team_id, the champion wins (carries it down its real path,
+--        incl. winning M104 if it gets there).
+--     3. Else the team with the better real group finish wins (1st > 2nd > 3rd).
+--     4. Tie (equal finish, neither is champion): team1 / team1_source side wins.
+--        Arbitrary-but-stable — `teams` carries no seed/ranking to break it.
+--
+--   Tiebreaker (predictions.total_goals): when null, set to the median of
+--   on-time submitters' total_goals (fallback constant 12, a realistic champion
+--   5-match playoff total inside the 0..200 CHECK). Never overwrites a user value.
+--
+--   updated_at: stamped to now() on touched predictions. Because this runs after
+--   the deadline, now() is later than every genuine on-time edit, so auto-filled
+--   entries sort LAST within a points/goal-closeness tie on the leaderboard
+--   (which tiebreaks on updated_at — see 0069). submitted_at is left untouched.
+--
+-- Super-admin gated, idempotent (re-running fills only still-missing matches),
+-- and scoped to leaderboard entries only (paid OR is_free credit — the
+-- `paid_at <= lock_time` predicate, lifted verbatim from get_leaderboard / 0070).
+
+-- ========== helper: _autofill_seed ==========
+-- A team's real group finish for the seed rule: 1 (won group), 2, 3, 4.
+-- Falls back to 9 when the team isn't found in standings (defensive; resolved
+-- knockout teams always finished 1st/2nd/3rd, so this never bites in practice).
+
+create or replace function public._autofill_seed(p_tournament_id uuid, p_team_id text)
+returns int
+language sql
+stable
+set search_path = public
+as $$
+    select coalesce(min(pos), 9) from (
+        select 1 as pos from public.group_standings
+            where tournament_id = p_tournament_id and first_team_id = p_team_id
+        union all
+        select 2 from public.group_standings
+            where tournament_id = p_tournament_id and second_team_id = p_team_id
+        union all
+        select 3 from public.group_standings
+            where tournament_id = p_tournament_id and third_team_id = p_team_id
+        union all
+        select 4 from public.group_standings
+            where tournament_id = p_tournament_id and fourth_team_id = p_team_id
+    ) s;
+$$;
+
+revoke all on function public._autofill_seed(uuid, text) from public;
+
+-- ========== helper: _autofill_resolve_source ==========
+-- Mirror of resolveTeamSource for the Phase 2 (post-deadline) path: group
+-- positions resolve from admin group_standings ONLY (never the user's Phase 1
+-- guesses), '3-...' from r32_bracket_assignments, 'M..' from the working winners
+-- map (p_winners: {match_id -> winner_team_id}), and 'L-M..' from the SF result.
+-- Returns null when a source can't be resolved.
+
+create or replace function public._autofill_resolve_source(
+    p_tournament_id uuid,
+    p_source text,
+    p_winners jsonb
+)
+returns text
+language plpgsql
+stable
+set search_path = public
+as $$
+declare
+    v_pos text;
+    v_group text;
+    v_team text;
+    v_inner_id text;
+    v_slot smallint;
+    v_inner_winner text;
+    v_src1 text;
+    v_src2 text;
+    v_it1 text;
+    v_it2 text;
+begin
+    -- Group position: '1A' = 1st of Group A, '2B', '3A', ...
+    if p_source ~ '^[123][A-L]$' then
+        v_pos := substring(p_source from 1 for 1);
+        v_group := substring(p_source from 2 for 1);
+        select case v_pos
+                   when '1' then first_team_id
+                   when '2' then second_team_id
+                   when '3' then third_team_id
+               end
+            into v_team
+            from public.group_standings
+            where tournament_id = p_tournament_id and group_id = v_group;
+        if v_team is null then
+            return null;
+        end if;
+        -- Dedupe: if this team is placed in a 3-XXXX R32 slot, it materializes
+        -- there instead — suppress here (matches resolver lines 69-76).
+        if exists (
+            select 1 from public.r32_bracket_assignments
+            where tournament_id = p_tournament_id and team_id = v_team
+        ) then
+            return null;
+        end if;
+        return v_team;
+    end if;
+
+    -- Best-3rd bracket slot: '3-ABCDF' -> the admin-assigned advancer for the
+    -- (match_id, slot) tuple that owns this source string.
+    if p_source ~ '^3-[A-L]+$' then
+        select km.id,
+               (case when km.team1_source = p_source then 1 else 2 end)::smallint
+            into v_inner_id, v_slot
+            from public.knockout_matches km
+            where km.team1_source = p_source or km.team2_source = p_source
+            limit 1;
+        if v_inner_id is null then
+            return null;
+        end if;
+        select team_id into v_team
+            from public.r32_bracket_assignments
+            where tournament_id = p_tournament_id
+              and match_id = v_inner_id
+              and slot = v_slot;
+        return v_team;
+    end if;
+
+    -- Match winner: 'M73' -> the (already-decided) winner of that match.
+    if p_source ~ '^M\d+$' then
+        return p_winners->>p_source;
+    end if;
+
+    -- Match loser: 'L-M101' -> resolve M101's two teams + winner, return the
+    -- one that is not the winner (third-place feeders).
+    if p_source ~ '^L-M\d+$' then
+        v_inner_id := substring(p_source from 3);   -- 'L-M101' -> 'M101'
+        v_inner_winner := p_winners->>v_inner_id;
+        if v_inner_winner is null then
+            return null;
+        end if;
+        select team1_source, team2_source into v_src1, v_src2
+            from public.knockout_matches where id = v_inner_id;
+        if v_src1 is null then
+            return null;
+        end if;
+        v_it1 := public._autofill_resolve_source(p_tournament_id, v_src1, p_winners);
+        v_it2 := public._autofill_resolve_source(p_tournament_id, v_src2, p_winners);
+        if v_inner_winner = v_it1 then
+            return v_it2;
+        elsif v_inner_winner = v_it2 then
+            return v_it1;
+        end if;
+        return null;
+    end if;
+
+    return null;
+end;
+$$;
+
+revoke all on function public._autofill_resolve_source(uuid, text, jsonb) from public;
+
+-- ========== admin_autofill_phase2_preview ==========
+-- Read-only: guards + eligibility count, used by the admin UI before the write.
+
+create or replace function public.admin_autofill_phase2_preview(p_tournament_id uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+    v_eligible int := 0;
+    v_resolution_ok boolean := true;
+    v_slot_count int;
+    v_assign_count int;
+begin
+    if not public.is_super_admin() then
+        raise exception 'forbidden';
+    end if;
+    if not exists (select 1 from public.tournaments where id = p_tournament_id) then
+        raise exception 'tournament not found';
+    end if;
+
+    if (select count(*) from public.group_standings where tournament_id = p_tournament_id) <> 12 then
+        v_resolution_ok := false;
+    else
+        select
+            (select count(*) from public.knockout_matches
+                where stage = 'round_of_32' and team1_source like '3-%')
+          + (select count(*) from public.knockout_matches
+                where stage = 'round_of_32' and team2_source like '3-%')
+            into v_slot_count;
+        select count(*) into v_assign_count
+            from public.r32_bracket_assignments where tournament_id = p_tournament_id;
+        if v_assign_count < v_slot_count then
+            v_resolution_ok := false;
+        end if;
+    end if;
+
+    select count(*) into v_eligible
+        from public.predictions p
+        where p.tournament_id = p_tournament_id
+          and p.champion_team_id is not null
+          and public.prediction_phase1_complete(p.id)
+          and exists (
+              select 1 from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id and tp.paid_at <= t.lock_time
+          )
+          and (
+              select count(*) from public.knockout_predictions kp
+              where kp.prediction_id = p.id and kp.winner_team_id is not null
+          ) < (select count(*) from public.knockout_matches);
+
+    return jsonb_build_object(
+        'eligible_count', v_eligible,
+        'resolution_data_ok', v_resolution_ok,
+        'phase', public.tournament_phase(p_tournament_id)
+    );
+end;
+$$;
+
+revoke all on function public.admin_autofill_phase2_preview(uuid) from public;
+grant execute on function public.admin_autofill_phase2_preview(uuid) to authenticated;
+
+-- ========== admin_autofill_phase2_brackets ==========
+
+create or replace function public.admin_autofill_phase2_brackets(p_tournament_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_eligible int := 0;
+    v_touched int := 0;
+    v_filled int := 0;
+    v_default_goals int;
+    v_slot_count int;
+    v_assign_count int;
+    v_pred record;
+    v_match record;
+    v_winners jsonb;
+    v_champion text;
+    v_t1 text;
+    v_t2 text;
+    v_winner text;
+    v_pred_filled int;
+begin
+    -- ----- guards -----
+    if not public.is_super_admin() then
+        raise exception 'forbidden';
+    end if;
+    if not exists (select 1 from public.tournaments where id = p_tournament_id) then
+        raise exception 'tournament not found';
+    end if;
+    if public.tournament_phase(p_tournament_id) <> 'phase2_locked' then
+        raise exception 'tournament is not phase2_locked';
+    end if;
+
+    -- Resolution data must exist or we'd write NULL winners. (Phase 2 can't open
+    -- without it, but check defensively.)
+    if (select count(*) from public.group_standings where tournament_id = p_tournament_id) <> 12 then
+        raise exception 'resolution data incomplete';
+    end if;
+    select
+        (select count(*) from public.knockout_matches
+            where stage = 'round_of_32' and team1_source like '3-%')
+      + (select count(*) from public.knockout_matches
+            where stage = 'round_of_32' and team2_source like '3-%')
+        into v_slot_count;
+    select count(*) into v_assign_count
+        from public.r32_bracket_assignments where tournament_id = p_tournament_id;
+    if v_assign_count < v_slot_count then
+        raise exception 'resolution data incomplete';
+    end if;
+
+    -- ----- tiebreaker default (median of on-time submitters; fallback 12) -----
+    select percentile_cont(0.5) within group (order by p.total_goals)::int
+        into v_default_goals
+        from public.predictions p
+        where p.tournament_id = p_tournament_id
+          and p.total_goals is not null
+          and exists (
+              select 1 from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id and tp.paid_at <= t.lock_time
+          );
+    if v_default_goals is null then
+        v_default_goals := 12;
+    end if;
+
+    -- ----- per eligible prediction -----
+    for v_pred in
+        select p.id, p.champion_team_id
+            from public.predictions p
+            where p.tournament_id = p_tournament_id
+              and p.champion_team_id is not null
+              and public.prediction_phase1_complete(p.id)
+              and exists (
+                  select 1 from public.tournament_payments tp
+                  join public.tournaments t on t.id = tp.tournament_id
+                  where tp.prediction_id = p.id and tp.paid_at <= t.lock_time
+              )
+              and (
+                  select count(*) from public.knockout_predictions kp
+                  where kp.prediction_id = p.id and kp.winner_team_id is not null
+              ) < (select count(*) from public.knockout_matches)
+    loop
+        v_eligible := v_eligible + 1;
+        v_champion := v_pred.champion_team_id;
+        v_pred_filled := 0;
+
+        -- Seed the working winners map from the user's existing (non-null) picks
+        -- so downstream rounds cascade from them and we never overwrite them.
+        select coalesce(jsonb_object_agg(kp.match_id, kp.winner_team_id), '{}'::jsonb)
+            into v_winners
+            from public.knockout_predictions kp
+            where kp.prediction_id = v_pred.id and kp.winner_team_id is not null;
+
+        for v_match in
+            select id, team1_source, team2_source
+                from public.knockout_matches
+                order by match_order
+        loop
+            -- Already decided (user pick or filled earlier this run) -> keep it.
+            if v_winners ? v_match.id then
+                continue;
+            end if;
+
+            v_t1 := public._autofill_resolve_source(p_tournament_id, v_match.team1_source, v_winners);
+            v_t2 := public._autofill_resolve_source(p_tournament_id, v_match.team2_source, v_winners);
+
+            if v_t1 is null and v_t2 is null then
+                continue;                                   -- unresolvable, skip
+            elsif v_t1 is null then
+                v_winner := v_t2;
+            elsif v_t2 is null then
+                v_winner := v_t1;
+            elsif v_t1 = v_champion then
+                v_winner := v_t1;                           -- champion override
+            elsif v_t2 = v_champion then
+                v_winner := v_t2;
+            elsif public._autofill_seed(p_tournament_id, v_t1)
+                  <= public._autofill_seed(p_tournament_id, v_t2) then
+                v_winner := v_t1;                           -- better/equal seed (tie -> team1)
+            else
+                v_winner := v_t2;
+            end if;
+
+            v_winners := jsonb_set(v_winners, array[v_match.id], to_jsonb(v_winner));
+
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+                values (v_pred.id, v_match.id, v_winner)
+                on conflict (prediction_id, match_id)
+                do update set winner_team_id = excluded.winner_team_id
+                where public.knockout_predictions.winner_team_id is null;
+
+            v_pred_filled := v_pred_filled + 1;
+            v_filled := v_filled + 1;
+        end loop;
+
+        if v_pred_filled > 0 then
+            v_touched := v_touched + 1;
+            update public.predictions
+                set total_goals = coalesce(total_goals, v_default_goals),
+                    updated_at = now()
+                where id = v_pred.id;
+        end if;
+    end loop;
+
+    return jsonb_build_object(
+        'predictions_eligible', v_eligible,
+        'predictions_touched', v_touched,
+        'matches_filled', v_filled
+    );
+end;
+$$;
+
+revoke all on function public.admin_autofill_phase2_brackets(uuid) from public;
+grant execute on function public.admin_autofill_phase2_brackets(uuid) to authenticated;


### PR DESCRIPTION
## Summary

After the Phase 2 (knockout) deadline, some paid/credited entries that completed Phase 1 will have missed submitting a knockout bracket — leaving them to score 0 on every knockout match. This adds an **admin-triggered** auto-fill that completes those brackets with a sensible default so the entries stay competitive, **without overwriting any pick the user did make**.

## What it does

- New migration `0071` with two SECURITY DEFINER, **super-admin-gated** RPCs:
  - `admin_autofill_phase2_brackets(uuid)` — the write path.
  - `admin_autofill_phase2_preview(uuid)` — read-only eligibility/resolution check for the UI.
- Runs **only when the tournament is `phase2_locked`** (deadline passed).
- Resolves each match's two real teams from **admin truth** — `group_standings` + `r32_bracket_assignments` — reimplementing the client resolver (`knockoutResolver.ts`) in SQL. It never falls back to Phase 1 group predictions, and **refuses to run until that resolution data is complete** (`resolution data incomplete`).
- **Winner rule:** champion-pick override → better real group finish (1st > 2nd > 3rd) → tie falls to the `team1` side. Cascades round-by-round; third-place (M103) from the semifinal losers.
- **Scope:** leaderboard entries only (paid or `is_free` credit), Phase-1-complete, with an incomplete bracket.
- **Never overwrites** existing user picks; **idempotent** (re-running fills only still-missing matches).
- Tiebreaker (`total_goals`) defaults to the **median of on-time submitters** (fallback `12`). Stamps `updated_at = now()` so auto-filled entries sort **last** within leaderboard ties.

## UI / API

- Admin card in `TournamentSettingsForm.tsx`: preview count + confirm dialog, super-admin only, **disabled** until `phase2_locked` and resolution data is complete.
- Two API routes (`autofill-brackets` + `/preview`) with error→status mapping (403/404/409), plus two new whitelisted error strings in `lib/api/errors.ts`.

## Tests

- Route handler tests for both endpoints (401/403/400/404/409/200).
- `autofillParity.test.ts` — encodes the fill-rule spec the SQL mirrors (champion wins final, champion eliminated by user pick honored, slot-1 tie, third-place from SF losers, group-3rd dedupe).
- Full suite green: `npm test` (77 suites / 572 tests), `npm run typecheck`, `npm run lint` (only pre-existing warnings).

## Local verification

Exercised end-to-end against local Supabase with mock players covering complete / empty / partial / unpaid / free-credit / champion-eliminated cases:
- Preview `eligible=4`, fill `{matches_filled: 124, predictions_touched: 4}`, re-run idempotent (`0`).
- **0 invalid** R32/cascade picks — every auto-filled winner is one of the two real bracket teams.
- Guard confirmed: an incomplete R32 bracket yields `resolution_data_ok: false` and the RPC raises `resolution data incomplete`.

> Note: the docs say "31 knockout matches" but the schema/seed actually have **32** (M73–M104); the completeness check is computed dynamically from `knockout_matches`, not hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)