### PR TITLE
chore(release): v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-06-28
+
+### Added
+
+- **Reset Phase 2.** A super-admin "Reset Phase 2" control reverts a tournament to its locked
+  Phase 1 state — closing Phase 2, clearing the Phase 2 lock time, and removing all per-fixture
+  knockout locks — while **preserving** everyone's knockout predictions (they reappear if Phase 2 is
+  re-opened). Backed by a new `admin_reset_phase_two` RPC behind a confirmation dialog. (#245)
+
 ## [1.8.1] - 2026-06-28
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Release v1.9.0 (MINOR — ships a feature).

### Added
- **Reset Phase 2** (#245) — super-admin control to revert a tournament to its locked Phase 1 state (clears the Phase 2 lock time + per-fixture locks, preserves knockout predictions), via a new `admin_reset_phase_two` RPC.

Version bumped `1.8.1 → 1.9.0`; CHANGELOG updated. Migration `0076` is pushed to the remote DB as part of this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
