### PR TITLE
feat(predictions): reveal others' Phase 1 in preview during Phase 2, seal knockout until lock

### DIFF
--- a/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
+++ b/frontend/src/app/leaderboard/LeaderboardPageContent.tsx
@@ -84,15 +84,17 @@ export function LeaderboardPageContent() {
 
   const currentUsername = profile?.username ?? null;
   // Staff (admin or super-admin — the latter doesn't imply the former) can
-  // always preview every bracket. Everyone else can preview others' entries in
-  // two windows where picks are frozen: while the Group Stage is locked
-  // (`phase1_locked`) and once the knockout bracket locks (`phase2_locked`).
-  // It stays restricted while picks are still editable (`phase1` group picks,
-  // `phase2_open` knockout picks) so a player can't copy a rival's in-progress
-  // picks. Fails closed while the tournament query is loading (phase defaults
-  // to phase1 → restricted).
+  // always preview every bracket. Everyone else can preview others' entries once
+  // the Group Stage is locked — `phase1_locked`, `phase2_open`, and
+  // `phase2_locked`. During `phase2_open` the knockout bracket + tiebreaker are
+  // redacted server-side (get_public_prediction, migration 0078) so only the
+  // frozen Phase 1 picks are revealed; the full bracket unlocks at
+  // `phase2_locked`. It stays restricted only while group picks are still
+  // editable (`phase1`), so a player can't copy a rival's in-progress group
+  // picks. Fails closed while the tournament query is loading (phase defaults to
+  // phase1 → restricted).
   const isStaff = !!profile?.isAdmin || !!profile?.isSuperAdmin;
-  const previewOthersLocked = !(phase === 'phase1_locked' || phase === 'phase2_locked');
+  const previewOthersLocked = phase === 'phase1';
   const canPreviewOthers = isStaff || !previewOthersLocked;
   // The leaderboard response shape depends on the viewer's identity:
   // admins get an extra `email` field, anon/auth users don't. Bake the
@@ -261,20 +263,9 @@ export function LeaderboardPageContent() {
         <div className="border-muted-foreground/20 bg-muted/40 text-muted-foreground mb-6 flex items-start gap-2 rounded-md border px-4 py-3 text-sm">
           <Lock className="mt-0.5 h-4 w-4 shrink-0" />
           <p>
-            <span className="text-foreground font-medium">Heads up —</span>{' '}
-            {phase === 'phase2_open' ? (
-              <>
-                brackets are private again while knockout picks are being made. Everyone&apos;s
-                full bracket reopens for viewing once the knockout bracket locks. This keeps picks
-                private while they can still be edited.
-              </>
-            ) : (
-              <>
-                you can preview only your own brackets for now. Other players&apos; group-stage
-                picks open for viewing once the group stage locks. This keeps picks private while
-                they can still be edited.
-              </>
-            )}
+            <span className="text-foreground font-medium">Heads up —</span> you can preview only
+            your own brackets for now. Other players&apos; group-stage picks open for viewing once
+            the group stage locks. This keeps picks private while they can still be edited.
           </p>
         </div>
       )}

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -203,8 +203,8 @@ export function LeaderboardTable({
                             size="sm"
                             disabled
                             className="cursor-not-allowed opacity-50"
-                            aria-label={`Previewing ${entry.predictionName}'s bracket unlocks when the knockout bracket locks`}
-                            title="Previewing other players' brackets unlocks when the knockout bracket locks"
+                            aria-label={`Previewing ${entry.predictionName}'s bracket unlocks once the group stage locks`}
+                            title="Previewing other players' brackets unlocks once the group stage locks"
                           >
                             <Eye className="mr-1.5 h-4 w-4" />
                             Preview

--- a/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
+++ b/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
@@ -152,7 +152,7 @@ describe('LeaderboardTable', () => {
     expect(ownPreview).toBeEnabled();
     // Other players' Preview buttons are still rendered but disabled.
     const lockedPreviews = screen.getAllByRole('button', {
-      name: /unlocks when the knockout bracket locks$/,
+      name: /unlocks once the group stage locks$/,
     });
     expect(lockedPreviews).toHaveLength(2);
     lockedPreviews.forEach((btn) => expect(btn).toBeDisabled());
@@ -173,7 +173,7 @@ describe('LeaderboardTable', () => {
     expect(previews).toHaveLength(3);
     previews.forEach((btn) => expect(btn).toBeEnabled());
     expect(
-      screen.queryByRole('button', { name: /unlocks when the knockout bracket locks$/ })
+      screen.queryByRole('button', { name: /unlocks once the group stage locks$/ })
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -17,6 +17,8 @@ import { BracketView } from '@/components/predictions/BracketView';
 import { GroupStandingsResults } from '@/components/results/GroupStandingsResults';
 import { AdvancersResults } from '@/components/results/AdvancersResults';
 import { TeamFlag } from '@/components/shared/TeamFlag';
+import { useTournamentLock } from '@/hooks/useTournamentLock';
+import { useAuthContext } from '@/providers/AuthProvider';
 import { fetchJSON } from '@/lib/api/fetchJSON';
 import { isPhase1StagesComplete } from '@/lib/predictions/paymentStatus';
 import type {
@@ -60,6 +62,15 @@ export function BracketPreviewDialog({
   onOpenChange,
 }: BracketPreviewDialogProps) {
   const open = predictionId !== null;
+
+  // Knockout picks stay sealed in the preview until Phase 2 locks, so a bracket
+  // can't be read off another entry before the knockout deadline. Admins /
+  // super-admins bypass (consistent with the server-side preview gate in
+  // migration 0057) so they can still moderate.
+  const { phase } = useTournamentLock();
+  const { profile } = useAuthContext();
+  const revealKnockout =
+    phase === 'phase2_locked' || !!profile?.isAdmin || !!profile?.isSuperAdmin;
 
   const predictionQuery = useQuery<PredictionDetail>({
     queryKey: ['prediction', apiBasePath, predictionId],
@@ -176,7 +187,9 @@ export function BracketPreviewDialog({
             <PredictionMetaBar
               username={predictionQuery.data!.username}
               championTeamId={predictionQuery.data!.championTeamId}
-              bracketChampionTeamId={bracketChampionTeamId}
+              // The bracket champion is the user's Final (M104) pick — a knockout
+              // selection — so it stays sealed alongside the bracket until lock.
+              bracketChampionTeamId={revealKnockout ? bracketChampionTeamId : null}
               totalGoals={predictionQuery.data!.totalGoals}
               teams={teamsQuery.data!}
             />
@@ -204,22 +217,31 @@ export function BracketPreviewDialog({
             </PreviewSection>
 
             <PreviewSection title="Phase 2 — Knockout Bracket">
-              <BracketView
-                matches={matchesQuery.data!}
-                teams={teamsQuery.data!}
-                // The preview resolves the bracket strictly from the admin's
-                // standings (Phase 2). The user's Phase-1 group picks are shown
-                // in the section above, so we deliberately omit them here —
-                // group slots render as TBD until standings are posted rather
-                // than as a what-if shape derived from those picks.
-                groupPredictions={[]}
-                knockoutPredictions={(predictionQuery.data!.knockout ?? []).map((k) => ({
-                  matchId: k.matchId,
-                  winnerId: k.winner,
-                }))}
-                bracketAssignments={bracketAssignments}
-                groupStandings={standingsQuery.data?.standings ?? []}
-              />
+              {revealKnockout ? (
+                <BracketView
+                  matches={matchesQuery.data!}
+                  teams={teamsQuery.data!}
+                  // The preview resolves the bracket strictly from the admin's
+                  // standings (Phase 2). The user's Phase-1 group picks are shown
+                  // in the section above, so we deliberately omit them here —
+                  // group slots render as TBD until standings are posted rather
+                  // than as a what-if shape derived from those picks.
+                  groupPredictions={[]}
+                  knockoutPredictions={(predictionQuery.data!.knockout ?? []).map((k) => ({
+                    matchId: k.matchId,
+                    winnerId: k.winner,
+                  }))}
+                  bracketAssignments={bracketAssignments}
+                  groupStandings={standingsQuery.data?.standings ?? []}
+                />
+              ) : (
+                <div
+                  className="bg-muted/40 text-muted-foreground flex items-center justify-center rounded-md border border-dashed px-4 py-10 text-center text-sm"
+                  role="status"
+                >
+                  Predictions will be revealed when Phase 2 is locked.
+                </div>
+              )}
             </PreviewSection>
           </>
         )}

--- a/frontend/src/components/predictions/BracketPreviewDialog.tsx
+++ b/frontend/src/components/predictions/BracketPreviewDialog.tsx
@@ -63,14 +63,8 @@ export function BracketPreviewDialog({
 }: BracketPreviewDialogProps) {
   const open = predictionId !== null;
 
-  // Knockout picks stay sealed in the preview until Phase 2 locks, so a bracket
-  // can't be read off another entry before the knockout deadline. Admins /
-  // super-admins bypass (consistent with the server-side preview gate in
-  // migration 0057) so they can still moderate.
   const { phase } = useTournamentLock();
   const { profile } = useAuthContext();
-  const revealKnockout =
-    phase === 'phase2_locked' || !!profile?.isAdmin || !!profile?.isSuperAdmin;
 
   const predictionQuery = useQuery<PredictionDetail>({
     queryKey: ['prediction', apiBasePath, predictionId],
@@ -128,6 +122,16 @@ export function BracketPreviewDialog({
     finalMatch && predictionQuery.data
       ? (predictionQuery.data.knockout.find((k) => k.matchId === finalMatch.id)?.winner ?? null)
       : null;
+
+  // Knockout picks are sealed in the preview UNLESS the entry is the viewer's own
+  // (you can always see your own picks), the viewer is an admin/super-admin, or
+  // Phase 2 has locked (everyone's picks frozen). For another member's entry
+  // before lock the leaderboard RPC also redacts the knockout server-side — this
+  // shows the "revealed when Phase 2 is locked" message instead of an empty bracket.
+  const isOwn =
+    !!profile?.username && predictionQuery.data?.username === profile.username;
+  const revealKnockout =
+    !!profile?.isAdmin || !!profile?.isSuperAdmin || isOwn || phase === 'phase2_locked';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/src/components/predictions/__tests__/BracketPreviewDialog.test.tsx
+++ b/frontend/src/components/predictions/__tests__/BracketPreviewDialog.test.tsx
@@ -65,16 +65,29 @@ describe('BracketPreviewDialog — knockout seal until Phase 2 locks', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetch();
-    useAuthContext.mockReturnValue({ profile: { isAdmin: false, isSuperAdmin: false } });
+    // Default viewer is a different member (bob) than the entry owner (alice).
+    useAuthContext.mockReturnValue({
+      profile: { username: 'bob', isAdmin: false, isSuperAdmin: false },
+    });
   });
 
-  it('seals the knockout bracket with a reveal message before Phase 2 locks', async () => {
+  it("seals another member's knockout with a reveal message before Phase 2 locks", async () => {
     useTournamentLock.mockReturnValue({ phase: 'phase2_open' });
     renderDialog();
     expect(await screen.findByText(MSG)).toBeInTheDocument();
   });
 
-  it('reveals the knockout bracket once Phase 2 is locked', async () => {
+  it('always shows the knockout for the entry owner, even during phase2_open', async () => {
+    useTournamentLock.mockReturnValue({ phase: 'phase2_open' });
+    useAuthContext.mockReturnValue({
+      profile: { username: 'alice', isAdmin: false, isSuperAdmin: false },
+    });
+    renderDialog();
+    expect(await screen.findByText(SECTION)).toBeInTheDocument();
+    expect(screen.queryByText(MSG)).not.toBeInTheDocument();
+  });
+
+  it('reveals the knockout to everyone once Phase 2 is locked', async () => {
     useTournamentLock.mockReturnValue({ phase: 'phase2_locked' });
     renderDialog();
     // Wait until the dialog has loaded (the section title only renders when ready).
@@ -84,7 +97,9 @@ describe('BracketPreviewDialog — knockout seal until Phase 2 locks', () => {
 
   it('bypasses the seal for admins', async () => {
     useTournamentLock.mockReturnValue({ phase: 'phase2_open' });
-    useAuthContext.mockReturnValue({ profile: { isAdmin: true, isSuperAdmin: false } });
+    useAuthContext.mockReturnValue({
+      profile: { username: 'bob', isAdmin: true, isSuperAdmin: false },
+    });
     renderDialog();
     expect(await screen.findByText(SECTION)).toBeInTheDocument();
     expect(screen.queryByText(MSG)).not.toBeInTheDocument();

--- a/frontend/src/components/predictions/__tests__/BracketPreviewDialog.test.tsx
+++ b/frontend/src/components/predictions/__tests__/BracketPreviewDialog.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
+
+import { BracketPreviewDialog } from '../BracketPreviewDialog';
+import { fixtureKnockoutMatches, fixtureTeams } from '@/test-utils/fixtures';
+
+jest.mock('@/lib/api/fetchJSON', () => ({ fetchJSON: jest.fn() }));
+jest.mock('@/hooks/useTournamentLock', () => ({ useTournamentLock: jest.fn() }));
+jest.mock('@/providers/AuthProvider', () => ({ useAuthContext: jest.fn() }));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { fetchJSON } = require('@/lib/api/fetchJSON');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { useTournamentLock } = require('@/hooks/useTournamentLock');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { useAuthContext } = require('@/providers/AuthProvider');
+
+const prediction = {
+  id: 'p1',
+  name: 'Main',
+  username: 'alice',
+  totalGoals: 5,
+  championTeamId: null,
+  submittedAt: null,
+  isPaid: true,
+  paidAt: null,
+  groups: [],
+  knockout: [{ matchId: 'M73', winner: 'mex' }],
+  advancers: [],
+};
+
+function mockFetch() {
+  fetchJSON.mockImplementation((url: string) => {
+    if (url === '/api/knockout-matches') return Promise.resolve(fixtureKnockoutMatches);
+    if (url === '/api/teams') return Promise.resolve(fixtureTeams);
+    if (url === '/api/groups') return Promise.resolve([]);
+    if (url === '/api/r32-bracket') return Promise.resolve({ assignments: [] });
+    if (url === '/api/group-standings') return Promise.resolve({ standings: [] });
+    return Promise.resolve(prediction); // the prediction-detail fetch
+  });
+}
+
+function wrap(node: React.ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{node}</QueryClientProvider>;
+}
+
+function renderDialog() {
+  render(
+    wrap(
+      <BracketPreviewDialog
+        predictionId="p1"
+        apiBasePath="/api/predictions"
+        onOpenChange={() => {}}
+      />
+    )
+  );
+}
+
+const MSG = /Predictions will be revealed when Phase 2 is locked/i;
+const SECTION = 'Phase 2 — Knockout Bracket';
+
+describe('BracketPreviewDialog — knockout seal until Phase 2 locks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch();
+    useAuthContext.mockReturnValue({ profile: { isAdmin: false, isSuperAdmin: false } });
+  });
+
+  it('seals the knockout bracket with a reveal message before Phase 2 locks', async () => {
+    useTournamentLock.mockReturnValue({ phase: 'phase2_open' });
+    renderDialog();
+    expect(await screen.findByText(MSG)).toBeInTheDocument();
+  });
+
+  it('reveals the knockout bracket once Phase 2 is locked', async () => {
+    useTournamentLock.mockReturnValue({ phase: 'phase2_locked' });
+    renderDialog();
+    // Wait until the dialog has loaded (the section title only renders when ready).
+    expect(await screen.findByText(SECTION)).toBeInTheDocument();
+    expect(screen.queryByText(MSG)).not.toBeInTheDocument();
+  });
+
+  it('bypasses the seal for admins', async () => {
+    useTournamentLock.mockReturnValue({ phase: 'phase2_open' });
+    useAuthContext.mockReturnValue({ profile: { isAdmin: true, isSuperAdmin: false } });
+    renderDialog();
+    expect(await screen.findByText(SECTION)).toBeInTheDocument();
+    expect(screen.queryByText(MSG)).not.toBeInTheDocument();
+  });
+});

--- a/supabase/migrations/0078_preview_phase1_during_phase2_open.sql
+++ b/supabase/migrations/0078_preview_phase1_during_phase2_open.sql
@@ -1,0 +1,109 @@
+-- 0078_preview_phase1_during_phase2_open.sql
+--
+-- Let other members preview an entry's Phase 1 (group-stage + best-3rd) picks
+-- during phase2_open, while keeping its still-editable Phase 2 picks (knockout
+-- bracket + tiebreaker total_goals) sealed until the knockout bracket locks.
+--
+-- 0058 blocked other members' previews ENTIRELY during phase2_open to avoid
+-- leaking editable knockout picks. But the group-stage picks are already frozen
+-- (phase1_locked precedes phase2_open), so they are safe to reveal. This re-emits
+-- 0058's get_public_prediction with two changes:
+--   1. the eligibility window adds 'phase2_open', so other members' rows are
+--      returned (previously a 404); and
+--   2. field-level redaction — total_goals and the knockout array are withheld
+--      (null / '[]') from non-owner, non-admin viewers until 'phase2_locked'.
+--      The Phase 1 fields (groups, advancers, champion_team_id) are frozen by
+--      phase1_locked, so they are always returned to an eligible viewer.
+--
+-- The owner and admins/super-admins always see everything (the `see_phase2`
+-- predicate), at every phase. Otherwise verbatim re-emit of the 0058 body.
+
+create or replace function public.get_public_prediction(p_prediction_id uuid)
+returns table (
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    total_goals int,
+    champion_team_id text,
+    submitted_at timestamptz,
+    groups jsonb,
+    knockout jsonb,
+    advancers jsonb
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with elig as (
+        select p.id, p.user_id, p.tournament_id, p.prediction_name, p.total_goals,
+               p.champion_team_id, p.submitted_at,
+               -- Phase 2 picks (knockout + tiebreaker) are revealed only to the
+               -- owner, admins, or once everything is frozen at phase2_locked.
+               (p.user_id = auth.uid()
+                or public.is_admin()
+                or public.is_super_admin()
+                or public.tournament_phase(p.tournament_id) = 'phase2_locked') as see_phase2
+        from public.predictions p
+        join public.tournament_payments tp on tp.prediction_id = p.id
+        join public.tournaments t on t.id = p.tournament_id
+        where p.id = p_prediction_id
+          and auth.uid() is not null
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and tp.paid_at <= t.lock_time
+          and (
+              p.user_id = auth.uid()
+              or public.is_admin()
+              or public.is_super_admin()
+              -- Phase 1 picks are frozen by phase1_locked, so other members may
+              -- preview from phase1_locked onward — including phase2_open, where
+              -- the Phase 2 fields below are redacted. Still excludes 'phase1'
+              -- (group picks editable).
+              or public.tournament_phase(p.tournament_id) in ('phase1_locked', 'phase2_open', 'phase2_locked')
+          )
+    )
+    select
+        e.id as prediction_id,
+        e.prediction_name::text,
+        pr.username::text as username,
+        case when e.see_phase2 then e.total_goals else null end as total_goals,
+        e.champion_team_id,
+        e.submitted_at,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'group_id', gp.group_id,
+                'first_team_id', gp.first_team_id,
+                'second_team_id', gp.second_team_id,
+                'third_team_id', gp.third_team_id,
+                'fourth_team_id', gp.fourth_team_id
+            ) order by gp.group_id)
+            from public.group_predictions gp
+            where gp.prediction_id = e.id),
+            '[]'::jsonb
+        ) as groups,
+        case
+            when e.see_phase2 then coalesce(
+                (select jsonb_agg(jsonb_build_object(
+                    'match_id', kp.match_id,
+                    'winner_team_id', kp.winner_team_id
+                ) order by kp.match_id)
+                from public.knockout_predictions kp
+                where kp.prediction_id = e.id),
+                '[]'::jsonb
+            )
+            else '[]'::jsonb
+        end as knockout,
+        coalesce(
+            (select jsonb_agg(jsonb_build_object(
+                'rank', ap.rank,
+                'team_id', ap.team_id
+            ) order by ap.rank)
+            from public.advancer_predictions ap
+            where ap.prediction_id = e.id),
+            '[]'::jsonb
+        ) as advancers
+    from elig e
+    join public.profiles pr on pr.id = e.user_id;
+$$;
+
+grant execute on function public.get_public_prediction(uuid) to authenticated;


### PR DESCRIPTION
## Why

In the bracket-preview dialog, knockout selections should be sealed before the knockout stage locks — but with the right nuance:

- **Your own entry** must never be sealed — you can always see your own knockout picks.
- **Another member's entry** during `phase2_open` should reveal its **Phase 1 group-stage** picks while keeping the **knockout** sealed (it's still editable, so it can't be copied).

## What

### Frontend (`BracketPreviewDialog`)
Gates the knockout section + bracket-champion meta by **ownership** instead of a blanket phase:
`reveal = own || admin || super-admin || phase2_locked`. The owner always sees their knockout; another member sees *"Predictions will be revealed when Phase 2 is locked."* until lock. Phase 1 sections and the tiebreaker stay as the data allows.

### Backend (`0078`, re-emits `get_public_prediction`)
`0058` blocked another member's preview **entirely** during `phase2_open` (to avoid leaking editable knockout picks), so the leaderboard preview 404'd. Now:
- the eligibility window includes `phase2_open`, so other members' **Phase 1** is returned; and
- **field-level redaction** — `knockout` (`[]`) and `total_goals` (`null`) are withheld from non-owner/non-admin viewers until `phase2_locked`, so the still-editable Phase 2 picks can't be read off the API even though the UI also hides them. Phase 1 (groups, advancers, champion) is frozen by `phase1_locked`, so it's always returned to an eligible viewer.

## Testing

- New/updated `BracketPreviewDialog.test.tsx` (4 cases): another member sealed pre-lock, **owner always sees own knockout during phase2_open**, everyone revealed at `phase2_locked`, admin bypass.
- DB functional check (rolled back): during `phase2_open`, the owner gets full data (goals + 3 knockout picks); another member gets Phase 1 (groups + champion) with `knockout = []` and `total_goals = NULL`.
- `npm test` (590 passing), `typecheck`, `lint` — all clean.

## Deploy note

Now includes a migration (`0078`) — needs `supabase db push` to prod, plus the Cloudflare frontend deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
