### PR TITLE
fix(phase1-winners): grant SELECT on phase1_winners (prod read-denied hotfix) + v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2026-06-28
+
+### Fixed
+
+- **Phase 1 winners card showed nothing after a snapshot.** Migration 0070 created the
+  `phase1_winners` table with a select-all policy but never granted table-level `SELECT` to the API
+  roles. Local default privileges masked it, but on the hosted project the read 500'd, so the Phase 1
+  group-stage top 3 never appeared even after a successful admin snapshot (the snapshot writes via a
+  SECURITY DEFINER RPC, so the data was already there — only the read was blocked). Adds the explicit
+  `grant select … to anon, authenticated`. (#247)
+
 ## [1.9.0] - 2026-06-28
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/supabase/migrations/0077_grant_phase1_winners.sql
+++ b/supabase/migrations/0077_grant_phase1_winners.sql
@@ -1,0 +1,14 @@
+-- 0077_grant_phase1_winners.sql
+--
+-- Hotfix (same class as 0075): migration 0070 created public.phase1_winners with
+-- a select-all RLS policy but never granted table-level SELECT to the API roles.
+-- Local default privileges auto-grant it, so it worked locally; on the remote
+-- project the anon/authenticated roles get "permission denied for table
+-- phase1_winners", so GET /api/leaderboard/phase1-winners 500s and the Phase 1
+-- winners card shows nothing even after a successful admin snapshot (the snapshot
+-- RPC is SECURITY DEFINER, so it writes fine — only the read is blocked).
+--
+-- The data is non-sensitive (usernames + points, top 3), already exposed by the
+-- phase1_winners_select_all policy. Grant matches the read-all-table convention.
+
+grant select on public.phase1_winners to anon, authenticated;


### PR DESCRIPTION
## Incident

After an admin snapshot, the **Phase 1 winners card showed nothing** in production — the group-stage top 3 never appeared.

## Cause

Migration `0070` created `public.phase1_winners` with a select-all RLS policy but never granted **table-level** `SELECT` to the API roles. Local default privileges auto-grant new tables, so it worked locally; the hosted project does not, so `GET /api/leaderboard/phase1-winners` hit `permission denied for table phase1_winners` and 500'd. The snapshot itself wrote fine (SECURITY DEFINER RPC) — only the read was blocked, so the data was there but invisible.

This is the same class as the `knockout_match_locks` fix (v1.8.1). An audit of all directly-read tables confirms `phase1_winners` was the only remaining sibling.

## Fix

`grant select on public.phase1_winners to anon, authenticated;` (migration `0077`).

## Status

- **Already hotfixed on the remote DB** — prod `/api/leaderboard/phase1-winners` now returns 200 with the top 3; the existing snapshot is visible immediately (no re-snapshot needed). This PR lands the migration in git and cuts **v1.9.1** (PATCH — `### Fixed` only). Local + remote migrations in sync (0077 on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
