### PR TITLE
fix(lock-banner): always show countdown; remove sticky dismiss

### DIFF
--- a/frontend/src/components/layout/LockStatusBanner.tsx
+++ b/frontend/src/components/layout/LockStatusBanner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import * as React from 'react';
-import { AlertCircle, Lock, Unlock, X } from 'lucide-react';
+import { useEffect } from 'react';
+import { AlertCircle, Lock, Unlock } from 'lucide-react';
 
 import { useTournamentLock } from '@/hooks/useTournamentLock';
 import { useAuth } from '@/hooks/useAuth';
@@ -10,13 +10,8 @@ import { formatRemaining } from '@/lib/formatRemaining';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
-function dismissKey(tournamentId: string, phase: string): string {
-  return `wc2026:banner-dismissed:${tournamentId}:${phase}`;
-}
-
 export function LockStatusBanner() {
   const {
-    tournamentId,
     lockTime,
     isLoading,
     phase,
@@ -26,34 +21,29 @@ export function LockStatusBanner() {
     knockoutLockTime,
   } = useTournamentLock();
   const { profile } = useAuth();
-  const [dismissed, setDismissed] = React.useState(false);
 
-  // Re-evaluate dismissal state when the tournament or phase change so
-  // a state transition re-shows the banner.
-  React.useEffect(() => {
-    if (!tournamentId || typeof window === 'undefined') {
-      setDismissed(false);
-      return;
-    }
+  // One-time cleanup: the dismiss control was removed (see below), but devices
+  // that dismissed under the old scheme still carry a sticky sessionStorage flag
+  // — on iOS Safari the session can persist for days. Sweep any leftover
+  // `banner-dismissed:*` keys on load so those users recover immediately.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
     try {
-      const flag = window.sessionStorage.getItem(dismissKey(tournamentId, phase));
-      setDismissed(flag === '1');
-    } catch {
-      setDismissed(false);
-    }
-  }, [tournamentId, phase]);
-
-  const handleDismiss = React.useCallback(() => {
-    if (!tournamentId || typeof window === 'undefined') return;
-    try {
-      window.sessionStorage.setItem(dismissKey(tournamentId, phase), '1');
+      for (const key of Object.keys(window.sessionStorage)) {
+        if (key.startsWith('wc2026:banner-dismissed:')) {
+          window.sessionStorage.removeItem(key);
+        }
+      }
     } catch {
       // best-effort
     }
-    setDismissed(true);
-  }, [tournamentId, phase]);
+  }, []);
 
-  if (isLoading || !lockTime || dismissed) return null;
+  // The banner is a time-critical deadline reminder, so it is always shown (no
+  // dismiss control). A previous sessionStorage-backed ✕ could permanently bury
+  // the countdown on iOS Safari, where the session survives tab restore /
+  // backgrounding for days.
+  if (isLoading || !lockTime) return null;
 
   const isSuperAdmin = profile?.isSuperAdmin === true;
   const urgent =
@@ -116,14 +106,6 @@ export function LockStatusBanner() {
             </span>
           )}
         </div>
-        <button
-          type="button"
-          onClick={handleDismiss}
-          aria-label="Dismiss notification"
-          className="-mr-1 inline-flex h-6 w-6 items-center justify-center rounded transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
-        >
-          <X className="h-4 w-4" aria-hidden />
-        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/LockStatusBanner.test.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as React from 'react';
 
@@ -139,20 +138,27 @@ describe('LockStatusBanner', () => {
     );
   });
 
-  it('persists dismiss in sessionStorage', async () => {
+  it('is always shown with no dismiss control', async () => {
+    // The banner is a time-critical deadline reminder; removing the ✕ avoids a
+    // dismissal getting stuck (notably on iOS Safari, where the session — and
+    // any stored dismiss flag — survives tab restore / backgrounding for days).
     mockTournament({ lockOffsetMs: 86_400_000 });
-    const user = userEvent.setup();
-    const { unmount } = render(wrap(<LockStatusBanner />));
-    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
-
-    await user.click(screen.getByRole('button', { name: /dismiss/i }));
-    expect(screen.queryByRole('status')).not.toBeInTheDocument();
-
-    // Mounting again with the same tournament + same locked-flag stays dismissed.
-    unmount();
     render(wrap(<LockStatusBanner />));
-    await waitFor(() => {
-      expect(screen.queryByRole('status')).not.toBeInTheDocument();
-    });
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument();
+  });
+
+  it('sweeps stale banner-dismissed flags from a prior session on load', async () => {
+    // Devices that dismissed under the old sticky scheme keep a key until the
+    // session resets; clean them up so the banner recovers immediately.
+    window.sessionStorage.setItem('wc2026:banner-dismissed:t1:phase1', '1');
+    window.sessionStorage.setItem('wc2026:banner-dismissed:t1:phase2_open', '1');
+    window.sessionStorage.setItem('unrelated:key', 'keep');
+    mockTournament({ lockOffsetMs: 86_400_000 });
+    render(wrap(<LockStatusBanner />));
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    expect(window.sessionStorage.getItem('wc2026:banner-dismissed:t1:phase1')).toBeNull();
+    expect(window.sessionStorage.getItem('wc2026:banner-dismissed:t1:phase2_open')).toBeNull();
+    expect(window.sessionStorage.getItem('unrelated:key')).toBe('keep');
   });
 });


### PR DESCRIPTION
## Problem

On iOS Safari the lock-status countdown banner ("You have 21h 47m left to make your knockout picks!") was missing above the header, while it showed fine on desktop for the same page/user.

Root cause: the banner's dismiss **✕** wrote a `wc2026:banner-dismissed:<tournamentId>:<phase>` flag to `sessionStorage`. iOS Safari keeps `sessionStorage` alive across tab restore / backgrounding for **days**, so a single (often accidental) tap permanently buried a time-critical deadline reminder on that device — while a fresh desktop session still rendered it. Confirmed live: clearing the key brought the banner straight back.

It was not a data, rendering, date-parsing, or domain bug. The `/api/tournament` fetch returns 200 with valid data on iOS, and the sibling pot/charity strip (same `['tournament']` cache) rendered normally.

## Fix

The banner is a time-critical deadline reminder, so it's now **always shown** — the whole "stuck dismissal" class of bug goes away:

- Remove the ✕ button and all dismiss logic (`sessionStorage`, `dismissKey`, dismissed state). Gate is now just `isLoading || !lockTime`.
- Add a one-time on-load **cleanup sweep** that removes any leftover `wc2026:banner-dismissed:*` keys, so devices stuck under the old scheme recover immediately (unrelated keys untouched).

## Tests

- Replaced the dismissal tests with "always shown / no dismiss control" + a cleanup-sweep test.
- `npm test` 591 passing · `npm run typecheck` clean · `npm run lint` clean (only pre-existing `jest.setup.tsx` warnings).

## Notes

- A separate, unrelated issue surfaced during diagnosis: a `www`→apex redirect causes Next.js RSC (`?_rsc=`) navigations to fail cross-origin on iOS Safari. Out of scope here; worth fixing at the Cloudflare/redirect layer.