### PR TITLE
feat(leaderboard): show each prediction's pick to win next to its name

### DIFF
--- a/frontend/src/app/api/leaderboard/__tests__/route.test.ts
+++ b/frontend/src/app/api/leaderboard/__tests__/route.test.ts
@@ -78,6 +78,8 @@ describe('GET /api/leaderboard', () => {
           knockout_points: 40,
           total_goals: 170,
           updated_at: '2026-05-29T12:00:00.000Z',
+          bracket_champion_code: 'ARG',
+          bracket_champion_name: 'Argentina',
           total_count: 2,
         },
         {
@@ -87,6 +89,8 @@ describe('GET /api/leaderboard', () => {
           group_points: 55,
           knockout_points: 35,
           total_goals: 175,
+          bracket_champion_code: null,
+          bracket_champion_name: null,
           total_count: 2,
         },
       ],
@@ -103,6 +107,12 @@ describe('GET /api/leaderboard', () => {
       groupPoints: 60,
       knockoutPoints: 40,
       updatedAt: '2026-05-29T12:00:00.000Z',
+      bracketChampionCode: 'ARG',
+      bracketChampionName: 'Argentina',
+    });
+    expect(body.entries[1]).toMatchObject({
+      bracketChampionCode: null,
+      bracketChampionName: null,
     });
     expect(body.entries[0].email).toBeUndefined();
     expect(supabaseMock.rpc).toHaveBeenCalledWith(

--- a/frontend/src/app/api/leaderboard/route.ts
+++ b/frontend/src/app/api/leaderboard/route.ts
@@ -63,6 +63,8 @@ export async function GET(request: NextRequest) {
     champion_pick_points: number;
     total_goals: number | null;
     updated_at: string | null;
+    bracket_champion_code: string | null;
+    bracket_champion_name: string | null;
     total_count: number;
   }>;
 
@@ -80,6 +82,8 @@ export async function GET(request: NextRequest) {
       knockoutPoints: row.knockout_points,
       championPickPoints: row.champion_pick_points ?? 0,
       updatedAt: row.updated_at ?? null,
+      bracketChampionCode: row.bracket_champion_code ?? null,
+      bracketChampionName: row.bracket_champion_name ?? null,
     })),
     total: Number(rows[0]?.total_count ?? 0),
     page,

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -14,6 +14,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { BracketPreviewDialog } from '@/components/predictions/BracketPreviewDialog';
+import { TeamFlag } from '@/components/shared/TeamFlag';
 import { getRankBadge } from '@/components/leaderboard/rankBadge';
 import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils';
@@ -155,13 +156,26 @@ export function LeaderboardTable({
                   <div className="flex flex-col">
                     <span
                       className={cn(
-                        'text-sm font-medium',
+                        'flex items-center gap-1.5 text-sm font-medium',
                         isCurrentUser && 'text-primary font-semibold'
                       )}
                     >
                       {entry.predictionName}
                       {isCurrentUser && (
-                        <span className="text-muted-foreground ml-2 text-xs">(You)</span>
+                        <span className="text-muted-foreground text-xs">(You)</span>
+                      )}
+                      {entry.bracketChampionCode && (
+                        <span
+                          title={entry.bracketChampionName ?? undefined}
+                          aria-label={
+                            entry.bracketChampionName
+                              ? `Pick to win: ${entry.bracketChampionName}`
+                              : undefined
+                          }
+                          className="inline-flex items-center"
+                        >
+                          <TeamFlag code={entry.bracketChampionCode} className="h-3.5 w-5" />
+                        </span>
                       )}
                     </span>
                     <span className="text-muted-foreground text-xs">

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -164,7 +164,7 @@ export function LeaderboardTable({
                       {isCurrentUser && (
                         <span className="text-muted-foreground text-xs">(You)</span>
                       )}
-                      {entry.bracketChampionCode && (
+                      {entry.bracketChampionCode ? (
                         <span
                           title={entry.bracketChampionName ?? undefined}
                           aria-label={
@@ -175,6 +175,13 @@ export function LeaderboardTable({
                           className="inline-flex items-center"
                         >
                           <TeamFlag code={entry.bracketChampionCode} className="h-3.5 w-5" />
+                        </span>
+                      ) : (
+                        <span
+                          aria-label="Pick to win: not yet made"
+                          className="text-muted-foreground/60 text-xs"
+                        >
+                          &mdash;
                         </span>
                       )}
                     </span>

--- a/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
+++ b/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
@@ -98,7 +98,7 @@ describe('LeaderboardTable', () => {
     expect(screen.getByText('5th')).toBeInTheDocument();
   });
 
-  it('shows the bracket champion flag (pick to win) when present, hidden otherwise', () => {
+  it('shows the bracket champion flag (pick to win) when present, a dash otherwise', () => {
     render(
       <LeaderboardTable
         entries={[
@@ -112,8 +112,9 @@ describe('LeaderboardTable', () => {
     expect(
       screen.getByLabelText('Pick to win: Argentina')
     ).toBeInTheDocument();
-    // The row without a pick renders no flag.
+    // The row without a pick renders a dash placeholder rather than nothing.
     expect(screen.queryByTitle('Brazil')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Pick to win: not yet made')).toBeInTheDocument();
   });
 
   it('renders email in place of username when present (admin view)', () => {

--- a/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
+++ b/frontend/src/components/leaderboard/__tests__/LeaderboardTable.test.tsx
@@ -98,6 +98,24 @@ describe('LeaderboardTable', () => {
     expect(screen.getByText('5th')).toBeInTheDocument();
   });
 
+  it('shows the bracket champion flag (pick to win) when present, hidden otherwise', () => {
+    render(
+      <LeaderboardTable
+        entries={[
+          { ...entries[0], bracketChampionCode: 'ARG', bracketChampionName: 'Argentina' },
+          { ...entries[1], bracketChampionCode: null, bracketChampionName: null },
+        ]}
+      />
+    );
+    // The flag wrapper exposes the team name via title + aria-label for hover/SR.
+    expect(screen.getByTitle('Argentina')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Pick to win: Argentina')
+    ).toBeInTheDocument();
+    // The row without a pick renders no flag.
+    expect(screen.queryByTitle('Brazil')).not.toBeInTheDocument();
+  });
+
   it('renders email in place of username when present (admin view)', () => {
     const adminEntries: LeaderboardEntry[] = [
       { ...entries[0], email: 'alice@example.com' },

--- a/frontend/src/types/tournament.ts
+++ b/frontend/src/types/tournament.ts
@@ -117,6 +117,14 @@ export interface LeaderboardEntry {
   championPickPoints: number;
   /** When the prediction's picks were last saved (predictions.updated_at). */
   updatedAt?: string | null;
+  /**
+   * FIFA 3-letter code of the team predicted to win the final (M104) — the
+   * "pick to win the tournament" shown as a flag next to the prediction name.
+   * Null before the final pick is made (or for legacy rows).
+   */
+  bracketChampionCode?: string | null;
+  /** Full name of the bracket champion team (for the flag's hover title). */
+  bracketChampionName?: string | null;
 }
 
 export interface LeaderboardRankMatch {

--- a/supabase/migrations/0082_leaderboard_bracket_champion.sql
+++ b/supabase/migrations/0082_leaderboard_bracket_champion.sql
@@ -1,0 +1,306 @@
+-- 0082_leaderboard_bracket_champion.sql
+--
+-- Surface each prediction's Bracket Final (M104) winner on the leaderboard so
+-- the UI can show a "pick to win the tournament" flag next to the prediction
+-- name. Adds two pass-through columns (bracket_champion_code / _name) to both
+-- get_leaderboard and admin_get_leaderboard.
+--
+-- The bracket champion is the team predicted to win match M104, stored in
+-- knockout_predictions.winner_team_id (distinct from the Gut Feeling Champion
+-- predictions.champion_team_id). Nulls are expected for legacy rows or before
+-- the final pick is made; the frontend renders nothing in that case.
+--
+-- Return-column changes require dropping the functions first (create or replace
+-- cannot alter a RETURNS TABLE signature). admin_get_leaderboard depends on
+-- get_leaderboard, so drop it first.
+
+drop function if exists public.admin_get_leaderboard(uuid, int, int, text);
+drop function if exists public.get_leaderboard(uuid, int, int, text);
+
+-- ========== get_leaderboard (re-emitted from 0081 + bracket champion) ==========
+create or replace function public.get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25,
+    p_search text default null
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    champion_pick_points int,
+    total_goals int,
+    updated_at timestamptz,
+    bracket_champion_code text,
+    bracket_champion_name text,
+    total_count bigint
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+    with actual_champion_goals as (
+        select champion_total_goals as goals
+        from public.tournaments
+        where id = p_tournament_id
+    ),
+    search_term as (
+        select nullif(trim(coalesce(p_search, '')), '') as q
+    ),
+    group_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when gp.first_team_id = gs.first_team_id and gp.second_team_id = gs.second_team_id
+                        then case when gp.group_id = 'I' then 15 else 10 end
+                    when gp.first_team_id = gs.second_team_id and gp.second_team_id = gs.first_team_id
+                        then 7
+                    else
+                        case
+                            when gp.first_team_id = gs.first_team_id then 5   -- single team, correct slot
+                            when gp.second_team_id = gs.second_team_id then 5 -- single team, correct slot
+                            when gp.first_team_id = gs.second_team_id then 2  -- single team, wrong slot
+                            when gp.second_team_id = gs.first_team_id then 2  -- single team, wrong slot
+                            else 0
+                        end
+                end
+            ), 0)::int as group_points
+        from public.predictions p
+        left join public.group_predictions gp on gp.prediction_id = p.id
+        left join public.group_standings gs
+            on gs.tournament_id = p.tournament_id
+            and gs.group_id = gp.group_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    advancer_scores as (
+        select
+            p.id as prediction_id,
+            coalesce(sum(
+                case
+                    when ta_rank.team_id is not null and ta_rank.team_id = ap.team_id then 2.5
+                    when ta_team.team_id is not null then 2.0
+                    else 0
+                end
+            ), 0)::numeric as advancer_points
+        from public.predictions p
+        left join public.advancer_predictions ap on ap.prediction_id = p.id
+        left join public.tournament_advancers ta_rank
+            on ta_rank.tournament_id = p.tournament_id
+            and ta_rank.rank = ap.rank
+        left join public.tournament_advancers ta_team
+            on ta_team.tournament_id = p.tournament_id
+            and ta_team.team_id = ap.team_id
+        where p.tournament_id = p_tournament_id
+        group by p.id
+    ),
+    knockout_round_totals as (
+        select s.prediction_id, coalesce(sum(s.round_points), 0)::int as round_points
+        from public.knockout_round_config() c
+        cross join lateral public.knockout_round_scores(
+            p_tournament_id, c.stage, c.correct_pts, c.wrong_pts
+        ) s
+        group by s.prediction_id
+    ),
+    champion_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_champion_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M104'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    third_place_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when kp.winner_team_id is not null and kp.winner_team_id = kr.winner_team_id
+                    then public.scoring_third_place_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_predictions kp on kp.prediction_id = p.id and kp.match_id = 'M103'
+        left join public.knockout_results kr on kr.tournament_id = p.tournament_id and kr.match_id = 'M103'
+        where p.tournament_id = p_tournament_id
+    ),
+    champion_pick_score as (
+        select
+            p.id as prediction_id,
+            (case
+                when p.champion_team_id is not null and p.champion_team_id = kr.winner_team_id
+                    then public.scoring_champion_pick_pts()
+                else 0
+            end)::int as points
+        from public.predictions p
+        left join public.knockout_results kr
+            on kr.tournament_id = p.tournament_id and kr.match_id = 'M104'
+        where p.tournament_id = p_tournament_id
+    ),
+    bracket_champion as (
+        select
+            p.id as prediction_id,
+            tch.code::text as bracket_champion_code,
+            tch.name::text as bracket_champion_name
+        from public.predictions p
+        left join public.knockout_predictions kp
+            on kp.prediction_id = p.id and kp.match_id = 'M104'
+        left join public.teams tch on tch.id = kp.winner_team_id
+        where p.tournament_id = p_tournament_id
+    ),
+    knockout_scores as (
+        select
+            p.id as prediction_id,
+            (coalesce(krt.round_points, 0)
+             + coalesce(cs.points, 0)
+             + coalesce(tps.points, 0))::int as knockout_points,
+            coalesce(cps.points, 0)::int as champion_pick_points
+        from public.predictions p
+        left join knockout_round_totals krt on krt.prediction_id = p.id
+        left join champion_score cs on cs.prediction_id = p.id
+        left join third_place_score tps on tps.prediction_id = p.id
+        left join champion_pick_score cps on cps.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+    ),
+    ranked as (
+        select
+            p.id as prediction_id,
+            p.prediction_name::text as prediction_name,
+            pr.username::text as username,
+            coalesce(gsc.group_points, 0) as group_points,
+            coalesce(asc_.advancer_points, 0)::numeric as advancer_points,
+            coalesce(ksc.knockout_points, 0) as knockout_points,
+            coalesce(ksc.champion_pick_points, 0) as champion_pick_points,
+            (coalesce(gsc.group_points, 0)
+                + coalesce(asc_.advancer_points, 0)
+                + coalesce(ksc.knockout_points, 0)
+                + coalesce(ksc.champion_pick_points, 0))::numeric as points,
+            p.total_goals,
+            p.updated_at as updated_at,
+            bc.bracket_champion_code,
+            bc.bracket_champion_name,
+            row_number() over (
+                order by
+                    (coalesce(gsc.group_points, 0)
+                        + coalesce(asc_.advancer_points, 0)
+                        + coalesce(ksc.knockout_points, 0)
+                        + coalesce(ksc.champion_pick_points, 0)) desc,
+                    case
+                        when (select goals from actual_champion_goals) is null or p.total_goals is null then null
+                        else abs(p.total_goals - (select goals from actual_champion_goals))
+                    end asc nulls last,
+                    p.updated_at asc nulls last
+            )::int as rank
+        from public.predictions p
+        join public.profiles pr on pr.id = p.user_id
+        left join group_scores gsc on gsc.prediction_id = p.id
+        left join advancer_scores asc_ on asc_.prediction_id = p.id
+        left join knockout_scores ksc on ksc.prediction_id = p.id
+        left join bracket_champion bc on bc.prediction_id = p.id
+        where p.tournament_id = p_tournament_id
+          and not p.voided
+          and (p.submitted_at is not null or public.prediction_phase1_complete(p.id))
+          and exists (
+              select 1
+              from public.tournament_payments tp
+              join public.tournaments t on t.id = tp.tournament_id
+              where tp.prediction_id = p.id
+                and tp.paid_at <= t.lock_time
+          )
+    )
+    select
+        rank,
+        prediction_id,
+        prediction_name,
+        username,
+        points,
+        group_points,
+        advancer_points,
+        knockout_points,
+        champion_pick_points,
+        total_goals,
+        updated_at,
+        bracket_champion_code,
+        bracket_champion_name,
+        count(*) over () as total_count
+    from ranked, search_term
+    where search_term.q is null
+       or ranked.username ilike '%' || search_term.q || '%'
+       or ranked.prediction_name ilike '%' || search_term.q || '%'
+    order by rank
+    offset greatest(p_page - 1, 0) * greatest(p_page_size, 1)
+    limit greatest(p_page_size, 1);
+$$;
+
+grant execute on function public.get_leaderboard(uuid, int, int, text) to anon, authenticated;
+
+-- ========== admin_get_leaderboard (re-emitted from 0068 + bracket champion) ==========
+create or replace function public.admin_get_leaderboard(
+    p_tournament_id uuid,
+    p_page int default 1,
+    p_page_size int default 25,
+    p_search text default null
+)
+returns table (
+    rank int,
+    prediction_id uuid,
+    prediction_name text,
+    username text,
+    email text,
+    points numeric,
+    group_points int,
+    advancer_points numeric,
+    knockout_points int,
+    champion_pick_points int,
+    total_goals int,
+    updated_at timestamptz,
+    bracket_champion_code text,
+    bracket_champion_name text,
+    total_count bigint
+)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+begin
+    if not public.is_admin() then
+        raise exception 'forbidden' using errcode = 'P0001';
+    end if;
+
+    return query
+    select
+        lb.rank,
+        lb.prediction_id,
+        lb.prediction_name,
+        lb.username,
+        u.email::text as email,
+        lb.points,
+        lb.group_points,
+        lb.advancer_points,
+        lb.knockout_points,
+        lb.champion_pick_points,
+        lb.total_goals,
+        lb.updated_at,
+        lb.bracket_champion_code,
+        lb.bracket_champion_name,
+        lb.total_count
+    from public.get_leaderboard(p_tournament_id, p_page, p_page_size, p_search) lb
+    join public.predictions p on p.id = lb.prediction_id
+    left join auth.users u on u.id = p.user_id
+    order by lb.rank;
+end;
+$$;
+
+grant execute on function public.admin_get_leaderboard(uuid, int, int, text) to authenticated;


### PR DESCRIPTION
## What

Adds each prediction's **pick to win the tournament** — the team predicted to win the Bracket Final (match M104) — as a small team flag next to the prediction name on every leaderboard row. The team name shows on hover (and via `aria-label` for screen readers). Rows without a final pick render no flag.

Requested by the pool: previously this info was one click deep in the bracket preview dialog.

## Changes

- **`supabase/migrations/0082_leaderboard_bracket_champion.sql`** — re-emits `get_leaderboard` (base: 0081) and `admin_get_leaderboard` (base: 0068) with two new pass-through columns `bracket_champion_code` / `bracket_champion_name`, derived via `LEFT JOIN knockout_predictions (match_id = 'M104') -> teams`. No scoring/paging/search/tiebreak logic changed. Functions are dropped first because the RETURNS TABLE signature changed.
- **`LeaderboardEntry`** (`types/tournament.ts`) — adds `bracketChampionCode` / `bracketChampionName`.
- **`/api/leaderboard/route.ts`** — maps the new RPC columns.
- **`LeaderboardTable.tsx`** — renders the flag inline in the Player cell using the existing `<TeamFlag>` component.

## Verification

- Applied 0082 to the local Supabase stack; both RPCs recreate cleanly and return the new columns (confirmed a seeded row surfaces its Netherlands M104 pick; rows without a pick return null).
- `npm test` (608 passed), `npm run typecheck`, `npm run lint` all clean. Added coverage to the route and table tests.
- Not verified against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)