### PR TITLE
fix(admin): hide editor Edit/New during lock for super admins too

### DIFF
--- a/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
+++ b/frontend/src/app/admin/users/[id]/AdminUserBracket.tsx
@@ -188,18 +188,16 @@ function PaymentRow({
 
 export function AdminUserBracket({ userId }: { userId: string }) {
   const queryClient = useQueryClient();
-  const { profile } = useAuth();
   const { isLocked, isLoading: lockLoading } = useTournamentLock();
   const [pendingDelete, setPendingDelete] = React.useState<AdminPrediction | null>(null);
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [previewId, setPreviewId] = React.useState<string | null>(null);
   const [voidingId, setVoidingId] = React.useState<string | null>(null);
 
-  // While the tournament is locked, only super admins may edit a user's picks
-  // (the admin_submit_predictions RPC enforces this). Hide the pick-edit
-  // affordances for everyone else so they aren't led to a dead end.
-  const isSuperAdmin = profile?.isSuperAdmin === true;
-  const editLocked = !lockLoading && isLocked && !isSuperAdmin;
+  // Once the tournament is locked the admin editor is read-only for ALL admins
+  // (including super admins): hide the pick-edit affordances (Edit + New
+  // prediction). Void / Preview / Delete / payment controls are unaffected.
+  const editLocked = !lockLoading && isLocked;
 
   const query = useQuery<AdminPredictionsResponse>({
     queryKey: ['admin-user-predictions', userId],

--- a/frontend/src/app/admin/users/[id]/__tests__/AdminUserBracket.test.tsx
+++ b/frontend/src/app/admin/users/[id]/__tests__/AdminUserBracket.test.tsx
@@ -63,9 +63,21 @@ describe('AdminUserBracket — lock-time edit hiding + void', () => {
     expect(screen.getByRole('button', { name: /^Void$/i })).toBeInTheDocument();
   });
 
-  it('super admin + locked: keeps Edit + New prediction', () => {
+  it('super admin + locked: ALSO hides Edit + New prediction', () => {
     mockProfile.isSuperAdmin = true;
     mockLock.isLocked = true;
+    render(<AdminUserBracket userId="u1" />);
+
+    // The admin editor is read-only for everyone once locked — super admins
+    // included. Void stays available.
+    expect(screen.queryByRole('link', { name: /New prediction/i })).toBeNull();
+    expect(screen.queryByRole('link', { name: /^Edit$/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /^Void$/i })).toBeInTheDocument();
+  });
+
+  it('unlocked: shows Edit + New prediction', () => {
+    mockProfile.isSuperAdmin = false;
+    mockLock.isLocked = false;
     render(<AdminUserBracket userId="u1" />);
 
     expect(screen.getByRole('link', { name: /New prediction/i })).toBeInTheDocument();


### PR DESCRIPTION
## Why

PR #252 hid the per-prediction **Edit** and **New prediction** buttons on the per-user admin page (`/admin/users/[id]`) for *non-super* admins while the tournament is locked, but kept them visible for **super admins**. Per the updated decision, the admin editor should be read-only for **everyone** once locked — extend the same treatment to super admins.

## Change

`AdminUserBracket.tsx`: `editLocked` drops the super-admin exemption — now `!lockLoading && isLocked`. The unused `profile` / `isSuperAdmin` in the main component are removed (the `useAuth` import stays for `PaymentRow`). Void / Preview / Delete / payment controls are unaffected.

UI-only: the `admin_submit_predictions` super-admin override (migration 0080) is left untouched as a break-glass API path; it's simply no longer surfaced in the UI during lock.

## Tests

- Flipped `super admin + locked` to assert Edit + New prediction are **hidden** (Void still present).
- Added an **unlocked-state** regression test (Edit + New shown).
- `npm test` → **607/607**, typecheck + lint clean.

## Out of scope

No DB change. The `/predictions/new` + `/predictions/[id]` deeplink redirect still **exempts** super admins (their own prediction pages, a different surface) — say the word if you want that frozen too for a full super-admin lockdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)