### PR TITLE
feat(admin): Reset Phase 2 — revert a tournament to its locked Phase 1 state

### DIFF
--- a/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
+++ b/frontend/src/app/admin/tournament/TournamentSettingsForm.tsx
@@ -105,6 +105,7 @@ export function TournamentSettingsForm() {
   const [savingPhase1, setSavingPhase1] = React.useState(false);
   const [snapshotting, setSnapshotting] = React.useState(false);
   const [busyPhase2, setBusyPhase2] = React.useState(false);
+  const [resetPhaseTwoOpen, setResetPhaseTwoOpen] = React.useState(false);
   const [resetDialogOpen, setResetDialogOpen] = React.useState(false);
   const [resetConfirm, setResetConfirm] = React.useState('');
   const [resetting, setResetting] = React.useState(false);
@@ -305,6 +306,34 @@ export function TournamentSettingsForm() {
       ]);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed');
+    } finally {
+      setBusyPhase2(false);
+    }
+  };
+
+  // Reset Phase 2: revert to the locked Phase 1 state. Clears knockout_unlocked +
+  // knockout_lock_time + per-fixture locks; preserves knockout predictions.
+  const handleResetPhaseTwo = async () => {
+    if (!tournament.data) return;
+    setBusyPhase2(true);
+    try {
+      const res = await fetch('/api/admin/tournament/reset-phase-two', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: tournament.data.id }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? 'Failed to reset Phase 2');
+      toast.success('Phase 2 reset — tournament is back in the locked Phase 1 state');
+      setResetPhaseTwoOpen(false);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['tournament'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-advancers'] }),
+        queryClient.invalidateQueries({ queryKey: ['admin-stats'] }),
+        queryClient.invalidateQueries({ queryKey: ['knockout-locks', tournament.data.id] }),
+      ]);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to reset Phase 2');
     } finally {
       setBusyPhase2(false);
     }
@@ -657,6 +686,16 @@ export function TournamentSettingsForm() {
               >
                 Close Phase 2
               </Button>
+              {isSuperAdmin && (phase === 'phase2_open' || phase === 'phase2_locked') && (
+                <Button
+                  variant="destructive"
+                  onClick={() => setResetPhaseTwoOpen(true)}
+                  disabled={busyPhase2}
+                  title="Revert to the locked Phase 1 state (keeps knockout picks)"
+                >
+                  Reset Phase 2
+                </Button>
+              )}
             </div>
           </CardContent>
         </Card>
@@ -851,6 +890,39 @@ export function TournamentSettingsForm() {
             </Button>
             <Button onClick={handleAutofill} disabled={autofilling}>
               {autofilling ? 'Filling…' : 'Auto-fill brackets'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={resetPhaseTwoOpen} onOpenChange={setResetPhaseTwoOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reset Phase 2</DialogTitle>
+            <DialogDescription>
+              Revert <span className="font-mono">{tournament.data?.name}</span> to its locked
+              Phase 1 state.
+            </DialogDescription>
+          </DialogHeader>
+          <ul className="text-muted-foreground list-disc space-y-1 pl-5 text-sm">
+            <li>Phase 2 closes — the tournament returns to the locked Phase 1 state.</li>
+            <li>The Phase 2 lock time is cleared (back to unset).</li>
+            <li>All per-fixture knockout locks are removed.</li>
+            <li>
+              <span className="font-medium">Knockout predictions are kept</span> — they reappear if
+              you re-open Phase 2.
+            </li>
+          </ul>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setResetPhaseTwoOpen(false)}
+              disabled={busyPhase2}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleResetPhaseTwo} disabled={busyPhase2}>
+              {busyPhase2 ? 'Resetting…' : 'Reset Phase 2'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/app/api/admin/tournament/reset-phase-two/__tests__/route.test.ts
+++ b/frontend/src/app/api/admin/tournament/reset-phase-two/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+const supabaseMock = {
+  auth: { getUser: jest.fn() },
+  from: jest.fn(),
+  rpc: jest.fn(),
+};
+
+jest.mock('@/lib/supabase/server', () => ({
+  getServerSupabase: async () => supabaseMock,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('../route');
+
+function postReq(body: unknown) {
+  return new NextRequest('http://localhost:3000/api/admin/tournament/reset-phase-two', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockAdminProfile(isAdmin: boolean) {
+  supabaseMock.from.mockImplementation(() => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: async () => ({ data: { is_admin: isAdmin } }) }),
+    }),
+  }));
+}
+
+describe('POST /api/admin/tournament/reset-phase-two', () => {
+  beforeEach(() => {
+    supabaseMock.auth.getUser.mockReset();
+    supabaseMock.from.mockReset();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when caller is not admin', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(false);
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    const res = await POST(postReq({}));
+    expect(res.status).toBe(400);
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when RPC raises forbidden (non-super-admin)', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: { message: 'forbidden' } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when RPC raises tournament not found', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: { message: 'tournament not found' } });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 200 and forwards the rpc arg on success', async () => {
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockAdminProfile(true);
+    supabaseMock.rpc.mockResolvedValue({ data: null, error: null });
+    const res = await POST(postReq({ id: 't1' }));
+    expect(res.status).toBe(200);
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('admin_reset_phase_two', {
+      p_tournament_id: 't1',
+    });
+  });
+});

