### PR TITLE
fix(knockout): let admins edit locked fixtures to unblock bracket progression

### DIFF
--- a/frontend/src/app/predictions/PredictionsPageContent.tsx
+++ b/frontend/src/app/predictions/PredictionsPageContent.tsx
@@ -297,6 +297,10 @@ function PaymentStatusBanner({
   );
 }
 
+// Stable empty set so the admin-editor override (which treats no fixture as
+// locked) keeps referential equality across renders for memo deps.
+const EMPTY_LOCKED_MATCH_IDS: Set<string> = new Set<string>();
+
 export function PredictionsPageContent({
   mode,
   predictionId,
@@ -319,15 +323,27 @@ export function PredictionsPageContent({
     user?.id
       ? `/api/admin/users/${user.id}/predictions`
       : apiBasePath;
-  // Per-phase editability for the user-side forms. Super admin bypasses both.
+  // The admin editor surface (mounted with an /api/admin base path, which the
+  // super-admin self-edit reroute above also produces) lets ANY admin correct a
+  // prediction through the lock — including kicked-off knockout fixtures — so
+  // they can unblock a user's bracket progression. The corresponding RPC bypass
+  // + audit log live in migration 0079.
+  const allowLockedEdit = effectiveApiBasePath.startsWith('/api/admin/');
+  // Per-phase editability for the user-side forms. Super admin bypasses both;
+  // the admin editor additionally unlocks the Phase 2 (knockout / tiebreaker)
+  // forms in locked phases. Phase 1 fields stay gated for regular admins to
+  // match the RPC (group/champion edits remain frozen post-Phase 1).
   const phase1Editable = phase === 'phase1' || isSuperAdmin;
-  const phase2Editable = phase === 'phase2_open' || isSuperAdmin;
-  // Super admin can keep navigating between steps after the tournament
-  // locks (they're the only role whose forms remain editable through
-  // locks — phase1Editable/phase2Editable above). Without this bypass
-  // the Continue button + step tabs get force-disabled by isLocked,
-  // stranding super admin on the Groups step in the admin editor.
-  const bypassLockNav = isSuperAdmin;
+  const phase2Editable = phase === 'phase2_open' || isSuperAdmin || allowLockedEdit;
+  // Super admin / admin editor can keep navigating between steps after the
+  // tournament locks. Without this bypass the Continue button + step tabs get
+  // force-disabled by isLocked, stranding them on the Groups step.
+  const bypassLockNav = isSuperAdmin || allowLockedEdit;
+  // In the admin editor the override lets an admin set winners on kicked-off
+  // fixtures, so no fixture is treated as frozen for completion/cascade — the
+  // admin must actually pick each one (which resolves the downstream slot) and
+  // their picks carry through later rounds. Regular users keep the real locks.
+  const effectiveLockedMatchIds = allowLockedEdit ? EMPTY_LOCKED_MATCH_IDS : lockedMatchIds;
 
   // A step is "locked" when its phase's edit window is closed for this user.
   // Phase 1 steps (Group Stage / Best 3rds / Gut Feeling) freeze once Phase 2
@@ -338,7 +354,7 @@ export function PredictionsPageContent({
   // stepper and Back / Continue (the forms themselves render read-only).
   const isStepLocked = React.useCallback(
     (step: Step): boolean => {
-      if (isSuperAdmin) return false;
+      if (isSuperAdmin || allowLockedEdit) return false;
       const top = topOf(step);
       const isPhase1Step =
         top === 'groups' || top === 'best_thirds' || top === 'champion_pick';
@@ -347,7 +363,7 @@ export function PredictionsPageContent({
       if (phase === 'phase1' && isPhase2Step) return true;
       return false;
     },
-    [isSuperAdmin, phase]
+    [isSuperAdmin, allowLockedEdit, phase]
   );
 
   const tournamentQuery = useQuery<{
@@ -571,8 +587,21 @@ export function PredictionsPageContent({
   const completedGroups = groupPredictions.filter(
     (p) => Object.values(p.positions).filter((v) => v !== null).length === 4
   ).length;
-  const completedKnockoutMatches = knockoutPredictions.filter(
-    (p) => p.winnerId !== null
+  // A knockout match is "resolved" for progression/completion when the user
+  // has picked a winner OR the fixture has individually locked (kicked off).
+  // A locked fixture is frozen — the user can no longer pick it (MatchCard
+  // disables selection), so requiring a winner there would trap them on the
+  // round forever. Locked-unpicked matches simply score 0. In the admin editor
+  // (effectiveLockedMatchIds is empty) only a real pick counts, so the admin is
+  // nudged to fill the kicked-off fixture they're correcting.
+  const isKnockoutMatchResolved = React.useCallback(
+    (matchId: string): boolean =>
+      knockoutPredictions.some((p) => p.matchId === matchId && p.winnerId !== null) ||
+      effectiveLockedMatchIds.has(matchId),
+    [knockoutPredictions, effectiveLockedMatchIds]
+  );
+  const completedKnockoutMatches = (matches ?? []).filter((m) =>
+    isKnockoutMatchResolved(m.id)
   ).length;
   const completedAdvancers = advancerPredictions.filter((a) => !!a.teamId).length;
   const tiebreakerSlots = 1;
@@ -659,12 +688,10 @@ export function PredictionsPageContent({
         out[s] = false;
         continue;
       }
-      out[s] = stageMatches.every((m) =>
-        knockoutPredictions.some((p) => p.matchId === m.id && p.winnerId !== null)
-      );
+      out[s] = stageMatches.every((m) => isKnockoutMatchResolved(m.id));
     }
     return out;
-  }, [matchesByStage, knockoutPredictions]);
+  }, [matchesByStage, isKnockoutMatchResolved]);
 
   const stepStatus: Record<Step, boolean> = {
     champion_pick: isChampionPickComplete,
@@ -824,7 +851,7 @@ export function PredictionsPageContent({
         groupPredictions,
         bracketAssignments,
         groupStandings,
-        lockedMatchIds
+        effectiveLockedMatchIds
       );
       persistDraft({ knockoutPredictions: next });
       if (changedMatchIds.length > 0) {
@@ -1475,6 +1502,7 @@ export function PredictionsPageContent({
               disabled={!phase2Editable}
               stage={currentStep}
               getMatchLockInfo={getMatchLockInfo}
+              allowLockedEdit={allowLockedEdit}
             />
           )}
 
@@ -1516,7 +1544,7 @@ export function PredictionsPageContent({
                 type="button"
                 variant="outline"
                 onClick={handleSaveProgress}
-                disabled={isLocked || isSubmitting || isSavingProgress}
+                disabled={lockedReadOnly || isSubmitting || isSavingProgress}
                 className="sm:w-auto"
               >
                 {isSavingProgress ? 'Saving…' : 'Save progress'}
@@ -1526,7 +1554,7 @@ export function PredictionsPageContent({
               <Button
                 type="button"
                 onClick={handleSavePhase1}
-                disabled={isLocked || isSavingProgress || isSubmitting}
+                disabled={lockedReadOnly || isSavingProgress || isSubmitting}
                 className="sm:w-auto"
               >
                 {isSavingProgress ? 'Saving…' : 'Save Phase 1 Picks'}
@@ -1537,7 +1565,7 @@ export function PredictionsPageContent({
               <Button
                 type="button"
                 onClick={handleSubmit}
-                disabled={isLocked || isSubmitting || isSavingProgress}
+                disabled={lockedReadOnly || isSubmitting || isSavingProgress}
                 className="sm:w-auto"
               >
                 {isSubmitting ? 'Submitting…' : 'Submit Prediction'}

--- a/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
+++ b/frontend/src/app/predictions/__tests__/PredictionsPageContent.test.tsx
@@ -215,6 +215,7 @@ interface QueryConfig {
   storedKnockout?: Array<{ matchId: string; winner: string | null }>;
   storedTotalGoals?: number | null;
   phase?: 'phase1' | 'phase1_locked' | 'phase2_open' | 'phase2_locked';
+  knockoutLocks?: Array<{ matchId: string; lockedAt: string }>;
 }
 
 function configureQueries({
@@ -224,6 +225,7 @@ function configureQueries({
   storedKnockout = [],
   storedTotalGoals = null,
   phase,
+  knockoutLocks = [],
 }: QueryConfig = {}) {
   mockUseQuery.mockImplementation(({ queryKey }: { queryKey: ReadonlyArray<unknown> }) => {
     const key = queryKey[0];
@@ -241,6 +243,7 @@ function configureQueries({
             phase:
               phase ??
               (new Date(tournamentLockTime) > new Date() ? 'phase1' : 'phase1_locked'),
+            knockoutLocks,
             totalEntries: 0,
             serverTime: new Date().toISOString(),
           },
@@ -941,6 +944,179 @@ describe('PredictionsPageContent — autosave', () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(JSON.parse(fetchMock.mock.calls[0][1].body).submit).toBe(false);
+  });
+
+  it('lets the user advance past R32 when a fixture locked before they picked it', async () => {
+    // Regression: a per-fixture lock (kickoff passed) freezes a match the user
+    // never picked. The user fills every other R32 match but the round-complete
+    // gate used to require a winner on EVERY match, so "Continue to Round of 16"
+    // stayed disabled forever. A locked-unpicked fixture must count as resolved.
+    configureQueries({
+      phase: 'phase2_open',
+      knockoutLocks: [
+        { matchId: 'M88', lockedAt: new Date(Date.now() - 60_000).toISOString() },
+      ],
+    });
+
+    const initial = {
+      id: 'pred-1',
+      name: 'Main',
+      totalGoals: 7,
+      championTeamId: 'arg',
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups: [],
+      // Every fixture picked EXCEPT M88 (a R32 match), which has locked.
+      knockout: fixtureKnockoutMatches
+        .filter((m) => m.id !== 'M88')
+        .map((m) => ({ matchId: m.id, winner: 'mex' })),
+      advancers: [],
+    };
+
+    render(<PredictionsPageContent mode="edit" predictionId="pred-1" initial={initial} />);
+
+    // Wizard auto-jumps to R32 in phase2_open.
+    await screen.findByTestId('knockout-bracket');
+    const continueBtn = await screen.findByRole('button', {
+      name: /Continue to Round of 16/,
+    });
+    expect(continueBtn).toBeEnabled();
+  });
+
+  it('keeps R32 Continue disabled while an UNLOCKED fixture is still unpicked', async () => {
+    // Negative case for the fix above: an un-actionable (locked) gap is fine,
+    // but a match the user can still pick must keep blocking progression.
+    configureQueries({ phase: 'phase2_open' });
+
+    const initial = {
+      id: 'pred-1',
+      name: 'Main',
+      totalGoals: 7,
+      championTeamId: 'arg',
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups: [],
+      // M88 unpicked and NOT locked → round still incomplete.
+      knockout: fixtureKnockoutMatches
+        .filter((m) => m.id !== 'M88')
+        .map((m) => ({ matchId: m.id, winner: 'mex' })),
+      advancers: [],
+    };
+
+    render(<PredictionsPageContent mode="edit" predictionId="pred-1" initial={initial} />);
+
+    await screen.findByTestId('knockout-bracket');
+    const continueBtn = await screen.findByRole('button', {
+      name: /Continue to Round of 16/,
+    });
+    expect(continueBtn).toBeDisabled();
+  });
+
+  it('in the admin editor, a locked-unpicked R32 fixture keeps Continue disabled until filled', async () => {
+    // Admin override (apiBasePath under /api/admin): unlike a regular user, the
+    // admin CAN edit a kicked-off fixture, so a locked-unpicked match no longer
+    // counts as resolved — it must actually be picked. This nudges the admin to
+    // set the missing winner (which resolves the downstream R16 slot) rather
+    // than silently skating past it.
+    configureQueries({
+      phase: 'phase2_open',
+      knockoutLocks: [
+        { matchId: 'M88', lockedAt: new Date(Date.now() - 60_000).toISOString() },
+      ],
+    });
+
+    const initial = {
+      id: 'pred-1',
+      name: 'Main',
+      totalGoals: 7,
+      championTeamId: 'arg',
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups: [],
+      // Every fixture picked EXCEPT the locked M88.
+      knockout: fixtureKnockoutMatches
+        .filter((m) => m.id !== 'M88')
+        .map((m) => ({ matchId: m.id, winner: 'mex' })),
+      advancers: [],
+    };
+
+    render(
+      <PredictionsPageContent
+        mode="edit"
+        predictionId="pred-1"
+        initial={initial}
+        apiBasePath="/api/admin/users/u1/predictions"
+      />
+    );
+
+    await screen.findByTestId('knockout-bracket');
+    const continueBtn = await screen.findByRole('button', {
+      name: /Continue to Round of 16/,
+    });
+    // Contrast with the regular-user case above (enabled): admin must fill M88.
+    expect(continueBtn).toBeDisabled();
+  });
+
+  it('lets an admin submit a complete Phase 2 prediction while phase2 is LOCKED', async () => {
+    // Regression: in a locked phase the footer commit buttons were gated on raw
+    // isLocked, so the admin editor showed an enabled-looking flow but the
+    // "Submit Prediction" button stayed disabled. The admin (bypassLockNav) must
+    // be able to commit once everything is filled.
+    configureQueries({ phase: 'phase2_locked' });
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ predictionId: 'pred-1' }) });
+
+    const groups = fixtureGroups.map((g) => ({
+      groupId: g.id,
+      first: g.teams[0].id,
+      second: g.teams[1].id,
+      third: g.teams[2].id,
+      fourth: g.teams[3].id,
+    }));
+    const advancers = fixtureGroups.slice(0, 8).map((g, i) => ({
+      rank: i + 1,
+      teamId: g.teams[2].id,
+    }));
+    const initial = {
+      id: 'pred-1',
+      name: 'Main',
+      totalGoals: 7,
+      championTeamId: 'arg',
+      submittedAt: new Date(Date.now() - 60_000).toISOString(),
+      isPaid: false,
+      paidAt: null,
+      groups,
+      knockout: fixtureKnockoutMatches.map((m) => ({ matchId: m.id, winner: 'mex' })),
+      advancers,
+    };
+
+    const user = userEvent.setup();
+    render(
+      <PredictionsPageContent
+        mode="edit"
+        predictionId="pred-1"
+        initial={initial}
+        apiBasePath="/api/admin/users/u1/predictions"
+      />
+    );
+
+    // All step tabs are unlocked for the admin; jump straight to the last step.
+    await user.click(await screen.findByRole('tab', { name: /Tiebreaker/ }));
+    const submitBtn = await screen.findByRole('button', { name: /Submit Prediction/ });
+    expect(submitBtn).toBeEnabled();
+
+    await user.click(submitBtn);
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Prediction submitted'));
+    // Routed through the admin RPC, with submit:true.
+    const submitCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).startsWith('/api/admin/users/u1/predictions') &&
+        JSON.parse((init as { body: string }).body).submit === true
+    );
+    expect(submitCall).toBeTruthy();
   });
 
   it('auto-commits an edit to a SUBMITTED prediction after the debounce (submit:false, no redirect)', async () => {

--- a/frontend/src/components/predictions/KnockoutBracket.tsx
+++ b/frontend/src/components/predictions/KnockoutBracket.tsx
@@ -97,6 +97,14 @@ interface KnockoutBracketProps {
    * to kickoff. Defaults to never-locked.
    */
   getMatchLockInfo?: (matchId: string) => { locked: boolean; remainingMs: number | null };
+  /**
+   * Admin-editor override: when true, per-fixture (kicked-off) locks no longer
+   * block selection, so an admin can correct a locked fixture's winner to
+   * unblock a user's bracket. The "Locked" badge still renders for context, and
+   * a locked-but-unpicked match no longer counts toward round completion (the
+   * admin is expected to actually pick it). Defaults to false (normal users).
+   */
+  allowLockedEdit?: boolean;
 }
 
 // resolveTeamSource lives in @/lib/knockoutResolver so both this editor and
@@ -140,6 +148,7 @@ function MatchCard({
   disabled,
   locked = false,
   lockRemainingMs = null,
+  allowLockedEdit = false,
 }: {
   match: KnockoutMatch;
   team1Id: string | null;
@@ -151,6 +160,8 @@ function MatchCard({
   locked?: boolean;
   /** Ms until this fixture locks, when a future lock is scheduled (else null). */
   lockRemainingMs?: number | null;
+  /** Admin override: allow selecting even a locked (kicked-off) fixture. */
+  allowLockedEdit?: boolean;
 }) {
   const team1 = getTeamDisplay(team1Id, teams);
   const team2 = getTeamDisplay(team2Id, teams);
@@ -171,7 +182,8 @@ function MatchCard({
   // A locked fixture always renders its stored winner and is never editable.
   const effectiveWinnerId = locked || isWinnerValid ? selectedWinnerId : null;
   const hasWinner = effectiveWinnerId !== null;
-  const canSelect = team1Id !== null && team2Id !== null && !disabled && !locked;
+  const canSelect =
+    team1Id !== null && team2Id !== null && !disabled && (!locked || allowLockedEdit);
 
   return (
     <Card
@@ -274,6 +286,7 @@ function StageSection({
   onPredictionChange,
   disabled,
   getMatchLockInfo,
+  allowLockedEdit = false,
 }: {
   stage: KnockoutStage;
   matches: KnockoutMatch[];
@@ -286,11 +299,17 @@ function StageSection({
   onPredictionChange: (matchId: string, winnerId: string | null) => void;
   disabled?: boolean;
   getMatchLockInfo?: (matchId: string) => { locked: boolean; remainingMs: number | null };
+  allowLockedEdit?: boolean;
 }) {
   const config = STAGE_CONFIG[stage];
   const completedCount = matches.filter((match) => {
     const prediction = knockoutPredictions.find((p) => p.matchId === match.id);
-    return prediction?.winnerId !== null && prediction?.winnerId !== undefined;
+    const hasWinner = prediction?.winnerId !== null && prediction?.winnerId !== undefined;
+    // A locked (kicked-off) fixture is frozen and counts as resolved even
+    // without a pick — it can no longer be acted on, so it shouldn't hold the
+    // round's "Complete" badge back. In the admin editor (allowLockedEdit) it's
+    // editable, so a locked-unpicked fixture stays incomplete until picked.
+    return hasWinner || (!allowLockedEdit && (getMatchLockInfo?.(match.id)?.locked ?? false));
   }).length;
 
   return (
@@ -364,6 +383,7 @@ function StageSection({
               disabled={disabled}
               locked={lockInfo?.locked ?? false}
               lockRemainingMs={lockInfo && !lockInfo.locked ? lockInfo.remainingMs : null}
+              allowLockedEdit={allowLockedEdit}
             />
           );
         })}
@@ -383,6 +403,7 @@ export function KnockoutBracket({
   disabled = false,
   stage,
   getMatchLockInfo,
+  allowLockedEdit = false,
 }: KnockoutBracketProps) {
   const stageMatches = React.useMemo(
     () => matches.filter((m) => m.stage === stage),
@@ -390,7 +411,16 @@ export function KnockoutBracket({
   );
 
   const totalMatches = matches.length;
-  const completedMatches = knockoutPredictions.filter((p) => p.winnerId !== null).length;
+  const completedMatches = matches.filter((m) => {
+    const hasWinner = knockoutPredictions.some(
+      (p) => p.matchId === m.id && p.winnerId !== null
+    );
+    // Locked (kicked-off) fixtures are frozen — count them as resolved so the
+    // summary badge stays in step with the unblocked Continue / Submit gates.
+    // In the admin editor (allowLockedEdit) locked fixtures are editable, so
+    // they only count once actually picked.
+    return hasWinner || (!allowLockedEdit && (getMatchLockInfo?.(m.id)?.locked ?? false));
+  }).length;
 
   return (
     <div className="space-y-6">
@@ -459,6 +489,7 @@ export function KnockoutBracket({
         onPredictionChange={onPredictionChange}
         disabled={disabled}
         getMatchLockInfo={getMatchLockInfo}
+        allowLockedEdit={allowLockedEdit}
       />
     </div>
   );

--- a/frontend/src/components/predictions/__tests__/KnockoutBracket.test.tsx
+++ b/frontend/src/components/predictions/__tests__/KnockoutBracket.test.tsx
@@ -168,5 +168,25 @@ describe('KnockoutBracket', () => {
       // Not locked yet → still selectable.
       expect(screen.getByRole('button', { name: /MEX.*Mexico/i })).toBeEnabled();
     });
+
+    it('lets an admin (allowLockedEdit) select a locked fixture, badge still shown', async () => {
+      // Admin-editor override: a kicked-off fixture keeps its "Locked" badge for
+      // context but its team buttons become clickable so the admin can correct
+      // the winner and unblock the user's bracket.
+      const user = userEvent.setup();
+      const { onPredictionChange } = renderBracket({
+        groupPredictions: createCompleteGroupPredictions(),
+        allowLockedEdit: true,
+        getMatchLockInfo: (matchId) =>
+          matchId === 'M73'
+            ? { locked: true, remainingMs: 0 }
+            : { locked: false, remainingMs: null },
+      });
+      expect(screen.getByText('Locked')).toBeInTheDocument();
+      const mexButton = screen.getByRole('button', { name: /MEX.*Mexico/i });
+      expect(mexButton).toBeEnabled();
+      await user.click(mexButton);
+      expect(onPredictionChange).toHaveBeenCalledWith('M73', 'mex');
+    });
   });
 });

--- a/supabase/migrations/0079_admin_knockout_lock_bypass.sql
+++ b/supabase/migrations/0079_admin_knockout_lock_bypass.sql
@@ -1,0 +1,290 @@
+-- 0079_admin_knockout_lock_bypass.sql
+--
+-- Admin override for locked (kicked-off) knockout fixtures + audit log.
+--
+-- Background: a bug left a user unable to submit their Round of 32 before those
+-- fixtures kicked off. Once a fixture kicks off it is per-fixture locked
+-- (knockout_match_locks) and 0072 honored that lock UNIFORMLY — even for super
+-- admin via admin_submit_predictions. With no winner recorded on the now-locked
+-- R32 matches, the downstream R16 slots never resolve, so the bracket can't be
+-- completed and the user is stranded.
+--
+-- Fix: admin_submit_predictions is already admin-only (is_admin() gate). Relax
+-- it so ANY admin, correcting a prediction through the admin editor, can:
+--   * save edits to an existing prediction in a locked phase (drop the
+--     phase1_locked / phase2_locked write block), and
+--   * overwrite knockout picks regardless of per-fixture locks.
+-- The regular-user RPC submit_predictions is left untouched — locks still apply
+-- to users.
+--
+-- Accountability: every knockout pick an admin changes once the tournament has
+-- begun (tournament_phase <> 'phase1') is recorded in admin_knockout_audit with
+-- the acting admin (id + email), the prediction owner (id + email), the match +
+-- stage, old/new winner, the phase at write time, and a timestamp.
+
+-- ========== table: admin_knockout_audit ==========
+create table if not exists public.admin_knockout_audit (
+    id             bigint generated always as identity primary key,
+    acted_by       uuid not null references auth.users(id),   -- the admin
+    acted_by_email text not null,                             -- admin email snapshot
+    user_id        uuid not null references auth.users(id),   -- prediction owner
+    user_email     text not null,                             -- owner email snapshot
+    prediction_id  uuid not null,
+    tournament_id  uuid not null,
+    match_id       text not null references public.knockout_matches(id),
+    stage          text not null,                             -- knockout_matches.stage
+    old_winner     text,                                      -- prior pick (nullable)
+    new_winner     text,                                      -- new pick (nullable)
+    phase          text not null,                             -- tournament_phase at write
+    created_at     timestamptz not null default now()
+);
+
+create index if not exists admin_knockout_audit_user_idx
+    on public.admin_knockout_audit (user_id, created_at desc);
+create index if not exists admin_knockout_audit_acted_by_idx
+    on public.admin_knockout_audit (acted_by, created_at desc);
+
+alter table public.admin_knockout_audit enable row level security;
+
+-- Admins may read the audit trail; no client INSERT/UPDATE/DELETE — rows are
+-- written only by the SECURITY DEFINER admin_submit_predictions RPC.
+drop policy if exists admin_knockout_audit_select_admin on public.admin_knockout_audit;
+create policy admin_knockout_audit_select_admin on public.admin_knockout_audit
+    for select using (public.is_admin());
+
+-- ========== admin_submit_predictions (lock bypass + audit) ==========
+create or replace function public.admin_submit_predictions(p_user_id uuid, payload jsonb)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_tournament_id uuid := (payload->>'tournament_id')::uuid;
+    v_prediction_id uuid := nullif(payload->>'prediction_id', '')::uuid;
+    v_prediction_name text := nullif(trim(payload->>'prediction_name'), '');
+    v_total_goals int := nullif(payload->>'total_goals', '')::int;
+    v_champion_team_id text := nullif(payload->>'champion_team_id', '');
+    v_has_champion_key boolean := payload ? 'champion_team_id';
+    v_mark_submitted boolean := coalesce((payload->>'submit')::boolean, true);
+    v_phase text;
+    v_super boolean;
+    v_acted_by_email text;
+    v_user_email text;
+    v_group jsonb;
+    v_match jsonb;
+    v_advancer jsonb;
+    v_rank int;
+    v_team_id text;
+    v_seen_ranks int[] := '{}';
+    v_seen_teams text[] := '{}';
+    v_valid_thirds text[];
+    v_group_id text;
+    v_team_ids text[];
+    v_mismatched_team text;
+    v_match_id text;
+    v_old_winner text;
+    v_new_winner text;
+    v_stage text;
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+    if p_user_id is null or v_tournament_id is null then
+        raise exception 'user_id and tournament_id are required' using errcode = 'P0001';
+    end if;
+
+    v_super := public.is_super_admin();
+    v_phase := public.tournament_phase(v_tournament_id);
+
+    -- Email snapshots for the audit trail (RPC is SECURITY DEFINER, so it may
+    -- read auth.users). Resolved once; reused per logged match below.
+    select email into v_acted_by_email from auth.users where id = auth.uid();
+    select email into v_user_email from auth.users where id = p_user_id;
+
+    -- New predictions still cannot be created once Phase 1 has ended (super
+    -- admin excepted). NOTE: unlike 0072 there is no longer a hard
+    -- 'predictions are locked' block here — an admin correcting an EXISTING
+    -- prediction may save in any phase, including phase1_locked / phase2_locked.
+    if not v_super then
+        if v_prediction_id is null and v_phase <> 'phase1' then
+            raise exception 'phase 1 ended; new predictions cannot be created'
+                using errcode = 'P0001';
+        end if;
+    end if;
+
+    if v_prediction_id is null then
+        if v_prediction_name is null then
+            raise exception 'prediction name required' using errcode = 'P0001';
+        end if;
+        if v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            insert into public.predictions (
+                user_id, tournament_id, prediction_name, total_goals,
+                champion_team_id, submitted_at
+            )
+            values (
+                p_user_id,
+                v_tournament_id,
+                v_prediction_name,
+                v_total_goals,
+                v_champion_team_id,
+                case when v_mark_submitted then now() else null end
+            )
+            returning id into v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    else
+        perform 1 from public.predictions
+            where id = v_prediction_id and user_id = p_user_id and tournament_id = v_tournament_id;
+        if not found then
+            raise exception 'prediction not found' using errcode = 'P0001';
+        end if;
+
+        if v_has_champion_key and v_champion_team_id is null then
+            raise exception 'champion pick required' using errcode = 'P0001';
+        end if;
+
+        begin
+            update public.predictions
+               set prediction_name = case
+                       when v_super or v_phase = 'phase1'
+                           then coalesce(v_prediction_name, prediction_name)
+                       else prediction_name
+                   end,
+                   total_goals = v_total_goals,
+                   champion_team_id = case
+                       when v_has_champion_key and (v_super or v_phase = 'phase1')
+                           then v_champion_team_id
+                       else champion_team_id
+                   end,
+                   submitted_at = case when v_mark_submitted then now() else submitted_at end
+             where id = v_prediction_id;
+        exception
+            when unique_violation then
+                raise exception 'prediction name taken' using errcode = 'P0001';
+        end;
+    end if;
+
+    if v_super or v_phase = 'phase1' then
+        delete from public.advancer_predictions where prediction_id = v_prediction_id;
+        delete from public.group_predictions where prediction_id = v_prediction_id;
+
+        for v_group in select * from jsonb_array_elements(coalesce(payload->'groups', '[]'::jsonb))
+        loop
+            v_group_id := v_group->>'group_id';
+            v_team_ids := array_remove(array[
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            ], null);
+
+            select t.id into v_mismatched_team
+              from public.teams t
+             where t.id = any(v_team_ids) and t.group_id is distinct from v_group_id
+             limit 1;
+
+            if v_mismatched_team is not null then
+                raise exception 'team % does not belong to group %', v_mismatched_team, v_group_id
+                    using errcode = 'P0001';
+            end if;
+
+            insert into public.group_predictions (
+                prediction_id, group_id, first_team_id, second_team_id, third_team_id, fourth_team_id
+            ) values (
+                v_prediction_id,
+                v_group_id,
+                nullif(v_group->>'first', ''),
+                nullif(v_group->>'second', ''),
+                nullif(v_group->>'third', ''),
+                nullif(v_group->>'fourth', '')
+            );
+        end loop;
+
+        select array_agg(third_team_id) into v_valid_thirds
+          from public.group_predictions
+         where prediction_id = v_prediction_id
+           and third_team_id is not null;
+
+        for v_advancer in select * from jsonb_array_elements(coalesce(payload->'advancers', '[]'::jsonb))
+        loop
+            v_rank := nullif(v_advancer->>'rank', '')::int;
+            v_team_id := nullif(v_advancer->>'team_id', '');
+            if v_team_id is null then
+                continue;
+            end if;
+            if v_rank is null or v_rank < 1 or v_rank > 8 then
+                raise exception 'advancer rank must be 1..8 (got %)', v_rank using errcode = 'P0001';
+            end if;
+            if v_rank = any(v_seen_ranks) then
+                raise exception 'duplicate advancer rank %', v_rank using errcode = 'P0001';
+            end if;
+            if v_team_id = any(v_seen_teams) then
+                raise exception 'duplicate advancer team' using errcode = 'P0001';
+            end if;
+            if v_valid_thirds is null or not (v_team_id = any(v_valid_thirds)) then
+                raise exception 'advancer team % not in your 3rd-place picks', v_team_id
+                    using errcode = 'P0001';
+            end if;
+            v_seen_ranks := array_append(v_seen_ranks, v_rank);
+            v_seen_teams := array_append(v_seen_teams, v_team_id);
+
+            insert into public.advancer_predictions (prediction_id, rank, team_id)
+            values (v_prediction_id, v_rank, v_team_id);
+        end loop;
+    end if;
+
+    -- Knockout: any admin may rewrite picks, INCLUDING per-fixture-locked
+    -- (kicked-off) matches — this is the override that unblocks bracket
+    -- progression. Guarded on the key's presence so a phase-1-only save does not
+    -- wipe knockout picks.
+    if payload ? 'knockout' then
+        -- Audit pass (before the rewrite, so old winners are still present).
+        -- Only log once the tournament has begun: a phase-1 edit is normal
+        -- pre-lock activity, not an after-the-fact override.
+        if v_phase <> 'phase1' then
+            for v_match in select * from jsonb_array_elements(payload->'knockout')
+            loop
+                v_match_id := v_match->>'match_id';
+                v_new_winner := nullif(v_match->>'winner', '');
+                select winner_team_id into v_old_winner
+                  from public.knockout_predictions
+                 where prediction_id = v_prediction_id and match_id = v_match_id;
+                if v_old_winner is distinct from v_new_winner then
+                    select stage into v_stage from public.knockout_matches where id = v_match_id;
+                    insert into public.admin_knockout_audit (
+                        acted_by, acted_by_email, user_id, user_email,
+                        prediction_id, tournament_id, match_id, stage,
+                        old_winner, new_winner, phase
+                    ) values (
+                        auth.uid(), v_acted_by_email, p_user_id, v_user_email,
+                        v_prediction_id, v_tournament_id, v_match_id, v_stage,
+                        v_old_winner, v_new_winner, v_phase
+                    );
+                end if;
+            end loop;
+        end if;
+
+        delete from public.knockout_predictions where prediction_id = v_prediction_id;
+        for v_match in select * from jsonb_array_elements(payload->'knockout')
+        loop
+            insert into public.knockout_predictions (prediction_id, match_id, winner_team_id)
+            values (
+                v_prediction_id,
+                v_match->>'match_id',
+                nullif(v_match->>'winner', '')
+            );
+        end loop;
+    end if;
+
+    return v_prediction_id;
+end;
+$$;
+
+grant execute on function public.admin_submit_predictions(uuid, jsonb) to authenticated;


### PR DESCRIPTION
## Problem

A bug left a user unable to submit their Round of 32 before those fixtures kicked off. Per-fixture knockout locks (`knockout_match_locks`) were honored **uniformly — even for super admin** — so the now-locked R32 matches had no recorded winner, the downstream R16 slots never resolved (stuck on "TBD"), and the bracket could not be completed or progressed.

## What this does

Lets **any admin** (and super-admins), working through the admin editor for the affected user (`/admin/users/[id]/predictions/[predictionId]`), edit knockout selections in any phase — **including kicked-off (locked) fixtures** — so they can set the missing winners and progress through all remaining rounds on the user's behalf. Every such change is audit-logged.

It also unblocks the **regular-user** Continue gate: a fixture that locks mid-bracket (before the user picked it) now counts as resolved, so a normal user is no longer trapped on a round they can't act on.

## Changes

**Backend — `supabase/migrations/0079_admin_knockout_lock_bypass.sql`**
- `create or replace admin_submit_predictions` (already `is_admin()`-gated): drops the locked-phase write block and ignores per-fixture locks on the knockout write, guarded on the `knockout` key so a phase-1-only save can't wipe picks.
- New append-only `admin_knockout_audit` table (admin-only `SELECT` RLS, no client write path): logs every knockout pick an admin changes once the tournament has begun (`tournament_phase <> 'phase1'`) — acting admin (id + email), prediction owner (id + email), match, stage, old/new winner, phase, timestamp.
- `submit_predictions` (regular users) is **untouched** — locks still apply to them.

**Frontend**
- `allowLockedEdit` (derived from the `/api/admin/` base path) unlocks the Phase 2 forms in locked phases, makes locked fixtures selectable in `KnockoutBracket` (the "Locked" badge stays for context), and treats no fixture as frozen for completion/cascade so the admin must actually pick each one (which resolves the downstream slot).
- Footer commit buttons (Submit / Save) switched off raw `isLocked` → `lockedReadOnly`, so admins can submit a complete bracket in a locked phase.

## Security — only admins/super-admins can override locked picks

Enforced at the server (RPC + route), runtime-proved in rolled-back transactions:
- Regular user via `submit_predictions` in a locked phase → **blocked** (`predictions are locked`).
- Regular user calling `admin_submit_predictions` directly → **blocked** (`forbidden`, the `is_admin()` gate).
- Regular user via `submit_predictions` in `phase2_open` → locked fixtures stay ignored (per-fixture skip), unlocked ones still editable.
- Admin / super-admin via the `requireAdmin`-gated admin route → allowed, with an audit row written.

## Verification

- `npm test` → **596/596 pass** (incl. new tests: admin can select a locked fixture; admin keeps Continue disabled until a locked fixture is filled; admin can submit a complete Phase 2 prediction while `phase2_locked`).
- `npm run typecheck` and `npm run lint` clean.
- Migration applied locally (`supabase migration up`) and runtime-smoke-tested (locked-fixture override + audit row + regular-user lockout). No production access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)