### PR TITLE
docs(backup): document session-pooler connection string

### DIFF
--- a/scripts/backup-remote-db.sh
+++ b/scripts/backup-remote-db.sh
@@ -11,15 +11,26 @@
 #
 # The connection string is NEVER read from git — pass it via the
 # SUPABASE_DB_URL env var or as the first argument. Get it from the Supabase
-# Dashboard → Project Settings → Database → Connection string. Use the
-# direct/session connection (port 5432), NOT the transaction pooler (6543),
-# so the dump can hold a consistent read.
+# Dashboard → Project Settings → Database → Connection string.
+#
+# Use the SESSION POOLER connection (port 5432), NOT the transaction pooler
+# (port 6543). The session pooler holds a consistent read for the dump; the
+# transaction pooler does not.
+#
+#   postgresql://postgres.<ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres
+#
+# Notes:
+#   - Username is "postgres.<ref>" (project ref embedded), NOT bare "postgres".
+#   - Do NOT use the direct host "db.<ref>.supabase.co" — on current Supabase
+#     infra it no longer resolves over IPv4 and pg_dump fails with
+#     'could not translate host name ... No address associated with hostname'.
+#   - URL-encode special characters in the password (e.g. '@' -> '%40').
 #
 # Examples:
-#   SUPABASE_DB_URL='postgresql://postgres:...@db.<ref>.supabase.co:5432/postgres' \
+#   SUPABASE_DB_URL='postgresql://postgres.<ref>:...@aws-0-<region>.pooler.supabase.com:5432/postgres' \
 #     scripts/backup-remote-db.sh
 #
-#   scripts/backup-remote-db.sh 'postgresql://postgres:...@db.<ref>.supabase.co:5432/postgres'
+#   scripts/backup-remote-db.sh 'postgresql://postgres.<ref>:...@aws-0-<region>.pooler.supabase.com:5432/postgres'
 #
 # Exit codes:
 #   0  snapshot written successfully


### PR DESCRIPTION
## What

Updates the header comments in `scripts/backup-remote-db.sh` to document the **session-pooler** connection string as the correct form for backups.

## Why

The previously-documented direct host `db.<ref>.supabase.co` no longer resolves over IPv4 on current Supabase infra. Running the backup fails with:

```
pg_dumpall: error: could not translate host name "db.<ref>.supabase.co" to address: No address associated with hostname
```

The session pooler host works and holds a consistent read for the dump.

## Changes

- Recommend `postgresql://postgres.<ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres` (port 5432 = session pooler; **not** 6543 transaction pooler).
- Note the username is `postgres.<ref>` (project ref embedded), not bare `postgres`.
- Note the direct `db.<ref>.supabase.co` host no longer resolves.
- Note password special chars must be URL-encoded.

Comments-only — no behavioral change to the script.