### PR TITLE
feat(knockout): per-fixture locking with progressive bracket, countdown, and FIFA tiebreak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-06-28
+
+### Added
+
+- **Per-fixture knockout locking.** Knockout fixtures can be locked individually at their own
+  kickoff while Phase 2 stays open, so users keep editing later rounds but cannot change a pick once
+  a match has started. Each fixture shows a live "Locks in …" countdown, admins get a per-fixture
+  lock control, and a new "Fill kicked-off fixtures" action fills blanks for already-started matches
+  with the outcome-blind default rule. (#243)
+- **Phase 1 winners snapshot.** Snapshots the Phase 1 (group stage + best-3rd advancers) top 3 when
+  Phase 2 opens and surfaces it on the prize modules, preserving the standalone Phase 1 result before
+  the live leaderboard folds in knockout points. (#239)
+- **Auto-fill for missing knockout brackets.** Super admins can fill blank knockout picks for paid,
+  Phase-1-complete entries after the knockout deadline, using an outcome-blind default so those
+  entries stay competitive. (#240)
+
+### Changed
+
+- **Phase 2 can open with incomplete 3rd-place assignments.** Opening Phase 2 no longer requires all
+  eight R32 best-3rd bracket slots to be assigned (the 12-group-standings requirement remains);
+  unassigned slots render TBD until filled. (#243)
+- **Autofill ties broken by FIFA ranking.** When two teams share the same real group finish, the
+  knockout auto-fills now pick the higher FIFA-ranked team rather than an arbitrary slot, via a new
+  `teams.fifa_ranking` column shared by both auto-fill paths. (#243)
+
+### Internal
+
+- Correct the knockout match count (31 → 32) in CLAUDE.md. (#241)
+- Document the backup script's session-pooler connection string. (#242)
+
 ## [1.7.0] - 2026-06-18
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
+++ b/frontend/src/app/admin/results/KnockoutResultsEditor.tsx
@@ -43,6 +43,11 @@ interface BracketAssignmentsResponse {
   assignments: Array<{ matchId: string; slot: 1 | 2; teamId: string }>;
 }
 
+interface KnockoutLockRow {
+  matchId: string;
+  lockedAt: string;
+}
+
 const STAGE_LABELS: Record<KnockoutMatch['stage'], string> = {
   round_of_32: 'Round of 32',
   round_of_16: 'Round of 16',
@@ -99,6 +104,23 @@ export function KnockoutResultsEditor({
       return { tournamentId, assignments: [] };
     },
   });
+
+  const locks = useQuery<KnockoutLockRow[]>({
+    queryKey: ['knockout-locks', tournamentId],
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/knockout-locks?tournamentId=${tournamentId}`).catch(
+        () => null
+      );
+      if (res && res.ok) return res.json();
+      return [];
+    },
+  });
+
+  const lockedAtById = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const l of locks.data ?? []) map.set(l.matchId, l.lockedAt);
+    return map;
+  }, [locks.data]);
 
   const submittedById = React.useMemo(() => {
     const map = new Map<string, KnockoutResultRow>();
@@ -236,6 +258,27 @@ export function KnockoutResultsEditor({
     }
   };
 
+  // Set (ISO string) or clear (null) the per-fixture prediction lock.
+  const handleSetLock = async (matchId: string, lockedAt: string | null) => {
+    try {
+      const res = await fetch(`/api/admin/knockout-matches/${matchId}/lock`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tournamentId, lockedAt }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? 'Failed to update lock');
+      }
+      toast.success(lockedAt ? `Match ${matchId} lock set` : `Match ${matchId} unlocked`);
+      await queryClient.invalidateQueries({ queryKey: ['knockout-locks', tournamentId] });
+      // The wizard reads locks from /api/tournament; nudge that cache too.
+      await queryClient.invalidateQueries({ queryKey: ['tournament'] });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to update lock');
+    }
+  };
+
   const grouped = React.useMemo(() => {
     const map = new Map<KnockoutMatch['stage'], KnockoutMatch[]>();
     for (const m of matches) {
@@ -324,6 +367,11 @@ export function KnockoutResultsEditor({
                     >
                       {savingId === m.id ? 'Saving…' : submitted ? 'Update' : 'Save'}
                     </Button>
+                    <MatchLockControl
+                      matchId={m.id}
+                      lockedAt={lockedAtById.get(m.id) ?? null}
+                      onSetLock={handleSetLock}
+                    />
                   </CardContent>
                 </Card>
               );
@@ -331,6 +379,95 @@ export function KnockoutResultsEditor({
           </div>
         </section>
       ))}
+    </div>
+  );
+}
+
+// Convert an ISO string to the value a <input type="datetime-local"> expects
+// (local wall-clock "YYYY-MM-DDTHH:mm", no timezone). Returns '' for null.
+function toDatetimeLocalValue(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// Per-fixture prediction-lock control. A fixture locked at a past time freezes
+// every user's pick for it; a future time schedules the lock at kickoff. This is
+// independent of the match RESULT entered above — it gates predictions, not truth.
+function MatchLockControl({
+  matchId,
+  lockedAt,
+  onSetLock,
+}: {
+  matchId: string;
+  lockedAt: string | null;
+  onSetLock: (matchId: string, lockedAt: string | null) => void | Promise<void>;
+}) {
+  const [draft, setDraft] = React.useState<string>(() => toDatetimeLocalValue(lockedAt));
+  // Clock read in an effect (never during render) so the lock status label stays
+  // current without tripping the purity rule.
+  const [nowMs, setNowMs] = React.useState<number | null>(null);
+
+  React.useEffect(() => {
+    setDraft(toDatetimeLocalValue(lockedAt));
+  }, [lockedAt]);
+
+  React.useEffect(() => {
+    setNowMs(Date.now());
+    const id = setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const lockedMs = lockedAt ? new Date(lockedAt).getTime() : null;
+  const isLockedNow = lockedMs !== null && nowMs !== null && nowMs >= lockedMs;
+  const isScheduled = lockedMs !== null && nowMs !== null && nowMs < lockedMs;
+
+  const statusLabel = isLockedNow
+    ? `🔒 Locked since ${new Date(lockedAt as string).toLocaleString()}`
+    : isScheduled
+      ? `⏳ Locks at ${new Date(lockedAt as string).toLocaleString()}`
+      : 'Predictions open';
+
+  return (
+    <div className="bg-muted/30 mt-1 space-y-2 rounded-md border px-3 py-2">
+      <p className="text-muted-foreground text-xs">{statusLabel}</p>
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="datetime-local"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          className="border-input bg-background h-8 rounded-md border px-2 text-xs"
+        />
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-8"
+          disabled={!draft}
+          onClick={() => onSetLock(matchId, draft ? new Date(draft).toISOString() : null)}
+        >
+          Set lock
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-8"
+          onClick={() => onSetLock(matchId, new Date().toISOString())}
+        >
+          Lock now
+        </Button>
+        {lockedAt ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-8"
+            onClick={() => onSetLock(matchId, null)}
+          >
+            Unlock
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -110,6 +110,7 @@ export function TournamentSettingsForm() {
   const [resetting, setResetting] = React.useState(false);
   const [autofillDialogOpen, setAutofillDialogOpen] = React.useState(false);
   const [autofilling, setAutofilling] = React.useState(false);
+  const [autofillingLocked, setAutofillingLocked] = React.useState(false);
 
   React.useEffect(() => {
     if (!tournament.data) return;
@@ -232,9 +233,10 @@ export function TournamentSettingsForm() {
   }, [matchesQuery.data]);
 
   const allStandingsSet = standingsCount === 12;
-  const allAssignmentsSet =
-    thirdPlaceSlotCount > 0 && assignmentsCount === thirdPlaceSlotCount;
-  const canOpenPhaseTwo = allStandingsSet && allAssignmentsSet;
+  // Phase 2 may open with partial 3rd-place bracket assignments (progressive
+  // per-fixture model): only the 12 group standings are required. Unassigned
+  // "3-XXXX" slots render TBD until the admin fills them.
+  const canOpenPhaseTwo = allStandingsSet;
   const phase = tournament.data?.phase ?? 'phase1';
 
   // Bracket auto-fill preview — how many paid/Phase-1-complete entries have an
@@ -373,6 +375,39 @@ export function TournamentSettingsForm() {
       toast.error(e instanceof Error ? e.message : 'Failed to auto-fill brackets');
     } finally {
       setAutofilling(false);
+    }
+  };
+
+  // Fill blanks only for fixtures that have ALREADY kicked off (individually
+  // locked), while Phase 2 is still open. Reuses the same outcome-blind rule as
+  // the whole-bracket autofill; safe to re-run after each kickoff.
+  const handleAutofillLocked = async () => {
+    if (!tournament.data) return;
+    setAutofillingLocked(true);
+    try {
+      const res = await fetch('/api/admin/tournament/autofill-locked-fixtures', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: tournament.data.id }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? 'Failed to fill locked fixtures');
+      const s = body.summary ?? {};
+      toast.success(
+        `Filled ${s.matches_filled ?? 0} locked ${
+          (s.matches_filled ?? 0) === 1 ? 'fixture' : 'fixtures'
+        } across ${s.predictions_touched ?? 0} ${
+          (s.predictions_touched ?? 0) === 1 ? 'entry' : 'entries'
+        }`
+      );
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['leaderboard'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
+      ]);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to fill locked fixtures');
+    } finally {
+      setAutofillingLocked(false);
     }
   };
 
@@ -562,9 +597,10 @@ export function TournamentSettingsForm() {
               />
               <p className="text-muted-foreground text-xs">
                 When knockout predictions freeze. Set + click Open Phase 2 to start the knockout
-                window. Group standings + R32 bracket assignments must be filled on the{' '}
-                <span className="font-mono">/admin/results</span> and{' '}
-                <span className="font-mono">/admin/advancers</span> tabs first.
+                window. All 12 group standings must be filled on the{' '}
+                <span className="font-mono">/admin/results</span> tab first. R32 3rd-place bracket
+                assignments (<span className="font-mono">/admin/advancers</span>) can be completed
+                after opening — unassigned slots show TBD until you fill them.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -580,15 +616,13 @@ export function TournamentSettingsForm() {
                 title={
                   !allStandingsSet
                     ? 'Enter all 12 group standings first'
-                    : !allAssignmentsSet
-                      ? 'Assign every R32 3rd-place slot first'
-                      : !phaseTwoLockIso
-                        ? 'Pick a Phase 2 lock time first'
-                        : phaseTwoLockInPast
-                          ? 'Phase 2 lock time must be in the future'
-                          : phase === 'phase2_locked'
-                            ? 'Phase 2 lock time has passed — set a new lock time above and click to reopen'
-                            : undefined
+                    : !phaseTwoLockIso
+                      ? 'Pick a Phase 2 lock time first'
+                      : phaseTwoLockInPast
+                        ? 'Phase 2 lock time must be in the future'
+                        : phase === 'phase2_locked'
+                          ? 'Phase 2 lock time has passed — set a new lock time above and click to reopen'
+                          : undefined
                 }
               >
                 {phase === 'phase2_locked' ? 'Reopen Phase 2' : 'Open Phase 2'}
@@ -626,6 +660,46 @@ export function TournamentSettingsForm() {
             </div>
           </CardContent>
         </Card>
+
+        {isSuperAdmin && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Fill kicked-off fixtures</CardTitle>
+              <p className="text-muted-foreground text-sm">
+                Super-admin only. While Phase 2 is open, fill blank picks for fixtures that have
+                already individually locked (kicked off) — so users who missed a fixture&apos;s
+                window get an outcome-blind default (same rule as the whole-bracket auto-fill) and
+                keep a complete downstream bracket. &ldquo;Outcome-blind&rdquo; means the default
+                winner is picked <strong>without looking at the real result</strong>: the
+                user&apos;s Champion pick wins if it&apos;s in the match; otherwise the team with
+                the better group-stage finish (group winner &gt; runner-up &gt; 3rd place), with
+                the higher bracket slot breaking a tie. Because it runs at kickoff — before the
+                match is decided — it&apos;s a fair forecast, not a backfill of the actual score.
+                Run shortly after each kickoff. Never overwrites an existing pick; safe to re-run.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm">
+                {phase !== 'phase2_open' && phase !== 'phase2_locked'
+                  ? 'Available once Phase 2 is open.'
+                  : 'Fills only fixtures whose lock time has passed.'}
+              </p>
+              <Button
+                onClick={handleAutofillLocked}
+                disabled={
+                  autofillingLocked || (phase !== 'phase2_open' && phase !== 'phase2_locked')
+                }
+                title={
+                  phase !== 'phase2_open' && phase !== 'phase2_locked'
+                    ? 'Phase 2 must be open'
+                    : undefined
+                }
+              >
+                {autofillingLocked ? 'Filling…' : 'Fill kicked-off fixtures'}
+              </Button>
+            </CardContent>
+          </Card>
+        )}
 
         {isSuperAdmin && (
           <Card>

--- a/frontend/src/app/api/admin/knockout-locks/route.ts
+++ b/frontend/src/app/api/admin/knockout-locks/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+/**
+ * List the per-fixture knockout locks for a tournament. Admin-gated read used by
+ * the knockout admin editor to show each fixture's lock state. (The user-facing
+ * wizard reads the same locks via the public /api/tournament route.)
+ */
+export async function GET(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const { searchParams } = new URL(request.url);
+  const tournamentId = searchParams.get('tournamentId');
+  if (!tournamentId) {
+    return NextResponse.json({ error: 'tournamentId is required' }, { status: 400 });
+  }
+
+  const { data, error } = await ctx.supabase
+    .from('knockout_match_locks')
+    .select('match_id, locked_at')
+    .eq('tournament_id', tournamentId);
+
+  if (error) return NextResponse.json({ error: safeMessage(error) }, { status: 500 });
+
+  const locks = ((data ?? []) as { match_id: string; locked_at: string }[]).map((l) => ({
+    matchId: l.match_id,
+    lockedAt: l.locked_at,
+  }));
+  return NextResponse.json(locks);
+}

--- a/frontend/src/app/api/admin/knockout-matches/[matchId]/lock/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/knockout-matches/[matchId]/lock/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { PATCH } = require('../route');
+
+function patchReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/knockout-matches/M73/lock', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ matchId: 'M73' }) };
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('PATCH /api/admin/knockout-matches/[matchId]/lock', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 403 for non-admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await PATCH(patchReq({ tournamentId: 't1', lockedAt: null }), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when tournamentId is missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await PATCH(patchReq({ lockedAt: null }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when lockedAt key is omitted', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await PATCH(patchReq({ tournamentId: 't1' }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards a lock time to the rpc', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: null });
+    const iso = '2026-06-28T19:00:00.000Z';
+    const res = await PATCH(patchReq({ tournamentId: 't1', lockedAt: iso }), ctx);
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_set_knockout_match_lock', {
+      p_tournament_id: 't1',
+      p_match_id: 'M73',
+      p_locked_at: iso,
+    });
+  });
+
+  it('forwards null (unlock) to the rpc', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: null });
+    const res = await PATCH(patchReq({ tournamentId: 't1', lockedAt: null }), ctx);
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_set_knockout_match_lock', {
+      p_tournament_id: 't1',
+      p_match_id: 'M73',
+      p_locked_at: null,
+    });
+  });
+});

--- a/frontend/src/app/api/admin/knockout-matches/[matchId]/lock/route.ts
+++ b/frontend/src/app/api/admin/knockout-matches/[matchId]/lock/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+type RouteContext = { params: Promise<{ matchId: string }> };
+
+/**
+ * Set (or clear) the per-fixture knockout lock for a match.
+ *
+ * Body `{ tournamentId, lockedAt }`:
+ *   - lockedAt: ISO timestamp → the fixture locks (becomes uneditable) at that
+ *     time. Admins set it to the fixture's kickoff in advance, or to now() to
+ *     lock immediately.
+ *   - lockedAt: null → unlock (the "unlock" half of unlock → edit → re-lock).
+ *
+ * Calls admin_set_knockout_match_lock (migration 0072).
+ */
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+  const { matchId } = await context.params;
+
+  const body = (await request.json()) as {
+    tournamentId?: string;
+    lockedAt?: string | null;
+  };
+
+  if (!body.tournamentId) {
+    return NextResponse.json({ error: 'tournamentId is required' }, { status: 400 });
+  }
+  if (body.lockedAt === undefined) {
+    return NextResponse.json(
+      { error: 'lockedAt is required (ISO timestamp, or null to unlock)' },
+      { status: 400 }
+    );
+  }
+
+  let lockedAt: string | null = null;
+  if (body.lockedAt !== null) {
+    const parsed = new Date(body.lockedAt);
+    if (Number.isNaN(parsed.getTime())) {
+      return NextResponse.json(
+        { error: 'lockedAt must be a valid ISO timestamp or null' },
+        { status: 400 }
+      );
+    }
+    lockedAt = parsed.toISOString();
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_set_knockout_match_lock', {
+    p_tournament_id: body.tournamentId,
+    p_match_id: matchId,
+    p_locked_at: lockedAt,
+  });
+
+  if (error) {
+    const msg = (error.message ?? '').toLowerCase();
+    const status = msg.includes('forbidden') ? 403 : msg.includes('not found') ? 404 : 400;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+
+  return NextResponse.json({ matchId, lockedAt });
+}

--- a/frontend/src/app/api/admin/tournament/autofill-locked-fixtures/route.ts
+++ b/frontend/src/app/api/admin/tournament/autofill-locked-fixtures/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+interface Body {
+  id?: string;
+}
+
+/**
+ * Fill blanks for knockout fixtures that have already individually locked
+ * (kicked off), while Phase 2 is still open. Super-admin-gated; calls
+ * admin_autofill_locked_fixtures (migration 0072), which reuses the same
+ * outcome-blind winner rule as the whole-bracket autofill but touches only
+ * locked fixtures and never overwrites a user's pick. Returns a fill summary.
+ */
+export async function POST(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json()) as Body;
+  if (!body.id) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 });
+  }
+
+  const { data, error } = await ctx.supabase.rpc('admin_autofill_locked_fixtures', {
+    p_tournament_id: body.id,
+  });
+
+  if (error) {
+    const msg = (error.message ?? '').toLowerCase();
+    let status = 400;
+    if (msg.includes('forbidden')) status = 403;
+    else if (msg.includes('not found')) status = 404;
+    else if (msg.includes('not open') || msg.includes('incomplete')) status = 409;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+
+  return NextResponse.json({ ok: true, summary: data });
+}

--- a/frontend/src/app/api/tournament/route.ts
+++ b/frontend/src/app/api/tournament/route.ts
@@ -39,12 +39,25 @@ export async function GET() {
   // RPC bypasses RLS and returns only two aggregates — safe for public
   // display. Eligibility predicate (paid_at <= lock_time, is_free split)
   // matches get_leaderboard.
-  const potStatsRes = await supabase.rpc('get_tournament_pot_stats', {
-    p_tournament_id: data.id,
-  });
+  const [potStatsRes, locksRes] = await Promise.all([
+    supabase.rpc('get_tournament_pot_stats', { p_tournament_id: data.id }),
+    // Per-fixture knockout locks for this tournament. Read-all RLS; powers the
+    // wizard's per-match disable. Time-sensitive, so it rides this uncached route
+    // (not the 1h-cached /api/knockout-matches metadata).
+    supabase
+      .from('knockout_match_locks')
+      .select('match_id, locked_at')
+      .eq('tournament_id', data.id),
+  ]);
   if (potStatsRes.error) {
     return NextResponse.json({ error: potStatsRes.error.message }, { status: 500 });
   }
+  if (locksRes.error) {
+    return NextResponse.json({ error: locksRes.error.message }, { status: 500 });
+  }
+  const knockoutLocks = (
+    (locksRes.data ?? []) as { match_id: string; locked_at: string }[]
+  ).map((l) => ({ matchId: l.match_id, lockedAt: l.locked_at }));
   const potStats = (potStatsRes.data?.[0] ?? { total_entries: 0, cash_paid_count: 0 }) as {
     total_entries: number;
     cash_paid_count: number;
@@ -82,6 +95,7 @@ export async function GET() {
     knockoutLockTime: data.knockout_lock_time,
     knockoutUnlocked: data.knockout_unlocked,
     phase,
+    knockoutLocks,
     totalEntries,
     cashPaidPredictionCount,
     potTotalCAD,

--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -308,7 +308,7 @@ export function PredictionsPageContent({
   const router = useRouter();
   const queryClient = useQueryClient();
   const { user, profile } = useAuthContext();
-  const { phase, isLocked } = useTournamentLock();
+  const { phase, isLocked, getMatchLockInfo, lockedMatchIds } = useTournamentLock();
   const isSuperAdmin = profile?.isSuperAdmin === true;
   // Super admin user-side writes route through the admin RPC so they can edit
   // their own predictions in any phase (including phase1_locked / phase2_*).
@@ -823,7 +823,8 @@ export function PredictionsPageContent({
         prev,
         groupPredictions,
         bracketAssignments,
-        groupStandings
+        groupStandings,
+        lockedMatchIds
       );
       persistDraft({ knockoutPredictions: next });
       if (changedMatchIds.length > 0) {
@@ -1473,6 +1474,7 @@ export function PredictionsPageContent({
               onPredictionChange={handleKnockoutPredictionChange}
               disabled={!phase2Editable}
               stage={currentStep}
+              getMatchLockInfo={getMatchLockInfo}
             />
           )}
 

--- a/frontend/src/components/layout/LockStatusBanner.tsx
+++ b/frontend/src/components/layout/LockStatusBanner.tsx
@@ -6,21 +6,9 @@ import { AlertCircle, Lock, Unlock, X } from 'lucide-react';
 import { useTournamentLock } from '@/hooks/useTournamentLock';
 import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/utils';
+import { formatRemaining } from '@/lib/formatRemaining';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-
-function formatRemaining(ms: number): string {
-  if (ms <= 0) return '0m';
-  const totalSec = Math.floor(ms / 1000);
-  const days = Math.floor(totalSec / 86400);
-  const hours = Math.floor((totalSec % 86400) / 3600);
-  const minutes = Math.floor((totalSec % 3600) / 60);
-  const seconds = totalSec % 60;
-  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  if (minutes > 0) return `${minutes}m ${seconds}s`;
-  return `${seconds}s`;
-}
 
 function dismissKey(tournamentId: string, phase: string): string {
   return `wc2026:banner-dismissed:${tournamentId}:${phase}`;

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import * as React from 'react';
-import { CheckCircle2, Circle, Trophy } from 'lucide-react';
+import { CheckCircle2, Circle, Clock, Lock, Trophy } from 'lucide-react';
+
+import { formatRemaining } from '@/lib/formatRemaining';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -88,6 +90,13 @@ interface KnockoutBracketProps {
   onPredictionChange: (matchId: string, winnerId: string | null) => void;
   disabled?: boolean;
   stage: KnockoutStage;
+  /**
+   * Per-fixture lock state. A fixture that has individually locked (kicked off)
+   * is frozen: its card is disabled with a "Locked" badge regardless of the
+   * bracket-wide `disabled` flag. A fixture with a future lock shows a countdown
+   * to kickoff. Defaults to never-locked.
+   */
+  getMatchLockInfo?: (matchId: string) => { locked: boolean; remainingMs: number | null };
 }
 
 // resolveTeamSource lives in @/lib/knockoutResolver so both this editor and
@@ -129,6 +138,8 @@ function MatchCard({
   selectedWinnerId,
   onSelect,
   disabled,
+  locked = false,
+  lockRemainingMs = null,
 }: {
   match: KnockoutMatch;
   team1Id: string | null;
@@ -137,6 +148,9 @@ function MatchCard({
   selectedWinnerId: string | null;
   onSelect: (winnerId: string | null) => void;
   disabled?: boolean;
+  locked?: boolean;
+  /** Ms until this fixture locks, when a future lock is scheduled (else null). */
+  lockRemainingMs?: number | null;
 }) {
   const team1 = getTeamDisplay(team1Id, teams);
   const team2 = getTeamDisplay(team2Id, teams);
@@ -145,22 +159,26 @@ function MatchCard({
   const isWinnerValid =
     selectedWinnerId === null || selectedWinnerId === team1Id || selectedWinnerId === team2Id;
 
-  // Auto-clear invalid selection when teams change
+  // Auto-clear invalid selection when teams change. Never auto-clear a locked
+  // fixture: its stored pick is frozen and must keep showing even if upstream
+  // resolution shifts.
   React.useEffect(() => {
-    if (selectedWinnerId && !isWinnerValid) {
+    if (!locked && selectedWinnerId && !isWinnerValid) {
       onSelect(null);
     }
-  }, [selectedWinnerId, isWinnerValid, onSelect]);
+  }, [locked, selectedWinnerId, isWinnerValid, onSelect]);
 
-  const effectiveWinnerId = isWinnerValid ? selectedWinnerId : null;
+  // A locked fixture always renders its stored winner and is never editable.
+  const effectiveWinnerId = locked || isWinnerValid ? selectedWinnerId : null;
   const hasWinner = effectiveWinnerId !== null;
-  const canSelect = team1Id !== null && team2Id !== null && !disabled;
+  const canSelect = team1Id !== null && team2Id !== null && !disabled && !locked;
 
   return (
     <Card
       className={cn(
         'w-full transition-colors',
-        hasWinner && 'border-green-500/50 bg-green-500/5 dark:bg-green-500/10'
+        hasWinner && 'border-green-500/50 bg-green-500/5 dark:bg-green-500/10',
+        locked && 'opacity-90'
       )}
     >
       <CardHeader className="p-3 pb-2">
@@ -171,10 +189,23 @@ function MatchCard({
               {formatSourcePair(match.team1Source, match.team2Source)}
             </span>
           </div>
-          <Badge variant="outline" className="shrink-0 text-xs">
-            {STAGE_CONFIG[match.stage].pointsHint}
-          </Badge>
+          {locked ? (
+            <Badge variant="secondary" className="shrink-0 text-xs">
+              <Lock className="mr-1 h-3 w-3" />
+              Locked
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="shrink-0 text-xs">
+              {STAGE_CONFIG[match.stage].pointsHint}
+            </Badge>
+          )}
         </div>
+        {!locked && lockRemainingMs !== null && (
+          <p className="mt-1 flex items-center gap-1 text-xs font-medium text-amber-600 dark:text-amber-500">
+            <Clock className="h-3 w-3 shrink-0" />
+            Locks in {formatRemaining(lockRemainingMs)}
+          </p>
+        )}
       </CardHeader>
       <CardContent className="space-y-2 p-3 pt-0">
         {/* Team 1 */}
@@ -242,6 +273,7 @@ function StageSection({
   groupStandings,
   onPredictionChange,
   disabled,
+  getMatchLockInfo,
 }: {
   stage: KnockoutStage;
   matches: KnockoutMatch[];
@@ -253,6 +285,7 @@ function StageSection({
   groupStandings: GroupStanding[];
   onPredictionChange: (matchId: string, winnerId: string | null) => void;
   disabled?: boolean;
+  getMatchLockInfo?: (matchId: string) => { locked: boolean; remainingMs: number | null };
 }) {
   const config = STAGE_CONFIG[stage];
   const completedCount = matches.filter((match) => {
@@ -317,6 +350,7 @@ function StageSection({
           );
           const prediction = knockoutPredictions.find((p) => p.matchId === match.id);
           const selectedWinnerId = prediction?.winnerId ?? null;
+          const lockInfo = getMatchLockInfo?.(match.id);
 
           return (
             <MatchCard
@@ -328,6 +362,8 @@ function StageSection({
               selectedWinnerId={selectedWinnerId}
               onSelect={(winnerId) => onPredictionChange(match.id, winnerId)}
               disabled={disabled}
+              locked={lockInfo?.locked ?? false}
+              lockRemainingMs={lockInfo && !lockInfo.locked ? lockInfo.remainingMs : null}
             />
           );
         })}
@@ -346,6 +382,7 @@ export function KnockoutBracket({
   onPredictionChange,
   disabled = false,
   stage,
+  getMatchLockInfo,
 }: KnockoutBracketProps) {
   const stageMatches = React.useMemo(
     () => matches.filter((m) => m.stage === stage),
@@ -421,6 +458,7 @@ export function KnockoutBracket({
         groupStandings={groupStandings}
         onPredictionChange={onPredictionChange}
         disabled={disabled}
+        getMatchLockInfo={getMatchLockInfo}
       />
     </div>
   );

--- a/frontend/src/components/predictions/__tests__/KnockoutBracket.test.tsx
+++ b/frontend/src/components/predictions/__tests__/KnockoutBracket.test.tsx
@@ -141,4 +141,32 @@ describe('KnockoutBracket', () => {
       expect(onPredictionChange).toHaveBeenCalledWith('M73', 'mex');
     });
   });
+
+  describe('per-fixture lock', () => {
+    it('shows a Locked badge and disables a fixture that has locked', () => {
+      renderBracket({
+        groupPredictions: createCompleteGroupPredictions(),
+        getMatchLockInfo: (matchId) =>
+          matchId === 'M73'
+            ? { locked: true, remainingMs: 0 }
+            : { locked: false, remainingMs: null },
+      });
+      // M73 = 1A vs 2B -> mex vs sui; both buttons disabled while locked.
+      expect(screen.getByText('Locked')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /MEX.*Mexico/i })).toBeDisabled();
+    });
+
+    it('shows a countdown for a fixture with a future lock, still editable', () => {
+      renderBracket({
+        groupPredictions: createCompleteGroupPredictions(),
+        getMatchLockInfo: (matchId) =>
+          matchId === 'M73'
+            ? { locked: false, remainingMs: 2 * 60 * 60 * 1000 + 15 * 60 * 1000 }
+            : { locked: false, remainingMs: null },
+      });
+      expect(screen.getByText(/Locks in 2h 15m/i)).toBeInTheDocument();
+      // Not locked yet → still selectable.
+      expect(screen.getByRole('button', { name: /MEX.*Mexico/i })).toBeEnabled();
+    });
+  });
 });

--- a/frontend/src/hooks/useTournamentLock.ts
+++ b/frontend/src/hooks/useTournamentLock.ts
@@ -5,6 +5,11 @@ import { useQuery } from '@tanstack/react-query';
 
 type Phase = 'phase1' | 'phase1_locked' | 'phase2_open' | 'phase2_locked';
 
+interface KnockoutLock {
+  matchId: string;
+  lockedAt: string;
+}
+
 interface TournamentResponse {
   id: string;
   slug: string;
@@ -15,6 +20,7 @@ interface TournamentResponse {
   knockoutUnlocked: boolean;
   phase: Phase;
   totalEntries: number;
+  knockoutLocks?: KnockoutLock[];
   serverTime: string;
 }
 
@@ -47,6 +53,21 @@ export interface TournamentLockState {
   hasActiveDeadline: boolean;
   /** True if |skewMs| > 5 minutes — surface a hint to the user. */
   clockSuspect: boolean;
+  /**
+   * True when a specific knockout fixture has individually locked (its kickoff
+   * has passed), evaluated against server time. Independent of the global phase
+   * lock — a fixture can lock while phase 2 is still open.
+   */
+  /** Ids of fixtures currently locked — handy for the cascade's immovable set. */
+  lockedMatchIds: Set<string>;
+  /**
+   * Per-fixture lock state for the wizard card:
+   *   - no lock scheduled → `{ locked: false, remainingMs: null }`
+   *   - lock in the future → `{ locked: false, remainingMs: > 0 }` (countdown)
+   *   - lock passed → `{ locked: true, remainingMs: 0 }`
+   * Evaluated against server time; recomputed every second.
+   */
+  getMatchLockInfo: (matchId: string) => { locked: boolean; remainingMs: number | null };
 }
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000;
@@ -108,6 +129,42 @@ export function useTournamentLock(): TournamentLockState {
   const hasActiveDeadline = activeDeadline !== null;
   const clockSuspect = Math.abs(skewMs) > FIVE_MINUTES_MS;
 
+  // Map of fixture id -> lock time (ms). Rebuilt only when the lock list changes.
+  const lockMsByMatch = React.useMemo(() => {
+    const m = new Map<string, number>();
+    for (const lock of data?.knockoutLocks ?? []) {
+      m.set(lock.matchId, new Date(lock.lockedAt).getTime());
+    }
+    return m;
+  }, [data?.knockoutLocks]);
+
+  // Set of fixtures whose lock time has passed, against server time (Date.now()
+  // + skew). Depends on `tick` so a fixture flips to locked the moment its
+  // kickoff passes, without a refetch.
+  const lockedMatchIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    const nowServer = Date.now() + skewMs;
+    for (const [matchId, lockedMs] of lockMsByMatch) {
+      if (nowServer >= lockedMs) ids.add(matchId);
+    }
+    return ids;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lockMsByMatch, skewMs, tick]);
+
+  const getMatchLockInfo = React.useCallback(
+    (matchId: string): { locked: boolean; remainingMs: number | null } => {
+      const lockedMs = lockMsByMatch.get(matchId);
+      if (lockedMs === undefined) return { locked: false, remainingMs: null };
+      const remaining = lockedMs - (Date.now() + skewMs);
+      return remaining <= 0
+        ? { locked: true, remainingMs: 0 }
+        : { locked: false, remainingMs: remaining };
+    },
+    // `tick` drives a fresh function each second so the card countdown re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [lockMsByMatch, skewMs, tick]
+  );
+
   return {
     tournamentId: data?.id ?? null,
     lockTime,
@@ -122,5 +179,7 @@ export function useTournamentLock(): TournamentLockState {
     remainingMs,
     hasActiveDeadline,
     clockSuspect,
+    lockedMatchIds,
+    getMatchLockInfo,
   };
 }

--- a/frontend/src/lib/__tests__/knockoutCascade.test.ts
+++ b/frontend/src/lib/__tests__/knockoutCascade.test.ts
@@ -189,4 +189,36 @@ describe('cascadeKnockoutPick', () => {
     expect(winnerOf(next, 'M97')).toBe('arg'); // stale pick left as-is
     expect(changedMatchIds).not.toContain('M97');
   });
+
+  it('never rewrites a locked downstream fixture (and the chain below it stays put)', () => {
+    // mex picked all the way to the Final. M90 has individually locked (kicked
+    // off), so flipping the still-editable M73 must NOT touch M90 — and since
+    // M90 keeps emitting mex, the matches below it stay mex too.
+    const predictions = withWinners({
+      M73: 'mex',
+      M75: 'ger',
+      M90: 'mex',
+      M97: 'mex',
+      M101: 'mex',
+      M104: 'mex',
+    });
+
+    const { predictions: next, changedMatchIds } = cascadeKnockoutPick(
+      'M73',
+      'sui',
+      fixtureKnockoutMatches,
+      predictions,
+      groupPredictions,
+      [],
+      [],
+      new Set(['M90'])
+    );
+
+    expect(winnerOf(next, 'M73')).toBe('sui'); // the edited match still changes
+    expect(winnerOf(next, 'M90')).toBe('mex'); // locked — frozen
+    expect(winnerOf(next, 'M97')).toBe('mex'); // fed by frozen M90 — unchanged
+    expect(winnerOf(next, 'M101')).toBe('mex');
+    expect(winnerOf(next, 'M104')).toBe('mex');
+    expect(changedMatchIds).not.toContain('M90');
+  });
 });

--- a/frontend/src/lib/fifaRankings.ts
+++ b/frontend/src/lib/fifaRankings.ts
@@ -1,6 +1,10 @@
 // Source: FIFA Men's World Ranking (https://www.fifa.com/fifa-world-ranking).
 // Hand-maintained; refresh after each official FIFA ranking publication.
 // Last updated: 2026-05.
+//
+// NOTE: these rankings are duplicated server-side in teams.fifa_ranking
+// (supabase migration 0074), which the SQL autofills use as their equal-group-
+// finish tiebreaker. Keep BOTH in sync when refreshing.
 
 import { ADVANCER_COUNT } from '@/lib/constants';
 import type { AdvancerPrediction, Group, GroupPrediction, Team } from '@/types/tournament';

--- a/frontend/src/lib/formatRemaining.ts
+++ b/frontend/src/lib/formatRemaining.ts
@@ -1,0 +1,20 @@
+/**
+ * Format a millisecond duration as a compact human countdown.
+ *   >= 1 day  -> "2d 3h 4m"
+ *   >= 1 hour -> "3h 4m"
+ *   >= 1 min  -> "4m 5s"
+ *   else      -> "5s"
+ * Non-positive input renders as "0m".
+ */
+export function formatRemaining(ms: number): string {
+  if (ms <= 0) return '0m';
+  const totalSec = Math.floor(ms / 1000);
+  const days = Math.floor(totalSec / 86400);
+  const hours = Math.floor((totalSec % 86400) / 3600);
+  const minutes = Math.floor((totalSec % 3600) / 60);
+  const seconds = totalSec % 60;
+  if (days > 0) return `${days}d ${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}

--- a/frontend/src/lib/knockoutCascade.ts
+++ b/frontend/src/lib/knockoutCascade.ts
@@ -63,7 +63,13 @@ export function cascadeKnockoutPick(
   predictions: KnockoutMatchPrediction[],
   groupPredictions: GroupPrediction[],
   bracketAssignments: R32BracketAssignment[] = [],
-  groupStandings: GroupStanding[] = []
+  groupStandings: GroupStanding[] = [],
+  /**
+   * Ids of fixtures that have individually locked (kicked off). A locked pick is
+   * frozen server-side, so the cascade must treat it as immovable: never rewrite
+   * a locked downstream match when an upstream winner changes.
+   */
+  lockedMatchIds: Set<string> = new Set()
 ): CascadeResult {
   // Snapshot each match's two contestants from the *current* predictions, so we
   // know which side every existing winner pick sat on before the change.
@@ -126,6 +132,7 @@ export function cascadeKnockoutPick(
 
   const changedMatchIds: string[] = [];
   for (const m of downstream) {
+    if (lockedMatchIds.has(m.id)) continue; // locked (kicked off) — frozen, never rewrite
     const oldWinner = winnerOf(m.id);
     if (oldWinner === null) continue; // nothing picked here — leave it
 

--- a/supabase/migrations/0072_per_fixture_knockout_lock.sql
+++ b/supabase/migrations/0072_per_fixture_knockout_lock.sql
@@ -1,0 +1,680 @@
+-- 0072_per_fixture_knockout_lock.sql
+--
+-- Per-fixture (progressive) knockout locking.
+--
+-- The Phase 2 window is otherwise all-or-nothing: an admin opens Phase 2
+-- (knockout_unlocked = true + a single knockout_lock_time) and EVERY knockout
+-- pick stays editable until that one deadline, then all freeze together. The
+-- WC2026 schedule makes that impossible: the group stage ends only hours before
+-- the first knockout match (M73) kicks off, and later R32 fixtures kick off over
+-- the following days. We want to keep the window open late so users can keep
+-- tuning later rounds, but lock EACH fixture individually at its own kickoff so
+-- no pick can change once a match has started.
+--
+-- Model: a per-(tournament, match) `locked_at` timestamp. A fixture is locked
+-- when now() >= locked_at. The admin sets it to the fixture's kickoff in advance
+-- (auto-applies) or to now() to lock immediately. This layers ON TOP of the
+-- existing global knockout_lock_time, which stays as a backstop.
+--
+-- Enforcement lives at the RPC boundary: submit_predictions / admin_submit_predictions
+-- preserve a locked fixture's stored pick and silently ignore incoming changes to
+-- it, while every other fixture stays editable. The lock is honored uniformly for
+-- everyone (including super-admin via admin_submit_predictions): to correct a
+-- locked pick an admin must unlock the fixture, edit, then re-lock.
+--
+-- For users who left a now-locked fixture blank, admin_autofill_locked_fixtures
+-- fills it with the existing outcome-blind rule from 0071 (champion override ->
+-- better real group finish -> slot-1 tiebreak). Because that rule never reads
+-- knockout_results, running it at a fixture's kickoff is a forecast, not a backfill.
+
+-- ========== table: knockout_match_locks ==========
+
+create table if not exists public.knockout_match_locks (
+    tournament_id uuid not null references public.tournaments(id) on delete cascade,
+    match_id      text not null references public.knockout_matches(id),
+    locked_at     timestamptz not null,
+    primary key (tournament_id, match_id)
+);
+
+alter table public.knockout_match_locks enable row level security;
+
+-- Lock times aren't secret; the prediction wizard needs them to disable cards.
+-- Read-all; no client writes (all mutations go through the admin RPC below).
+drop policy if exists knockout_match_locks_select_all on public.knockout_match_locks;
+create policy knockout_match_locks_select_all
+    on public.knockout_match_locks for select using (true);
+
+-- ========== helper: is_knockout_match_locked ==========
+
+create or replace function public.is_knockout_match_locked(
+    p_tournament_id uuid,
+    p_match_id text
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select exists (
+        select 1 from public.knockout_match_locks
+        where tournament_id = p_tournament_id
+          and match_id = p_match_id
+          and now() >= locked_at
+    );
+$$;
+
+grant execute on function public.is_knockout_match_locked(uuid, text) to authenticated;
+
+-- ========== admin RPC: admin_set_knockout_match_lock ==========
+-- p_locked_at = null  -> unlock (delete the row)   [the "unlock" half of
+--                                                    unlock -> edit -> re-lock]
+-- p_locked_at set     -> schedule/set the lock time (upsert)
+
+create or replace function public.admin_set_knockout_match_lock(
+    p_tournament_id uuid,
+    p_match_id text,
+    p_locked_at timestamptz
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if not exists (select 1 from public.tournaments where id = p_tournament_id) then
+        raise exception 'tournament not found' using errcode = 'P0001';
+    end if;
+    if not exists (select 1 from public.knockout_matches where id = p_match_id) then
+        raise exception 'match not found' using errcode = 'P0001';
+    end if;
+
+    if p_locked_at is null then
+        delete from public.knockout_match_locks
+            where tournament_id = p_tournament_id and match_id = p_match_id;
+    else
+        insert into public.knockout_match_locks (tournament_id, match_id, locked_at)
+            values (p_tournament_id, p_match_id, p_locked_at)
+            on conflict (tournament_id, match_id)
+            do update set locked_at = excluded.locked_at;
+    end if;
+end;
+$$;
+
+revoke all on function public.admin_set_knockout_match_lock(uuid, text, timestamptz) from public;
+grant execute on function public.admin_set_knockout_match_lock(uuid, text, timestamptz) to authenticated;
+
+-- ========== submit_predictions (re-emit from 0050, per-fixture lock guard) ==========
+-- Verbatim re-emit of the 0050 body. ONLY the phase2_open knockout write block
+-- changes: instead of "delete all + reinsert all", it deletes only UNLOCKED
+-- fixtures and skips locked fixtures on insert, so a locked fixture's stored pick
+-- is authoritative and incoming changes to it are silently ignored.
+
+create or replace function public.submit_predictions(payload jsonb)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid := (payload->>'tournament_id')::uuid;
+    v_prediction_id uuid := nullif(payload->>'prediction_id', '')::uuid;
+    v_prediction_name text := nullif(trim(payload->>'prediction_name'), '');
+    v_total_goals int := nullif(payload->>'total_goals', '')::int;
+    v_champion_team_id text := nullif(payload->>'champion_team_id', '');
+    v_has_champion_key boolean := payload ? 'champion_team_id';
+    v_mark_submitted boolean := coalesce((payload->>'submit')::boolean, true);
+    v_user uuid := auth.uid();
+    v_phase text;
+    v_has_phase1_fields boolean;
+    v_has_phase2_fields boolean;
+    v_group jsonb;
+    v_match jsonb;
+    v_advancer jsonb;
+    v_rank int;
+    v_team_id text;
+    v_seen_ranks int[] := '{}';
+    v_seen_teams text[] := '{}';
+    v_valid_thirds text[];
+    v_group_id text;
+    v_team_ids text[];
+    v_mismatched_team text;
+begin
+    if v_user is null then
+        raise exception 'not authenticated';
+    end if;
+
+    v_phase := public.tournament_phase(v_tournament_id);
+
+    if v_prediction_id is null and v_phase <> 'phase1' then
+        raise exception 'phase 1 ended; new predictions cannot be created'
+            using errcode = 'P0001';
+    end if;
+
+    v_has_phase1_fields := (payload ? 'groups' and jsonb_array_length(payload->'groups') > 0)
+        or (payload ? 'advancers' and jsonb_array_length(payload->'advancers') > 0)
+        or v_has_champion_key;
+    v_has_phase2_fields := (payload ? 'knockout' and jsonb_array_length(payload->'knockout') > 0)
+        or (v_total_goals is not null);
+
+    if v_phase = 'phase1_locked' or v_phase = 'phase2_locked' then
+        raise exception 'predictions are locked';
+    end if;
+
+    if v_phase = 'phase1' and v_has_phase2_fields then
+        raise exception 'phase 1 only fields allowed' using errcode = 'P0001';
+    end if;
+    if v_phase = 'phase2_open' and v_has_phase1_fields then
+        raise exception 'phase 1 ended; group + advancer picks are frozen'
+            using errcode = 'P0001';
+    end if;
+
+    if v_prediction_id is null then
+        if v_prediction_name is null then
+            raise exception 'prediction name required' using errcode = 'P0001';
+        end if;
+        if v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            insert into public.predictions (
+                user_id, tournament_id, prediction_name, total_goals,
+                champion_team_id, submitted_at
+            )
+            values (
+                v_user,
+                v_tournament_id,
+                v_prediction_name,
+                v_total_goals,
+                v_champion_team_id,
+                case when v_mark_submitted then now() else null end
+            )
+            returning id into v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    else
+        perform 1 from public.predictions
+            where id = v_prediction_id and user_id = v_user and tournament_id = v_tournament_id;
+        if not found then
+            raise exception 'prediction not found' using errcode = 'P0001';
+        end if;
+
+        if v_has_champion_key and v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.predictions
+               set prediction_name = case
+                       when v_phase = 'phase1'
+                           then coalesce(v_prediction_name, prediction_name)
+                       else prediction_name
+                   end,
+                   total_goals = case when v_phase = 'phase2_open' then v_total_goals else total_goals end,
+                   champion_team_id = case
+                       when v_phase = 'phase1' and v_has_champion_key then v_champion_team_id
+                       else champion_team_id
+                   end,
+                   submitted_at = case when v_mark_submitted then now() else submitted_at end
+             where id = v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    if v_phase = 'phase1' then
+        delete from public.advancer_predictions where prediction_id = v_prediction_id;
+        delete from public.group_predictions where prediction_id = v_prediction_id;
+
+        for v_group in select * from jsonb_array_elements(coalesce(payload->'groups', '[]'::jsonb))
+        loop
+            v_group_id := v_group->>'group_id';
+            v_team_ids := array_remove(array[
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            ], null);
+
+            select t.id into v_mismatched_team
+              from public.teams t
+             where t.id = any(v_team_ids) and t.group_id is distinct from v_group_id
+             limit 1;
+
+            if v_mismatched_team is not null then
+                raise exception 'team % does not belong to group %', v_mismatched_team, v_group_id
+                    using errcode = 'P0001';
+            end if;
+
+            insert into public.group_predictions (
+                prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id
+            ) values (
+                v_prediction_id,
+                v_group_id,
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            );
+        end loop;
+
+        select array_agg(third_team_id) into v_valid_thirds
+          from public.group_predictions
+         where prediction_id = v_prediction_id
+           and third_team_id is not null;
+
+        for v_advancer in select * from jsonb_array_elements(coalesce(payload->'advancers', '[]'::jsonb))
+        loop
+            v_rank := nullif(v_advancer->>'rank', '')::int;
+            v_team_id := nullif(v_advancer->>'team_id', '');
+            if v_team_id is null then
+                continue;
+            end if;
+            if v_rank is null or v_rank < 1 or v_rank > 8 then
+                raise exception 'advancer rank must be 1..8 (got %)', v_rank using errcode = 'P0001';
+            end if;
+            if v_rank = any(v_seen_ranks) then
+                raise exception 'duplicate advancer rank %', v_rank using errcode = 'P0001';
+            end if;
+            if v_team_id = any(v_seen_teams) then
+                raise exception 'duplicate advancer team' using errcode = 'P0001';
+            end if;
+            if v_valid_thirds is null or not (v_team_id = any(v_valid_thirds)) then
+                raise exception 'advancer team % not in your 3rd-place picks', v_team_id
+                    using errcode = 'P0001';
+            end if;
+            v_seen_ranks := array_append(v_seen_ranks, v_rank);
+            v_seen_teams := array_append(v_seen_teams, v_team_id);
+
+            insert into public.advancer_predictions (prediction_id, rank, team_id)
+            values (v_prediction_id, v_rank, v_team_id);
+        end loop;
+    elsif v_phase = 'phase2_open' then
+        -- Per-fixture lock: delete only UNLOCKED fixtures; a locked fixture's
+        -- stored pick is authoritative and survives the rewrite.
+        delete from public.knockout_predictions kp
+            where kp.prediction_id = v_prediction_id
+              and not public.is_knockout_match_locked(v_tournament_id, kp.match_id);
+        for v_match in select * from jsonb_array_elements(coalesce(payload->'knockout', '[]'::jsonb))
+        loop
+            -- Silently ignore incoming changes to a locked fixture (stale clients
+            -- are safe). Locked rows were never deleted above, so skipping here
+            -- preserves them.
+            if public.is_knockout_match_locked(v_tournament_id, v_match->>'match_id') then
+                continue;
+            end if;
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+            values (
+                v_prediction_id,
+                v_match->>'match_id',
+                nullif(v_match->>'winner', '')
+            );
+        end loop;
+    end if;
+
+    return v_prediction_id;
+end;
+$$;
+
+grant execute on function public.submit_predictions(jsonb) to authenticated;
+
+-- ========== admin_submit_predictions (re-emit from 0050, per-fixture lock guard) ==========
+-- Verbatim re-emit of the 0050 body. ONLY the knockout write block changes, the
+-- same way as submit_predictions. The per-fixture lock is honored even for
+-- super-admin (no v_super bypass here): correcting a locked pick requires an
+-- explicit unlock (admin_set_knockout_match_lock(..., null)) first.
+
+create or replace function public.admin_submit_predictions(p_user_id uuid, payload jsonb)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid := (payload->>'tournament_id')::uuid;
+    v_prediction_id uuid := nullif(payload->>'prediction_id', '')::uuid;
+    v_prediction_name text := nullif(trim(payload->>'prediction_name'), '');
+    v_total_goals int := nullif(payload->>'total_goals', '')::int;
+    v_champion_team_id text := nullif(payload->>'champion_team_id', '');
+    v_has_champion_key boolean := payload ? 'champion_team_id';
+    v_mark_submitted boolean := coalesce((payload->>'submit')::boolean, true);
+    v_phase text;
+    v_super boolean;
+    v_group jsonb;
+    v_match jsonb;
+    v_advancer jsonb;
+    v_rank int;
+    v_team_id text;
+    v_seen_ranks int[] := '{}';
+    v_seen_teams text[] := '{}';
+    v_valid_thirds text[];
+    v_group_id text;
+    v_team_ids text[];
+    v_mismatched_team text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_user_id is null or v_tournament_id is null then
+        raise exception 'user_id and tournament_id are required' using errcode = 'P0001';
+    end if;
+
+    v_super := public.is_super_admin();
+    v_phase := public.tournament_phase(v_tournament_id);
+
+    if not v_super then
+        if v_prediction_id is null and v_phase <> 'phase1' then
+            raise exception 'phase 1 ended; new predictions cannot be created'
+                using errcode = 'P0001';
+        end if;
+        if v_phase = 'phase1_locked' or v_phase = 'phase2_locked' then
+            raise exception 'predictions are locked';
+        end if;
+    end if;
+
+    if v_prediction_id is null then
+        if v_prediction_name is null then
+            raise exception 'prediction name required' using errcode = 'P0001';
+        end if;
+        if v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            insert into public.predictions (
+                user_id, tournament_id, prediction_name, total_goals,
+                champion_team_id, submitted_at
+            )
+            values (
+                p_user_id,
+                v_tournament_id,
+                v_prediction_name,
+                v_total_goals,
+                v_champion_team_id,
+                case when v_mark_submitted then now() else null end
+            )
+            returning id into v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    else
+        perform 1 from public.predictions
+            where id = v_prediction_id and user_id = p_user_id and tournament_id = v_tournament_id;
+        if not found then
+            raise exception 'prediction not found' using errcode = 'P0001';
+        end if;
+
+        if v_has_champion_key and v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.predictions
+               set prediction_name = case
+                       when v_super or v_phase = 'phase1'
+                           then coalesce(v_prediction_name, prediction_name)
+                       else prediction_name
+                   end,
+                   total_goals = v_total_goals,
+                   champion_team_id = case
+                       when v_has_champion_key and (v_super or v_phase = 'phase1')
+                           then v_champion_team_id
+                       else champion_team_id
+                   end,
+                   submitted_at = case when v_mark_submitted then now() else submitted_at end
+             where id = v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    if v_super or v_phase = 'phase1' then
+        delete from public.advancer_predictions where prediction_id = v_prediction_id;
+        delete from public.group_predictions where prediction_id = v_prediction_id;
+
+        for v_group in select * from jsonb_array_elements(coalesce(payload->'groups', '[]'::jsonb))
+        loop
+            v_group_id := v_group->>'group_id';
+            v_team_ids := array_remove(array[
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            ], null);
+
+            select t.id into v_mismatched_team
+              from public.teams t
+             where t.id = any(v_team_ids) and t.group_id is distinct from v_group_id
+             limit 1;
+
+            if v_mismatched_team is not null then
+                raise exception 'team % does not belong to group %', v_mismatched_team, v_group_id
+                    using errcode = 'P0001';
+            end if;
+
+            insert into public.group_predictions (
+                prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id
+            ) values (
+                v_prediction_id,
+                v_group_id,
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            );
+        end loop;
+
+        select array_agg(third_team_id) into v_valid_thirds
+          from public.group_predictions
+         where prediction_id = v_prediction_id
+           and third_team_id is not null;
+
+        for v_advancer in select * from jsonb_array_elements(coalesce(payload->'advancers', '[]'::jsonb))
+        loop
+            v_rank := nullif(v_advancer->>'rank', '')::int;
+            v_team_id := nullif(v_advancer->>'team_id', '');
+            if v_team_id is null then
+                continue;
+            end if;
+            if v_rank is null or v_rank < 1 or v_rank > 8 then
+                raise exception 'advancer rank must be 1..8 (got %)', v_rank using errcode = 'P0001';
+            end if;
+            if v_rank = any(v_seen_ranks) then
+                raise exception 'duplicate advancer rank %', v_rank using errcode = 'P0001';
+            end if;
+            if v_team_id = any(v_seen_teams) then
+                raise exception 'duplicate advancer team' using errcode = 'P0001';
+            end if;
+            if v_valid_thirds is null or not (v_team_id = any(v_valid_thirds)) then
+                raise exception 'advancer team % not in your 3rd-place picks', v_team_id
+                    using errcode = 'P0001';
+            end if;
+            v_seen_ranks := array_append(v_seen_ranks, v_rank);
+            v_seen_teams := array_append(v_seen_teams, v_team_id);
+
+            insert into public.advancer_predictions (prediction_id, rank, team_id)
+            values (v_prediction_id, v_rank, v_team_id);
+        end loop;
+    end if;
+
+    if v_super or v_phase = 'phase2_open' then
+        -- Per-fixture lock applies uniformly (no super-admin bypass): a locked
+        -- fixture's stored pick survives. To change it, unlock the fixture first.
+        delete from public.knockout_predictions kp
+            where kp.prediction_id = v_prediction_id
+              and not public.is_knockout_match_locked(v_tournament_id, kp.match_id);
+        for v_match in select * from jsonb_array_elements(coalesce(payload->'knockout', '[]'::jsonb))
+        loop
+            if public.is_knockout_match_locked(v_tournament_id, v_match->>'match_id') then
+                continue;
+            end if;
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+            values (
+                v_prediction_id,
+                v_match->>'match_id',
+                nullif(v_match->>'winner', '')
+            );
+        end loop;
+    end if;
+
+    return v_prediction_id;
+end;
+$$;
+
+grant execute on function public.admin_submit_predictions(uuid, jsonb) to authenticated;
+
+-- ========== admin_autofill_locked_fixtures ==========
+-- Fills blanks for fixtures that are ALREADY LOCKED (kicked off), reusing the
+-- exact outcome-blind winner rule + source resolution from 0071. Unlike
+-- admin_autofill_phase2_brackets, this runs DURING phase2_open and touches only
+-- locked fixtures, so users keep editing everything not yet kicked off.
+--
+--   Per locked, still-blank match: resolve the two real teams, then
+--     1. champion override, 2. better real group finish, 3. slot-1 tiebreak.
+--   It never reads knockout_results, so the pick is a forecast, not a backfill.
+--   Does NOT touch predictions.total_goals or .updated_at (those stay the user's
+--   to set until the global lock; the 0071 sweep handles them at phase2_locked).
+
+create or replace function public.admin_autofill_locked_fixtures(p_tournament_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_eligible int := 0;
+    v_touched int := 0;
+    v_filled int := 0;
+    v_phase text;
+    v_pred record;
+    v_match record;
+    v_winners jsonb;
+    v_champion text;
+    v_t1 text;
+    v_t2 text;
+    v_winner text;
+    v_pred_filled int;
+begin
+    -- ----- guards -----
+    if not public.is_super_admin() then
+        raise exception 'forbidden';
+    end if;
+    if not exists (select 1 from public.tournaments where id = p_tournament_id) then
+        raise exception 'tournament not found';
+    end if;
+    v_phase := public.tournament_phase(p_tournament_id);
+    if v_phase not in ('phase2_open', 'phase2_locked') then
+        raise exception 'knockout phase is not open';
+    end if;
+
+    -- Resolution data must exist or we'd write NULL winners. (Phase 2 can't open
+    -- without it, but check defensively — mirrors 0071.)
+    if (select count(*) from public.group_standings where tournament_id = p_tournament_id) <> 12 then
+        raise exception 'resolution data incomplete';
+    end if;
+
+    -- Nothing to do if no fixture is currently locked.
+    if not exists (
+        select 1 from public.knockout_match_locks
+        where tournament_id = p_tournament_id and now() >= locked_at
+    ) then
+        return jsonb_build_object(
+            'predictions_eligible', 0, 'predictions_touched', 0, 'matches_filled', 0
+        );
+    end if;
+
+    -- ----- per eligible prediction (same eligibility as 0071) -----
+    for v_pred in
+        select p.id, p.champion_team_id
+            from public.predictions p
+            where p.tournament_id = p_tournament_id
+              and p.champion_team_id is not null
+              and public.prediction_phase1_complete(p.id)
+              and exists (
+                  select 1 from public.tournament_payments tp
+                  join public.tournaments t on t.id = tp.tournament_id
+                  where tp.prediction_id = p.id and tp.paid_at <= t.lock_time
+              )
+    loop
+        v_eligible := v_eligible + 1;
+        v_champion := v_pred.champion_team_id;
+        v_pred_filled := 0;
+
+        -- Seed the working winners map from the user's existing (non-null) picks
+        -- so downstream locked fixtures cascade from them and we never overwrite.
+        select coalesce(jsonb_object_agg(kp.match_id, kp.winner_team_id), '{}'::jsonb)
+            into v_winners
+            from public.knockout_predictions kp
+            where kp.prediction_id = v_pred.id and kp.winner_team_id is not null;
+
+        for v_match in
+            select id, team1_source, team2_source
+                from public.knockout_matches
+                order by match_order
+        loop
+            -- Already has a pick (user or filled earlier this run) -> keep it.
+            if v_winners ? v_match.id then
+                continue;
+            end if;
+            -- Only fill fixtures that have actually locked (kicked off). Leave
+            -- everything still editable for the user to finish.
+            if not public.is_knockout_match_locked(p_tournament_id, v_match.id) then
+                continue;
+            end if;
+
+            v_t1 := public._autofill_resolve_source(p_tournament_id, v_match.team1_source, v_winners);
+            v_t2 := public._autofill_resolve_source(p_tournament_id, v_match.team2_source, v_winners);
+
+            if v_t1 is null and v_t2 is null then
+                continue;                                   -- unresolvable, skip
+            elsif v_t1 is null then
+                v_winner := v_t2;
+            elsif v_t2 is null then
+                v_winner := v_t1;
+            elsif v_t1 = v_champion then
+                v_winner := v_t1;                           -- champion override
+            elsif v_t2 = v_champion then
+                v_winner := v_t2;
+            elsif public._autofill_seed(p_tournament_id, v_t1)
+                  <= public._autofill_seed(p_tournament_id, v_t2) then
+                v_winner := v_t1;                           -- better/equal seed (tie -> team1)
+            else
+                v_winner := v_t2;
+            end if;
+
+            v_winners := jsonb_set(v_winners, array[v_match.id], to_jsonb(v_winner));
+
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+                values (v_pred.id, v_match.id, v_winner)
+                on conflict (prediction_id, match_id)
+                do update set winner_team_id = excluded.winner_team_id
+                where public.knockout_predictions.winner_team_id is null;
+
+            v_pred_filled := v_pred_filled + 1;
+            v_filled := v_filled + 1;
+        end loop;
+
+        if v_pred_filled > 0 then
+            v_touched := v_touched + 1;
+        end if;
+    end loop;
+
+    return jsonb_build_object(
+        'predictions_eligible', v_eligible,
+        'predictions_touched', v_touched,
+        'matches_filled', v_filled
+    );
+end;
+$$;
+
+revoke all on function public.admin_autofill_locked_fixtures(uuid) from public;
+grant execute on function public.admin_autofill_locked_fixtures(uuid) to authenticated;

--- a/supabase/migrations/0073_phase2_open_without_full_r32_assignments.sql
+++ b/supabase/migrations/0073_phase2_open_without_full_r32_assignments.sql
@@ -1,0 +1,58 @@
+-- 0073_phase2_open_without_full_r32_assignments.sql
+--
+-- Relax the Phase 2 open guard for the progressive per-fixture model (0072).
+--
+-- admin_set_phase_two (latest body in 0052) refused to open Phase 2 until BOTH
+-- all 12 group standings AND all 8 R32 3rd-place bracket slots were assigned.
+-- That second requirement blocks the exact situation per-fixture locking exists
+-- for: the group stage finishes only hours before the first knockout kicks off,
+-- but the best-8 third-place advancers (and therefore the 8 "3-XXXX" R32 slot
+-- assignments) aren't finalised until later. We need Phase 2 open early so users
+-- can enter already-decided fixtures (e.g. M73 = 2A vs 2B, which depends on no
+-- 3rd-place slot at all).
+--
+-- Fix: keep the 12-group-standings guard (groups are complete before any
+-- knockout kickoff, and they feed every 1st/2nd-seeded R32 match), but DROP the
+-- all-8-bracket-slots guard. Unassigned "3-XXXX" slots simply resolve to TBD and
+-- stay unpickable until the admin assigns them; everything already resolved is
+-- enterable immediately. Otherwise a verbatim re-emit of the 0052 body.
+
+create or replace function public.admin_set_phase_two(
+    p_tournament_id uuid,
+    p_unlocked boolean,
+    p_lock_time timestamptz default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_standings_count int;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    if p_unlocked then
+        select count(*) into v_standings_count
+          from public.group_standings
+         where tournament_id = p_tournament_id;
+        if v_standings_count <> 12 then
+            raise exception 'all 12 group standings must be entered before opening phase 2 (% of 12)',
+                v_standings_count
+                using errcode = 'P0001';
+        end if;
+        -- NOTE: the former "all R32 3rd-place bracket slots must be assigned"
+        -- guard is intentionally removed — Phase 2 may open with partial 3rd-place
+        -- assignments; unassigned slots render TBD until the admin fills them.
+    end if;
+
+    update public.tournaments
+       set knockout_unlocked = p_unlocked,
+           knockout_lock_time = case when p_unlocked then p_lock_time else knockout_lock_time end
+     where id = p_tournament_id;
+end;
+$$;
+
+grant execute on function public.admin_set_phase_two(uuid, boolean, timestamptz) to authenticated;

--- a/supabase/migrations/0074_autofill_fifa_ranking_tiebreak.sql
+++ b/supabase/migrations/0074_autofill_fifa_ranking_tiebreak.sql
@@ -1,0 +1,344 @@
+-- 0074_autofill_fifa_ranking_tiebreak.sql
+--
+-- Break autofill ties by FIFA ranking instead of the arbitrary slot-1 fallback.
+--
+-- The outcome-blind autofill rule (champion -> better group finish -> ???) used
+-- the team1_source side whenever two teams had the SAME real group finish, only
+-- because `teams` carried no ranking to decide it more meaningfully. We now add a
+-- `fifa_ranking` column (populated from the FIFA Men's World Ranking, mirroring
+-- frontend/src/lib/fifaRankings.ts) and use it as the tiebreaker: on equal group
+-- finish, the higher-ranked team (lower number) wins; slot-1 remains the final
+-- fallback only when a ranking is missing or also tied.
+--
+-- The winner rule is extracted into one helper, public._autofill_pick_winner,
+-- so both autofills (admin_autofill_phase2_brackets [0071], whole-bracket; and
+-- admin_autofill_locked_fixtures [0072], per-fixture) share it and can't drift.
+--
+-- NOTE: rankings are now duplicated (this column + fifaRankings.ts, which the
+-- client uses for its own group/advancer autofills). Refresh BOTH together after
+-- each official FIFA ranking publication.
+
+-- ========== teams.fifa_ranking column + data ==========
+
+alter table public.teams add column if not exists fifa_ranking int;
+
+update public.teams t set fifa_ranking = f.rank
+  from (values
+    ('ESP',1),('ARG',2),('FRA',3),('ENG',4),('BRA',5),('POR',6),('NED',7),('BEL',8),('CRO',9),('GER',11),
+    ('MAR',12),('COL',13),('URU',14),('USA',15),('MEX',16),('SUI',17),('SEN',18),('JPN',19),('IRN',21),('KOR',22),
+    ('ECU',24),('AUS',25),('AUT',26),('CAN',28),('TUR',30),('NOR',32),('SWE',33),('ALG',36),('CZE',37),('EGY',38),
+    ('SCO',39),('CIV',40),('PAN',41),('PAR',45),('QAT',50),('TUN',51),('UZB',55),('RSA',58),('KSA',59),('COD',60),
+    ('CPV',62),('JOR',64),('IRQ',68),('BIH',75),('CUW',80),('HAI',85),('GHA',86),('NZL',88)
+  ) as f(code, rank)
+ where t.code = f.code;
+
+-- Fail loudly if any team was left unranked (a code mismatch would silently
+-- degrade the tiebreaker back to slot-1 for that team).
+do $$
+declare v_missing int;
+begin
+    select count(*) into v_missing from public.teams where fifa_ranking is null;
+    if v_missing > 0 then
+        raise exception 'fifa_ranking not populated for % team(s)', v_missing;
+    end if;
+end $$;
+
+-- ========== helper: _autofill_pick_winner ==========
+-- The single source of truth for the outcome-blind autofill winner rule:
+--   1. only one side resolved      -> that team (null if neither resolves)
+--   2. champion override            -> the entry's champion if it's in the match
+--   3. better real group finish     -> 1st > 2nd > 3rd (lower _autofill_seed)
+--   4. equal finish                 -> better FIFA ranking (lower number)
+--   5. missing/equal ranking        -> stable slot-1 (team1) fallback
+
+create or replace function public._autofill_pick_winner(
+    p_tournament_id uuid,
+    p_team1 text,
+    p_team2 text,
+    p_champion text
+)
+returns text
+language plpgsql
+stable
+set search_path = public
+as $$
+declare
+    s1 int; s2 int; r1 int; r2 int;
+begin
+    if p_team1 is null and p_team2 is null then return null; end if;
+    if p_team1 is null then return p_team2; end if;
+    if p_team2 is null then return p_team1; end if;
+
+    if p_team1 = p_champion then return p_team1; end if;
+    if p_team2 = p_champion then return p_team2; end if;
+
+    s1 := public._autofill_seed(p_tournament_id, p_team1);
+    s2 := public._autofill_seed(p_tournament_id, p_team2);
+    if s1 < s2 then return p_team1; end if;
+    if s2 < s1 then return p_team2; end if;
+
+    -- Equal group finish: break by FIFA ranking (lower number = better team),
+    -- then fall back to the slot-1 side when a ranking is missing or also tied.
+    select fifa_ranking into r1 from public.teams where id = p_team1;
+    select fifa_ranking into r2 from public.teams where id = p_team2;
+    if coalesce(r1, 2147483647) <= coalesce(r2, 2147483647) then
+        return p_team1;
+    else
+        return p_team2;
+    end if;
+end;
+$$;
+
+revoke all on function public._autofill_pick_winner(uuid, text, text, text) from public;
+
+-- ========== admin_autofill_phase2_brackets (re-emit from 0071, shared rule) ==========
+
+create or replace function public.admin_autofill_phase2_brackets(p_tournament_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_eligible int := 0;
+    v_touched int := 0;
+    v_filled int := 0;
+    v_default_goals int;
+    v_slot_count int;
+    v_assign_count int;
+    v_pred record;
+    v_match record;
+    v_winners jsonb;
+    v_champion text;
+    v_t1 text;
+    v_t2 text;
+    v_winner text;
+    v_pred_filled int;
+begin
+    if not public.is_super_admin() then
+        raise exception 'forbidden';
+    end if;
+    if not exists (select 1 from public.tournaments where id = p_tournament_id) then
+        raise exception 'tournament not found';
+    end if;
+    if public.tournament_phase(p_tournament_id) <> 'phase2_locked' then
+        raise exception 'tournament is not phase2_locked';
+    end if;
+
+    if (select count(*) from public.group_standings where tournament_id = p_tournament_id) <> 12 then
+        raise exception 'resolution data incomplete';
+    end if;
+    select
+        (select count(*) from public.knockout_matches
+            where stage = 'round_of_32' and team1_source like '3-%')
+      + (select count(*) from public.knockout_matches
+            where stage = 'round_of_32' and team2_source like '3-%')
+        into v_slot_count;
+    select count(*) into v_assign_count
+        from public.r32_bracket_assignments where tournament_id = p_tournament_id;
+    if v_assign_count < v_slot_count then
+        raise exception 'resolution data incomplete';
+    end if;
+
+    select percentile_cont(0.5) within group (order by p.total_goals)::int
+        into v_default_goals
+        from public.predictions p
+        where p.tournament_id = p_tournament_id
+          and p.total_goals is not null
+          and exists (
+              select 1 from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id and tp.paid_at <= t.lock_time
+          );
+    if v_default_goals is null then
+        v_default_goals := 12;
+    end if;
+
+    for v_pred in
+        select p.id, p.champion_team_id
+            from public.predictions p
+            where p.tournament_id = p_tournament_id
+              and p.champion_team_id is not null
+              and public.prediction_phase1_complete(p.id)
+              and exists (
+                  select 1 from public.tournament_payments tp
+                  join public.tournaments t on t.id = tp.tournament_id
+                  where tp.prediction_id = p.id and tp.paid_at <= t.lock_time
+              )
+              and (
+                  select count(*) from public.knockout_predictions kp
+                  where kp.prediction_id = p.id and kp.winner_team_id is not null
+              ) < (select count(*) from public.knockout_matches)
+    loop
+        v_eligible := v_eligible + 1;
+        v_champion := v_pred.champion_team_id;
+        v_pred_filled := 0;
+
+        select coalesce(jsonb_object_agg(kp.match_id, kp.winner_team_id), '{}'::jsonb)
+            into v_winners
+            from public.knockout_predictions kp
+            where kp.prediction_id = v_pred.id and kp.winner_team_id is not null;
+
+        for v_match in
+            select id, team1_source, team2_source
+                from public.knockout_matches
+                order by match_order
+        loop
+            if v_winners ? v_match.id then
+                continue;
+            end if;
+
+            v_t1 := public._autofill_resolve_source(p_tournament_id, v_match.team1_source, v_winners);
+            v_t2 := public._autofill_resolve_source(p_tournament_id, v_match.team2_source, v_winners);
+
+            v_winner := public._autofill_pick_winner(p_tournament_id, v_t1, v_t2, v_champion);
+            if v_winner is null then
+                continue;                                   -- both sides unresolvable
+            end if;
+
+            v_winners := jsonb_set(v_winners, array[v_match.id], to_jsonb(v_winner));
+
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+                values (v_pred.id, v_match.id, v_winner)
+                on conflict (prediction_id, match_id)
+                do update set winner_team_id = excluded.winner_team_id
+                where public.knockout_predictions.winner_team_id is null;
+
+            v_pred_filled := v_pred_filled + 1;
+            v_filled := v_filled + 1;
+        end loop;
+
+        if v_pred_filled > 0 then
+            v_touched := v_touched + 1;
+            update public.predictions
+                set total_goals = coalesce(total_goals, v_default_goals),
+                    updated_at = now()
+                where id = v_pred.id;
+        end if;
+    end loop;
+
+    return jsonb_build_object(
+        'predictions_eligible', v_eligible,
+        'predictions_touched', v_touched,
+        'matches_filled', v_filled
+    );
+end;
+$$;
+
+revoke all on function public.admin_autofill_phase2_brackets(uuid) from public;
+grant execute on function public.admin_autofill_phase2_brackets(uuid) to authenticated;
+
+-- ========== admin_autofill_locked_fixtures (re-emit from 0072, shared rule) ==========
+
+create or replace function public.admin_autofill_locked_fixtures(p_tournament_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_eligible int := 0;
+    v_touched int := 0;
+    v_filled int := 0;
+    v_phase text;
+    v_pred record;
+    v_match record;
+    v_winners jsonb;
+    v_champion text;
+    v_t1 text;
+    v_t2 text;
+    v_winner text;
+    v_pred_filled int;
+begin
+    if not public.is_super_admin() then
+        raise exception 'forbidden';
+    end if;
+    if not exists (select 1 from public.tournaments where id = p_tournament_id) then
+        raise exception 'tournament not found';
+    end if;
+    v_phase := public.tournament_phase(p_tournament_id);
+    if v_phase not in ('phase2_open', 'phase2_locked') then
+        raise exception 'knockout phase is not open';
+    end if;
+
+    if (select count(*) from public.group_standings where tournament_id = p_tournament_id) <> 12 then
+        raise exception 'resolution data incomplete';
+    end if;
+
+    if not exists (
+        select 1 from public.knockout_match_locks
+        where tournament_id = p_tournament_id and now() >= locked_at
+    ) then
+        return jsonb_build_object(
+            'predictions_eligible', 0, 'predictions_touched', 0, 'matches_filled', 0
+        );
+    end if;
+
+    for v_pred in
+        select p.id, p.champion_team_id
+            from public.predictions p
+            where p.tournament_id = p_tournament_id
+              and p.champion_team_id is not null
+              and public.prediction_phase1_complete(p.id)
+              and exists (
+                  select 1 from public.tournament_payments tp
+                  join public.tournaments t on t.id = tp.tournament_id
+                  where tp.prediction_id = p.id and tp.paid_at <= t.lock_time
+              )
+    loop
+        v_eligible := v_eligible + 1;
+        v_champion := v_pred.champion_team_id;
+        v_pred_filled := 0;
+
+        select coalesce(jsonb_object_agg(kp.match_id, kp.winner_team_id), '{}'::jsonb)
+            into v_winners
+            from public.knockout_predictions kp
+            where kp.prediction_id = v_pred.id and kp.winner_team_id is not null;
+
+        for v_match in
+            select id, team1_source, team2_source
+                from public.knockout_matches
+                order by match_order
+        loop
+            if v_winners ? v_match.id then
+                continue;
+            end if;
+            if not public.is_knockout_match_locked(p_tournament_id, v_match.id) then
+                continue;
+            end if;
+
+            v_t1 := public._autofill_resolve_source(p_tournament_id, v_match.team1_source, v_winners);
+            v_t2 := public._autofill_resolve_source(p_tournament_id, v_match.team2_source, v_winners);
+
+            v_winner := public._autofill_pick_winner(p_tournament_id, v_t1, v_t2, v_champion);
+            if v_winner is null then
+                continue;
+            end if;
+
+            v_winners := jsonb_set(v_winners, array[v_match.id], to_jsonb(v_winner));
+
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+                values (v_pred.id, v_match.id, v_winner)
+                on conflict (prediction_id, match_id)
+                do update set winner_team_id = excluded.winner_team_id
+                where public.knockout_predictions.winner_team_id is null;
+
+            v_pred_filled := v_pred_filled + 1;
+            v_filled := v_filled + 1;
+        end loop;
+
+        if v_pred_filled > 0 then
+            v_touched := v_touched + 1;
+        end if;
+    end loop;
+
+    return jsonb_build_object(
+        'predictions_eligible', v_eligible,
+        'predictions_touched', v_touched,
+        'matches_filled', v_filled
+    );
+end;
+$$;
+
+revoke all on function public.admin_autofill_locked_fixtures(uuid) from public;
+grant execute on function public.admin_autofill_locked_fixtures(uuid) to authenticated;


### PR DESCRIPTION
## Why

The group stage ends only hours before the first knockout match kicks off, with later R32 fixtures spread over the following days. The existing all-or-nothing Phase 2 window forced an impossible choice: lock the whole bracket at the first kickoff (a few hours to predict everything), or leave already-started matches editable. This adds **progressive per-fixture locking** — Phase 2 stays open late, but each fixture freezes at its own kickoff so no pick can change once a match starts.

## What

### Database (append-only migrations)
- **0072 — per-fixture lock:** `knockout_match_locks` table + `is_knockout_match_locked()` + `admin_set_knockout_match_lock()` (set a lock time / "lock now" / unlock). `submit_predictions` and `admin_submit_predictions` re-emitted to **preserve locked fixtures** (delete only unlocked rows, skip locked on insert) — honored uniformly, **including super-admin** (correct a locked pick via unlock → edit → re-lock). `admin_autofill_locked_fixtures()` fills blanks for kicked-off fixtures with the outcome-blind rule, never overwriting an existing pick.
- **0073 — open Phase 2 with partial data:** relaxes `admin_set_phase_two` so Phase 2 can open before all 8 R32 3rd-place slots are assigned (keeps the 12-group-standings guard). Unassigned slots render TBD until filled.
- **0074 — FIFA tiebreak:** `teams.fifa_ranking` column (all 48 populated; migration fails loudly if any team is unranked) + shared `_autofill_pick_winner()` helper. Both autofills now break equal-group-finish ties by FIFA ranking, with slot-1 only as the final fallback.

### Frontend
- `useTournamentLock` exposes `lockedMatchIds` + `getMatchLockInfo` (server-time aware, ticking).
- `KnockoutBracket` disables a locked fixture with a 🔒 **Locked** badge and shows a live **"Locks in …" countdown** for fixtures with a future lock; cascade treats locked picks as immovable.
- Admin: per-fixture lock control in `KnockoutResultsEditor`; **"Fill kicked-off fixtures"** button in `TournamentSettingsForm`; `/api/tournament` now returns `knockoutLocks`.
- Extracted `formatRemaining` into a shared util (reused by `LockStatusBanner`).

## Security
- Regular users have **no** direct RLS write path to `knockout_predictions` during Phase 2 (`is_before_lock` = false), so the SECURITY DEFINER RPC is their only path and it enforces the lock. Verified empirically: direct UPDATE/DELETE → 0 rows, INSERT → RLS violation; users also cannot write `knockout_match_locks` (no unlock, no forge).
- Admins retain a trusted-tier `is_admin()` RLS write on `knockout_predictions` (no app code uses it). Flagged in review as optional defense-in-depth.

## Testing
- `npm test` (580 passing, incl. new: cascade immovability, lock-route status codes, locked-badge/countdown rendering), `typecheck`, `lint` all clean.
- Migrations applied locally; functional checks (rolled back where appropriate) for lock preservation, autofill guards, the relaxed Phase 2 guard, and the FIFA tiebreak helper.

## Notes
- FIFA rankings are now duplicated (`teams.fifa_ranking` + `fifaRankings.ts`); cross-referenced comments added — refresh both together.
- Operational: run **"Fill kicked-off fixtures"** shortly after each kickoff so users who left a now-locked fixture blank keep a complete downstream bracket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