--- a/frontend/src/app/api/admin/tournament/reset-phase-two/route.ts
+++ b/frontend/src/app/api/admin/tournament/reset-phase-two/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin, isAdminGateError } from '@/lib/auth/requireAdmin';
+import { safeMessage } from '@/lib/api/errors';
+
+interface Body {
+  id?: string;
+}
+
+/**
+ * Reset Phase 2: revert a tournament to its locked Phase 1 state. Super-admin-gated;
+ * calls admin_reset_phase_two (migration 0076), which clears knockout_unlocked +
+ * knockout_lock_time and deletes the tournament's per-fixture locks, while preserving
+ * all knockout predictions (re-opening Phase 2 restores them).
+ */
+export async function POST(request: NextRequest) {
+  const ctx = await requireAdmin();
+  if (isAdminGateError(ctx)) return ctx.response;
+
+  const body = (await request.json()) as Body;
+  if (!body.id) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 });
+  }
+
+  const { error } = await ctx.supabase.rpc('admin_reset_phase_two', {
+    p_tournament_id: body.id,
+  });
+
+  if (error) {
+    const msg = (error.message ?? '').toLowerCase();
+    const status = msg.includes('forbidden') ? 403 : msg.includes('not found') ? 404 : 400;
+    return NextResponse.json({ error: safeMessage(error) }, { status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/supabase/migrations/0076_admin_reset_phase_two.sql
+++ b/supabase/migrations/0076_admin_reset_phase_two.sql
@@ -1,0 +1,43 @@
+-- 0076_admin_reset_phase_two.sql
+--
+-- "Reset Phase 2" — revert a tournament to its locked Phase 1 state.
+--
+-- admin_set_phase_two's "close" path (knockout_unlocked = false) reverts the
+-- phase to phase1_locked but deliberately PRESERVES knockout_lock_time, so the
+-- Phase 2 lock time is left stale and per-fixture locks (knockout_match_locks,
+-- 0072) linger and would silently re-apply on a future reopen. This RPC is the
+-- clean-slate revert: it clears the Phase 2 config entirely and the per-fixture
+-- locks, but PRESERVES users' knockout_predictions (re-opening Phase 2 restores
+-- the picks untouched), so the action is fully reversible.
+--
+-- Super-admin gated (a tournament-wide phase revert is weighty); the lighter,
+-- time-preserving "Close Phase 2" (admin_set_phase_two, is_admin) stays as-is.
+
+create or replace function public.admin_reset_phase_two(p_tournament_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if not public.is_super_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if not exists (select 1 from public.tournaments where id = p_tournament_id) then
+        raise exception 'tournament not found' using errcode = 'P0001';
+    end if;
+
+    update public.tournaments
+       set knockout_unlocked = false,
+           knockout_lock_time = null
+     where id = p_tournament_id;
+
+    -- Per-fixture locks are a Phase-2 artifact; clear them so any future reopen
+    -- starts clean. (They're inert in phase1_locked anyway.) knockout_predictions
+    -- are intentionally left intact — this revert is reversible.
+    delete from public.knockout_match_locks where tournament_id = p_tournament_id;
+end;
+$$;
+
+revoke all on function public.admin_reset_phase_two(uuid) from public;
+grant execute on function public.admin_reset_phase_two(uuid) to authenticated;


### PR DESCRIPTION
## Why

An admin can open Phase 2, but there's no clean way to back it out. "Close Phase 2" reverts the phase (`knockout_unlocked = false`) yet `admin_set_phase_two` deliberately **preserves** `knockout_lock_time` on close (`case when p_unlocked then p_lock_time else knockout_lock_time end`), so the Phase 2 time is left stale and per-fixture locks (`knockout_match_locks`) linger and would silently re-apply on a future reopen.

## What

A super-admin **"Reset Phase 2"** that fully reverts a tournament to its locked Phase 1 state.

- **`0076` — `admin_reset_phase_two(p_tournament_id)`** (super-admin gated, SECURITY DEFINER): sets `knockout_unlocked = false`, **clears** `knockout_lock_time`, and deletes the tournament's `knockout_match_locks`. **Preserves** `knockout_predictions` — re-opening Phase 2 restores the picks untouched, so the action is fully reversible. The lighter, time-preserving "Close Phase 2" (is-admin) stays as-is.
- **`POST /api/admin/tournament/reset-phase-two`** — `requireAdmin` → RPC → error translation (403/404/400). Mirrors the `autofill-brackets` route.
- **Frontend** — a super-admin-only red **"Reset Phase 2"** button in the Phase 2 admin card (shown only when Phase 2 is open/locked) behind a confirmation dialog that spells out exactly what's cleared vs kept.

## Result

With `knockout_unlocked = false` and `lock_time` already past, `tournament_phase()` returns `phase1_locked`; the Phase 2 lock-time input reads as unset and "Open Phase 2" is available again.

## Testing

- `npm test` (586 passing, incl. new 6-case route test), `typecheck`, `lint` — all clean.
- Local DB functional check (rolled back): revert → `phase1_locked`, `knockout_lock_time` null, per-fixture locks = 0, `knockout_predictions` unchanged (7→7); non-super-admin → `forbidden`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
