### PR TITLE
fix(knockout): grant SELECT on knockout_match_locks (prod 500 hotfix) + v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-06-28
+
+### Fixed
+
+- **Production 500 on `/api/tournament`.** Migration 0072 created the
+  `knockout_match_locks` table with RLS but never granted table-level `SELECT` to the API roles.
+  Local default privileges masked the omission, but on the hosted project the public `anon` role
+  hit `permission denied for table knockout_match_locks`, 500-ing every tournament read. Adds the
+  explicit `grant select … to anon, authenticated` per the project's read-all-table convention. (#244)
+
 ## [1.8.0] - 2026-06-28
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/supabase/migrations/0075_grant_knockout_match_locks.sql
+++ b/supabase/migrations/0075_grant_knockout_match_locks.sql
@@ -1,0 +1,15 @@
+-- 0075_grant_knockout_match_locks.sql
+--
+-- Hotfix for a production 500 on GET /api/tournament:
+--   {"error":"permission denied for table knockout_match_locks"}
+--
+-- Migration 0072 created public.knockout_match_locks with RLS + a select-all
+-- policy but never granted table-level SELECT to the API roles. Local default
+-- privileges auto-granted it (so it worked locally), but on the remote project
+-- the anon role had no privilege and every public /api/tournament read failed.
+-- The project convention is an explicit grant per read-all table (e.g.
+-- r32_bracket_assignments); this restores that. The lock times are non-sensitive
+-- (select-all policy), so anon + authenticated both get SELECT; writes still go
+-- only through the admin SECURITY DEFINER RPC.
+
+grant select on public.knockout_match_locks to anon, authenticated;


### PR DESCRIPTION
## Incident

Production `GET /api/tournament` returned **500** for all visitors:
`{"error":"permission denied for table knockout_match_locks"}`.

## Cause

Migration `0072` created `public.knockout_match_locks` with RLS + a select-all policy but never granted **table-level** `SELECT` to the API roles. The local Supabase stack auto-grants new tables to `anon`/`authenticated` via default privileges, so it worked locally; the hosted project does not, so the public `anon` role was denied and every tournament read 500'd.

## Fix

`grant select on public.knockout_match_locks to anon, authenticated;` (migration `0075`) — matching the project's explicit per-read-all-table grant convention. Writes still go only through the `is_admin()`-gated SECURITY DEFINER RPC.

## Status

- **Already hotfixed on the remote DB** (`supabase db push`) — prod `/api/tournament` now returns **200** with `knockoutLocks` reading correctly. This PR lands the migration in git and cuts **v1.8.1** (PATCH — `### Fixed` only).
- Local + remote migrations in sync (0075 applied to both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
